### PR TITLE
fix: output with the raw data (ask the user) + Word report (v1.0.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -90,7 +90,7 @@ Ask the user for a directory or file list if not given. Recognized: `.d` (Bruker
 
 ### 1b. Check for a prior analysis of this dataset
 ```
-python3 scripts/session.py find-prior --base ~/Documents/DataAnalysis --raw /path/to/*.d
+python3 scripts/session.py find-prior --raw /path/to/*.d
 ```
 If a match is returned, this is a **re-analysis** of an existing dataset — note the
 prior session dir; you'll pass it to `session.py init --reanalysis-of` (step 3b) so
@@ -143,15 +143,23 @@ python3 scripts/collect_conditions.py --validate conditions.csv --against report
 File.Name,Group sheet for them to fill.) → detail: `references/conditions.md`.
 
 ### 3b. Create the analysis session (organize all files)
-Now that you know the organism + design, scaffold a tidy session directory (the
-lab `~/Documents/DataAnalysis/sessions/` convention) and route **everything** into
-it — inputs, outputs, scripts, logs:
+**Ask the user where the results should go** — two choices:
+- **In the folder with their raw data** (default, recommended — keeps results next
+  to the data): pass `--raw` and omit `--base`.
+- **A central location** (e.g. their Documents folder, or a path they give): pass
+  `--base <that path>` (results land under `<path>/sessions/`).
+
+Then scaffold the session and route **everything** into it:
 ```
-python3 scripts/session.py init --name "<short study name>" \
-    --base ~/Documents/DataAnalysis --raw /path/to/*.d \
+# default — results live with the raw data:
+python3 scripts/session.py init --name "<short study name>" --raw /path/to/*.d \
     [--reanalysis-of <prior session dir from step 1b>]
+# or central, if the user chose one:
+python3 scripts/session.py init --name "<short study name>" --raw /path/to/*.d \
+    --base ~/Documents/DataAnalysis
 ```
-It prints a `paths` map. **Use those paths for every later step** — put
+The output's `placement` tells you which was used. **Use the printed `paths` map for
+every later step** — put
 `conditions.csv` and the FASTA in `paths.input_dir`, search output in
 `paths.search_out`, DE results in `paths.de_dir` (= `output/tables`), the
 reproducibility bundle in `paths.repro_dir`, the report in
@@ -259,7 +267,14 @@ Biological Interpretation, How This Analysis Works, Methods). Compute significan
 proteins, up/down splits, cross-comparison overlaps, and lowest-CV proteins
 directly from the CSVs — cite specific proteins, never fabricate. The brief takes
 its pipeline description from `de_provenance.json`, so the report stays correct
-for whichever engine/method ran. → detail: `references/analysis.md`.
+for whichever engine/method ran.
+
+Then **also save the report as a Word document** (both formats are required):
+```
+python3 scripts/to_docx.py --in <session>/output/AI_Analysis_Report.md \
+    --out <session>/output/AI_Analysis_Report.docx
+```
+→ detail: `references/analysis.md`.
 
 ### 10. Reproducibility bundle (mandatory)
 Assemble the bundle that makes the whole analysis reproducible:
@@ -287,7 +302,7 @@ Catalog everything the run produced so the user knows what each file is:
 ```
 python3 scripts/make_report.py --out OUTPUT_FILES.md \
   --search-out ./search_out --de-dir ./de_results --repro ./reproducibility \
-  --extra ./conditions.csv ./search.fasta ./wf ./AI_Analysis_Report.md
+  --extra ./conditions.csv ./search.fasta ./wf ./AI_Analysis_Report.md ./AI_Analysis_Report.docx
 ```
 `OUTPUT_FILES.md` lists every file with its size and a plain-language description,
 grouped by purpose, and flags anything unrecognized (never silently omitted).

--- a/skill/ucdavis-proteomics-core-pipeline/references/analysis.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/analysis.md
@@ -12,7 +12,10 @@ inline instead of shipping the prompt to an external API.
 2. **The agent reads the brief and the data files and writes `AI_Analysis_Report.md`.**
    It computes significant proteins, up/down splits, cross-comparison overlaps, and
    lowest-CV proteins from the CSVs — citing specific proteins, never fabricating.
-3. `make_report.py` writes `OUTPUT_FILES.md` — every output file, its size, and a
+3. `to_docx.py` saves the report **also as `AI_Analysis_Report.docx`** (pandoc, with
+   a python-docx fallback so the Word file is always produced). Both `.md` and
+   `.docx` are required outputs.
+4. `make_report.py` writes `OUTPUT_FILES.md` — every output file, its size, and a
    plain-language description, grouped by purpose.
 
 ## Report sections (faithful to DE-LIMP's export prompt)

--- a/skill/ucdavis-proteomics-core-pipeline/references/outputs.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/outputs.md
@@ -1,11 +1,21 @@
 # Output packaging, re-analysis & comparison
 
-Every run is packaged into a tidy **session directory** so people can find things,
-matching the lab convention in `~/Documents/DataAnalysis/sessions/`.
+Every run is packaged into a tidy **session directory** so people can find things.
+
+## Where the session goes — ask the user
+The orchestrator asks where results should live (SKILL.md step 3b):
+- **Default (recommended): in the folder with the raw data** being analyzed. The
+  session folder is created right inside that directory, so results sit next to the
+  files they came from. Pass `--raw <globs>` and omit `--base`.
+- **A central location** the user prefers (e.g. `~/Documents/DataAnalysis`, or any
+  path they give): pass `--base <path>` → the session is created under
+  `<path>/sessions/`.
+
+`session.py init` reports `placement` (`with-raw-data` | `central` | `reanalysis`).
 
 ## Session layout (`session.py`)
 ```
-sessions/<YYYY-MM-DD>_<DescriptiveName>/
+<YYYY-MM-DD>_<DescriptiveName>/    # inside the raw-data folder, or under <base>/sessions/
   README.md                 # what this was + where everything is (written at finalize)
   input/                    # conditions.csv, search.fasta, params.*, wf/workflow.manifest.json,
                             #   raw_files.txt (raw data is referenced, NOT copied — too large)
@@ -15,15 +25,16 @@ sessions/<YYYY-MM-DD>_<DescriptiveName>/
     figures/                # plots (reserved)
     reproducibility/        # the full bundle (reproduce.sh, env lock, checksums)
     AI_Analysis_Report.md   # the biological interpretation (read first)
+    AI_Analysis_Report.docx # the same report as a Word document
     OUTPUT_FILES.md         # catalog of every file
     comparison/             # (re-analyses) COMPARISON.md + concordance CSVs
   scripts/                  # a copy of the skill scripts that ran this analysis (self-contained)
   logs/                     # commands.log + engine logs
 ```
 
-- `session.py init --name "..." [--reanalysis-of <prior>] --raw <globs>` makes the
-  folders and prints a `paths` map; **route every step's `--out`/`--outdir`/`--dest`
-  into those paths**.
+- `session.py init --name "..." --raw <globs> [--base <path>] [--reanalysis-of <prior>]`
+  makes the folders and prints a `paths` map; **route every step's
+  `--out`/`--outdir`/`--dest` into those paths**.
 - `session.py finalize --dir <session> [--zip]` writes `README.md`, moves any loose
   tables/figures into their subdirs, and (for a re-analysis) writes `DIFFERENCES.md`.
 

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/make_report.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/make_report.py
@@ -61,6 +61,7 @@ CATALOG = [
     (r"^commands\.log$", "Inputs", "Verbatim log of every command the run executed (audit trail)."),
 
     (r"^AI_Analysis_Report\.md$", "Analysis report", "The biological + QC interpretation of the results (the AI analysis)."),
+    (r"^AI_Analysis_Report\.docx$", "Analysis report", "The analysis report as a Word document (same content as the .md)."),
     (r"^ANALYSIS_PROMPT\.md$", "Analysis report", "The analysis brief the agent followed to write the report."),
     (r"^OUTPUT_FILES\.md$", "Analysis report", "This file — the catalog of all outputs."),
 ]

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/session.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/session.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """
 session.py  --  Package a run's inputs and outputs into a tidy, browsable session
-directory, matching the lab convention in ~/Documents/DataAnalysis/sessions:
+directory. By DEFAULT the session is created IN THE FOLDER WITH THE RAW DATA being
+analyzed; pass --base to put it in a central location instead (e.g. the user's
+Documents). The orchestrator asks the user which they want (see SKILL.md).
 
-    sessions/<YYYY-MM-DD>_<DescriptiveName>/
+    <YYYY-MM-DD>_<DescriptiveName>/    # next to the raw files, or under <base>/sessions/
       README.md                 # what this analysis was + where everything is
       input/                    # conditions, FASTA, params, workflow manifest, raw-file list
       output/
@@ -18,9 +20,12 @@ directory, matching the lab convention in ~/Documents/DataAnalysis/sessions:
 
 Two subcommands:
 
-  # at the start, once you know the organism/study — make the folders, get paths
-  python3 session.py init --name "HeLa QC DIA" --base ~/Documents/DataAnalysis
-  #   -> prints JSON with every canonical path; route all later steps into them
+  # at the start — make the folders, get paths.
+  #   default (results live with the raw data):
+  python3 session.py init --name "HeLa QC DIA" --raw /data/HeLaQC/*.d
+  #   central location instead (user chose Documents / a custom folder):
+  python3 session.py init --name "HeLa QC DIA" --raw /data/HeLaQC/*.d --base ~/Documents/DataAnalysis
+  #   -> prints JSON with every canonical path + "placement"; route later steps into them
 
   # at the end — write README, catalog outputs, optionally zip
   python3 session.py finalize --dir <session_dir> [--zip]
@@ -73,18 +78,23 @@ def raw_set(session_dir):
 
 def do_find_prior(a):
     """Scan existing sessions for ones covering the same raw files (same dataset)."""
-    base = os.path.abspath(os.path.expanduser(a.base))
-    sessions_root = os.path.join(base, "sessions")
-    mine = set()
+    mine, raw_dirs = set(), set()
     for pat in (a.raw or []):
         hits = [os.path.abspath(p.rstrip("/")) for p in glob.glob(pat)]
         if hits:
             mine.update(hits)
+            raw_dirs.update(os.path.dirname(h) for h in hits)
         else:
             mine.add(pat)
-    # also walk reanalysis subfolders
-    candidates = glob.glob(os.path.join(sessions_root, "*")) + \
-                 glob.glob(os.path.join(sessions_root, "*", "reanalysis", "*"))
+    # look where sessions can live: alongside the raw data (default), and in a
+    # central --base/sessions if the user used one. Include reanalysis subfolders.
+    roots = list(raw_dirs)
+    if a.base:
+        roots.append(os.path.join(os.path.abspath(os.path.expanduser(a.base)), "sessions"))
+    candidates = []
+    for root in roots:
+        candidates += glob.glob(os.path.join(root, "*"))
+        candidates += glob.glob(os.path.join(root, "*", "reanalysis", "*"))
     hits = []
     for c in candidates:
         if not os.path.isdir(c):
@@ -104,17 +114,50 @@ def do_find_prior(a):
                      indent=2))
 
 
+def _resolve_raws(patterns):
+    raws = []
+    for pat in (patterns or []):
+        raws.extend(sorted(glob.glob(pat)) or [pat])
+    return raws
+
+
+def _raw_dir(raws):
+    """The directory that contains the raw files (their common parent)."""
+    if not raws:
+        return None
+    dirs = [os.path.dirname(os.path.abspath(r.rstrip("/"))) for r in raws]
+    try:
+        return os.path.commonpath(dirs)
+    except ValueError:
+        return dirs[0]
+
+
 def do_init(a):
     date = a.date or datetime.date.today().isoformat()
     slug = slugify(a.name)
-    base = os.path.abspath(os.path.expanduser(a.base))
+    raws = _resolve_raws(a.raw)
+    raw_dir = _raw_dir(raws)
+
+    # WHERE the results go (the orchestrator asks the user; see SKILL.md):
+    #   --reanalysis-of <prior>  -> nested under the original
+    #   --base <path>            -> a central location the user chose (e.g. ~/Documents/DataAnalysis)
+    #   (neither, with --raw)    -> DEFAULT: in the folder with the raw data being analyzed
     if a.reanalysis_of:
         prior = os.path.abspath(os.path.expanduser(a.reanalysis_of))
         if not os.path.isdir(prior):
             sys.exit(f"--reanalysis-of: prior session not found: {prior}")
         session_dir = os.path.join(prior, "reanalysis", f"{date}_{slug}")
-    else:
+        placement = "reanalysis"
+    elif a.base:
+        base = os.path.abspath(os.path.expanduser(a.base))
         session_dir = os.path.join(base, "sessions", f"{date}_{slug}")
+        placement = "central"
+    elif raw_dir:
+        session_dir = os.path.join(raw_dir, f"{date}_{slug}")
+        placement = "with-raw-data"
+    else:
+        session_dir = os.path.join(os.path.abspath("."), f"{date}_{slug}")
+        placement = "cwd"
     for sd in SUBDIRS:
         os.makedirs(os.path.join(session_dir, sd), exist_ok=True)
     p = paths_for(session_dir)
@@ -129,10 +172,7 @@ def do_init(a):
         sys.stderr.write(f"[session] could not copy skill scripts: {e}\n")
 
     # record raw file locations (not the files themselves)
-    if a.raw:
-        raws = []
-        for pat in a.raw:
-            raws.extend(sorted(glob.glob(pat)) or [pat])
+    if raws:
         with open(p["raw_list"], "w") as fh:
             fh.write("# Raw MS files used in this analysis (not copied — too large).\n")
             for r in raws:
@@ -154,7 +194,7 @@ def do_init(a):
                  "(search, tables, figures, reproducibility, report), `scripts/`, `logs/`.\n")
 
     print(json.dumps({"created": session_dir, "date": date, "name": a.name,
-                      "reanalysis_of": parent, "paths": p}, indent=2))
+                      "placement": placement, "reanalysis_of": parent, "paths": p}, indent=2))
 
 
 def _load(path):
@@ -330,13 +370,13 @@ def main():
     sub = ap.add_subparsers(dest="cmd", required=True)
     i = sub.add_parser("init", help="scaffold a session directory and print canonical paths")
     i.add_argument("--name", required=True, help="short descriptive study name")
-    i.add_argument("--base", default="~/Documents/DataAnalysis", help="root holding sessions/")
+    i.add_argument("--base", default="", help="central location for the session (e.g. ~/Documents/DataAnalysis). OMIT to put results in the folder with the raw data (default).")
     i.add_argument("--date", default="", help="YYYY-MM-DD (default: today)")
-    i.add_argument("--raw", nargs="*", help="raw file paths/globs to record in input/raw_files.txt")
+    i.add_argument("--raw", nargs="*", help="raw file paths/globs; their folder is where results go by default")
     i.add_argument("--reanalysis-of", default="", help="prior session dir; nests this run under <prior>/reanalysis/")
     i.set_defaults(func=do_init)
     fp = sub.add_parser("find-prior", help="find existing sessions covering the same raw files")
-    fp.add_argument("--base", default="~/Documents/DataAnalysis")
+    fp.add_argument("--base", default="", help="also scan this central location's sessions/ (optional)")
     fp.add_argument("--raw", nargs="*", required=True)
     fp.set_defaults(func=do_find_prior)
     f = sub.add_parser("finalize", help="write README, tidy output/, optionally zip")

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/setup.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/setup.sh
@@ -85,7 +85,8 @@ fi
 create_env() {
   local pkgs=(python=3.11 pyarrow pyyaml
               "r-base>=4.5" bioconductor-limpa bioconductor-limma
-              r-arrow r-dplyr r-tidyr sage-proteomics)
+              r-arrow r-dplyr r-tidyr sage-proteomics
+              pandoc python-docx)   # pandoc + python-docx: Markdown report -> Word .docx
   # proteowizard (msconvert) is bioconda LINUX-only
   if [ "$OS" = "linux" ]; then pkgs+=(proteowizard); fi
 

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/to_docx.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/to_docx.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+to_docx.py  --  Convert a Markdown report to a Word (.docx) document.
+
+The analysis report is saved as both Markdown and Word. This makes the .docx from
+the .md. Uses pandoc when available (best fidelity: headings, tables, bold/italic,
+lists); otherwise falls back to a built-in python-docx renderer so a Word file is
+ALWAYS produced (headings, paragraphs, bullet lists, and pipe tables).
+
+Both pandoc and python-docx are installed by setup.sh into the conda env, so the
+pandoc path is the normal one; the fallback is a safety net.
+
+Usage:
+  python3 to_docx.py --in AI_Analysis_Report.md --out AI_Analysis_Report.docx
+"""
+import sys, os, re, shutil, subprocess, argparse
+
+
+def via_pandoc(md_path, out_path):
+    pandoc = shutil.which("pandoc")
+    if not pandoc:
+        return False
+    try:
+        subprocess.run([pandoc, md_path, "-o", out_path, "--from", "gfm",
+                        "--standalone"], check=True, capture_output=True, text=True)
+        return os.path.exists(out_path)
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write(f"[to_docx] pandoc failed ({e.stderr.strip()[:200]}); using fallback\n")
+        return False
+
+
+def _add_inline(paragraph, text):
+    """Render minimal inline markdown (**bold**, *italic*, `code`) into runs."""
+    for chunk in re.split(r"(\*\*.+?\*\*|\*.+?\*|`.+?`)", text):
+        if not chunk:
+            continue
+        if chunk.startswith("**") and chunk.endswith("**"):
+            paragraph.add_run(chunk[2:-2]).bold = True
+        elif chunk.startswith("*") and chunk.endswith("*"):
+            paragraph.add_run(chunk[1:-1]).italic = True
+        elif chunk.startswith("`") and chunk.endswith("`"):
+            r = paragraph.add_run(chunk[1:-1]); r.font.name = "Courier New"
+        else:
+            paragraph.add_run(chunk)
+
+
+def via_python_docx(md_path, out_path):
+    try:
+        from docx import Document
+    except ImportError:
+        return False
+    doc = Document()
+    lines = open(md_path, encoding="utf-8").read().splitlines()
+    i, n = 0, len(lines)
+    while i < n:
+        line = lines[i].rstrip()
+        # pipe table: header row, separator row, then body rows
+        if line.startswith("|") and i + 1 < n and re.match(r"^\s*\|[ \-:|]+\|\s*$", lines[i + 1]):
+            rows = []
+            while i < n and lines[i].strip().startswith("|"):
+                cells = [c.strip() for c in lines[i].strip().strip("|").split("|")]
+                rows.append(cells); i += 1
+            rows = [r for j, r in enumerate(rows) if j != 1]  # drop the --- separator
+            if rows:
+                t = doc.add_table(rows=len(rows), cols=max(len(r) for r in rows))
+                t.style = "Light Grid Accent 1"
+                for ri, r in enumerate(rows):
+                    for ci, c in enumerate(r):
+                        t.rows[ri].cells[ci].text = re.sub(r"[*`]", "", c)
+            continue
+        m = re.match(r"^(#{1,6})\s+(.*)$", line)
+        if m:
+            doc.add_heading(m.group(2).strip(), level=min(len(m.group(1)), 4))
+        elif re.match(r"^\s*[-*+]\s+", line):
+            p = doc.add_paragraph(style="List Bullet")
+            _add_inline(p, re.sub(r"^\s*[-*+]\s+", "", line))
+        elif re.match(r"^\s*\d+\.\s+", line):
+            p = doc.add_paragraph(style="List Number")
+            _add_inline(p, re.sub(r"^\s*\d+\.\s+", "", line))
+        elif line.strip() in ("---", "___", "***"):
+            pass  # horizontal rule -> skip
+        elif line.strip():
+            _add_inline(doc.add_paragraph(), line)
+        i += 1
+    doc.save(out_path)
+    return os.path.exists(out_path)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--in", dest="inp", required=True)
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+    if not os.path.exists(a.inp):
+        sys.exit(f"input not found: {a.inp}")
+
+    if via_pandoc(a.inp, a.out):
+        print(f"[to_docx] wrote {a.out} (pandoc)")
+    elif via_python_docx(a.inp, a.out):
+        print(f"[to_docx] wrote {a.out} (python-docx fallback)")
+    else:
+        sys.exit("Could not convert to .docx: neither pandoc nor python-docx is available. "
+                 "Re-run setup.sh to install them.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two fixes from real-world use of the skill:

**1. Where results go.** Previously hardcoded to `~/Documents/DataAnalysis`. Now the session folder is created **in the folder with the raw data** by default, and the agent **asks the user** whether to put results next to the data or in a central location (e.g. Documents). `session.py init` reports a `placement` field; `find-prior` scans the raw-data folder.

**2. Word output.** The analysis report is now saved as **both** `AI_Analysis_Report.md` and `AI_Analysis_Report.docx` (new `to_docx.py` — pandoc with a python-docx fallback, both installed by `setup.sh`).

Version bumped to **1.0.1** so installed plugins auto-update. Passes `claude plugin validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)