### PR TITLE
feat: HIVE access onboarding — local Claude Code drives HIVE over SSH (v1.0.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -57,6 +57,39 @@ the scripts handle it.
 
 ## Flow
 
+### 0a. Access & environment — ASK THIS FIRST
+**Claude Code runs locally on the user's machine.** Heavy steps either run locally or
+are driven on **HIVE over SSH with the user's private key** — they do NOT run Claude
+Code on HIVE. Ask two questions, then verify and pick a mode:
+
+1. **"Do you have access to UC Davis HIVE (an account + an SSH private key)?"**
+   If yes, **ask where their private key is** (e.g. `~/.ssh/id_ed25519`).
+2. **"Are you a member of the UC Davis Proteomics Core?"**
+
+Verify (don't just trust the answers):
+```
+bash scripts/check_access.sh <hive_user> <private_key_path>
+```
+Read `recommended_mode` + `facility_software_available`, then:
+
+- **HIVE = yes → `hive_remote`:** drive HIVE over SSH from the local Claude Code
+  (`export HIVE_USER=… HIVE_KEY=…`; use `scripts/hive_exec.sh '<cmd>'`). The search
+  runs as a **SLURM job** (`run_search.py --sbatch` → `hive_exec.sh 'sbatch job.sh'`),
+  never the login node. HIVE gives **compute**; the Core software is separate (next).
+- **Core member = yes (with HIVE) → reuse the installed software** in
+  `/quobyte/proteomics-grp/`: `acquire_tools.sh` finds the DIA-NN `.sif`,
+  `fetch_fasta.py --hive` reuses pre-staged FASTAs. No rebuilding.
+- **HIVE = yes but NOT Core → rebuild the toolchain in your own HIVE home** (you can't
+  read the group dir). Follow `references/access.md` → "Rebuild on HIVE" (run
+  `setup.sh` + `acquire_tools.sh` + `fetch_fasta.py` on HIVE via `hive_exec.sh`). **List
+  these steps for the user — do not guess.**
+- **Core = yes but NO HIVE →** the Core software is on HIVE, unreachable without HIVE
+  access → fall back to **local**; suggest requesting a HIVE account.
+- **Both = no → `local`:** `setup.sh` installs the toolchain on the user's machine
+  (no admin); public engines (DIA-NN Academia, Sage). Self-contained, works fully.
+
+Tell the user which mode you're using and why. → full runbook: `references/access.md`.
+
 ### 0. One-time setup (install everything that's missing)
 ```
 bash scripts/setup.sh

--- a/skill/ucdavis-proteomics-core-pipeline/references/access.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/access.md
@@ -1,0 +1,105 @@
+# Access & where the skill runs (HIVE runbook)
+
+**Model: Claude Code runs LOCALLY on the user's computer.** When a step should run on
+HIVE, the local Claude Code drives HIVE **over SSH using the user's private key**
+(`ssh -i <key> <user>@hive.hpc.ucdavis.edu '<command>'`, wrapped by `hive_exec.sh`).
+The skill is never installed *on* HIVE for the user; it submits work there.
+
+**Why local (not Claude Code on HIVE):** running Claude Code on a HIVE interactive
+node ties up that node and the session **times out** mid-analysis. Keeping Claude Code
+on the laptop means it stays alive while the actual compute runs as detached **SLURM
+jobs** on HIVE — nothing depends on an interactive session staying open.
+
+## Step 0a asks two questions → pick a mode
+1. **"Do you have access to UC Davis HIVE (account + SSH private key)?"**
+   If yes, **ask where the private key is** (e.g. `~/.ssh/id_ed25519`).
+2. **"Are you a member of the UC Davis Proteomics Core?"**
+
+Verify before trusting the answers:
+```
+bash scripts/check_access.sh <hive_user> <private_key_path>
+```
+Reads `recommended_mode` + `facility_software_available`. Then:
+
+| HIVE access | Core member | Mode | What happens |
+|---|---|---|---|
+| no | no | **local** | `setup.sh` installs the toolchain on the user's machine; public engines (DIA-NN Academia, Sage). |
+| **yes** | **yes** | **hive_remote** | Drive HIVE over SSH. **Reuse the Core software already installed** in `/quobyte/proteomics-grp` (DIA-NN `.sif`, pre-staged FASTAs). Search runs as a SLURM job. |
+| **yes** | no | **hive_remote** | Drive HIVE over SSH, but you **rebuild the toolchain in your own HIVE home** (you can't read the Core group dir). See "Rebuild on HIVE" below. |
+| no | yes | **local** | The Core software is on HIVE; without HIVE access you can't reach it → run locally with public engines and tell the user to request a HIVE account. |
+
+## hive_remote runbook (Claude Code local → HIVE over SSH)
+Set the connection once, then everything HIVE-side goes through `hive_exec.sh`:
+```
+export HIVE_USER=<hive_user>
+export HIVE_KEY=<private_key_path>        # the path the user gave you
+bash scripts/hive_exec.sh 'hostname; sbatch --version | head -1'   # confirm
+```
+1. **Put the skill's scripts on HIVE once** (they run there):
+   ```
+   bash scripts/hive_exec.sh 'mkdir -p ~/proteomics-pipeline'
+   bash scripts/hive_exec.sh --put ./scripts '~/proteomics-pipeline/'
+   ```
+2. **Toolchain on HIVE:**
+   - **Core member:** `acquire_tools.sh` (run on HIVE) finds the group DIA-NN
+     container (`/quobyte/proteomics-grp/dia-nn/*.sif`); `fetch_fasta.py --hive`
+     reuses `/quobyte/proteomics-grp/MRS/` FASTAs. Build the R/Python/DE env once with
+     `setup.sh` (it's the same micromamba env):
+     ```
+     bash scripts/hive_exec.sh 'bash ~/proteomics-pipeline/scripts/setup.sh'
+     ```
+   - **Non-Core HIVE user:** same `setup.sh`, plus you must acquire DIA-NN/Sage
+     yourself (no group `.sif`). See "Rebuild on HIVE".
+3. **Stage the raw data** (skip if it's already on HIVE — Core data usually is):
+   ```
+   bash scripts/hive_exec.sh --put /path/to/raw '~/proteomics-pipeline/data/'
+   ```
+4. **Run the search as a SLURM job** (never the login node). Generate the sbatch
+   script with `run_search.py --sbatch`, put it on HIVE, submit, and poll:
+   ```
+   # build job.sh locally (or on HIVE), then:
+   bash scripts/hive_exec.sh --put ./job.sh '~/proteomics-pipeline/job.sh'
+   bash scripts/hive_exec.sh 'cd ~/proteomics-pipeline && sbatch job.sh'
+   bash scripts/hive_exec.sh 'squeue -u $USER'     # poll until done
+   ```
+5. **DE + figures + report:** run on HIVE (`run_de.R`, `make_figures.R`, …) or pull
+   `report.parquet` back and run them locally (DE/figures are light).
+6. **Retrieve results** into the session folder on the user's machine:
+   ```
+   bash scripts/hive_exec.sh --get '~/proteomics-pipeline/out' ./<session>/output/
+   ```
+
+## Rebuild on HIVE (non-Core users) — exact steps, no guessing
+You have HIVE compute but not the Core's `/quobyte/proteomics-grp` software, so build
+your own copy in your HIVE home. Run all of this **on HIVE** (via `hive_exec.sh`):
+1. **Skill scripts + base env:**
+   ```
+   bash scripts/hive_exec.sh 'bash ~/proteomics-pipeline/scripts/setup.sh'
+   ```
+   This installs micromamba + R + limpa + limma + arrow + Sage + Python/pyarrow into
+   `~/.proteomics-pipeline/` (no admin). DE, Sage (DDA), and figures now work.
+2. **DIA-NN (for DIA data):** you can't use the group `.sif`, so let the skill fetch
+   the free academic Linux build into your home:
+   ```
+   bash scripts/hive_exec.sh 'PIN_ENGINE=diann PIN_VERSION=2.6.0 bash ~/proteomics-pipeline/scripts/acquire_tools.sh hpc'
+   ```
+   `acquire_tools.sh` downloads the DIA-NN Academia Linux zip to
+   `~/.proteomics-pipeline/tools/diann/<version>/` (needs glibc ≥ Mint 21.2 / .NET 8;
+   if the native binary won't run on the node, build the Apptainer image from the
+   zip's Dockerfile). Check its `tools.json` `notes`.
+3. **FASTA:** without the Core's pre-staged proteomes, download from UniProt:
+   ```
+   bash scripts/hive_exec.sh 'python3 ~/proteomics-pipeline/scripts/fetch_fasta.py --proteome UP000005640 --add-contaminants --out ~/proteomics-pipeline/search.fasta'
+   ```
+4. Then run the search via SLURM as above. Everything else (DE/figures/report/audit/
+   reproducibility) is identical to a local run.
+
+## Notes
+- Heavy compute **must** go through `sbatch` — never run a search on the login node.
+- "Core member" = read access to `/quobyte/proteomics-grp`. If `check_access.sh` shows
+  `proteomics_grp_access: false` over SSH, the account isn't in the group yet — request
+  it from the Core.
+- Licensed software (e.g. Spectronaut) only runs where licensed; Sage + DIA-NN Academia
+  run anywhere.
+- Laptop→HIVE staging of large raw data is real bandwidth; prefer pointing at data
+  already on HIVE/the proteomics share when possible.

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/check_access.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/check_access.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check_access.sh  --  Ground the two onboarding questions by probing what's
+# actually reachable, and recommend where to run. Emits JSON on stdout.
+#
+# The skill asks the user:
+#   Q1. Do you have access to UC Davis HIVE (account + SSH private key)?
+#   Q2. Are you a member of the UC Davis Proteomics Core?
+#
+# This script verifies those answers against reality so the orchestrator doesn't
+# just take the user's word for it:
+#   on_hive               this machine is a HIVE node (sbatch present)
+#   proteomics_grp_access /quobyte/proteomics-grp is readable here (Core software)
+#   hive_ssh              if not on HIVE and a user is given, can we SSH in? and
+#                         does that HIVE account have sbatch + proteomics-grp access?
+#
+# Model: Claude Code runs LOCALLY; HIVE work is driven over SSH with the user's
+# private key. So this tests SSH to HIVE using that key.
+#
+# Usage: bash check_access.sh [hive_user] [private_key_path]
+#        (or set HIVE_USER / HIVE_KEY)
+# =============================================================================
+set -uo pipefail
+have() { command -v "$1" >/dev/null 2>&1; }
+HU="${1:-${HIVE_USER:-}}"
+KEY="${2:-${HIVE_KEY:-}}"
+KEY="${KEY/#\~/$HOME}"   # expand a leading ~
+HIVE_HOST="${HIVE_HOST:-hive.hpc.ucdavis.edu}"
+
+ON_HIVE=false; have sbatch && ON_HIVE=true
+GRP=false; [ -d /quobyte/proteomics-grp ] && ls /quobyte/proteomics-grp >/dev/null 2>&1 && GRP=true
+
+HIVE_SSH="not_tested"; SSH_SBATCH=false; SSH_GRP=false; KEY_FOUND=true
+[ -n "$KEY" ] && [ ! -f "$KEY" ] && KEY_FOUND=false
+if ! $ON_HIVE && [ -n "$HU" ] && [ "$KEY_FOUND" = true ]; then
+  KEY_OPT=""; [ -n "$KEY" ] && KEY_OPT="-i $KEY"
+  out="$(timeout 25 ssh $KEY_OPT -o BatchMode=yes -o ConnectTimeout=12 -o IdentitiesOnly=yes "$HU@$HIVE_HOST" \
+        'command -v sbatch >/dev/null 2>&1 && echo HAS_SBATCH; ls -d /quobyte/proteomics-grp 2>/dev/null && echo HAS_GRP' 2>/dev/null)"
+  if [ -n "$out" ]; then
+    HIVE_SSH="ok"
+    echo "$out" | grep -q HAS_SBATCH && SSH_SBATCH=true
+    echo "$out" | grep -q proteomics-grp && SSH_GRP=true
+  else
+    HIVE_SSH="failed"   # key/account/VPN problem, or host unreachable
+  fi
+fi
+
+# Decide the recommended execution mode + facility-software availability.
+# Model: Claude Code is LOCAL; HIVE work is driven over SSH with the key.
+HAS_SLURM=$([ "$ON_HIVE" = true ] || [ "$SSH_SBATCH" = true ] && echo true || echo false)
+FACILITY_SW=$([ "$GRP" = true ] || [ "$SSH_GRP" = true ] && echo true || echo false)
+if   $ON_HIVE;                  then MODE="hive_local"   # already on HIVE -> submit SLURM here
+elif [ "$SSH_SBATCH" = true ];  then MODE="hive_remote"  # local Claude Code -> drive HIVE over SSH (the intended HIVE mode)
+else                                 MODE="local"; fi     # run on the user's own machine
+
+cat <<JSON
+{
+  "on_hive": $ON_HIVE,
+  "key_path_valid": $KEY_FOUND,
+  "proteomics_grp_access": $GRP,
+  "hive_ssh": "$HIVE_SSH",
+  "hive_ssh_has_sbatch": $SSH_SBATCH,
+  "hive_ssh_has_proteomics_grp": $SSH_GRP,
+  "can_use_slurm": $HAS_SLURM,
+  "facility_software_available": $FACILITY_SW,
+  "recommended_mode": "$MODE",
+  "notes": [
+    "Claude Code runs locally; in hive_remote mode it drives HIVE over SSH with the user's private key (ssh -i <key> <user>@hive).",
+    "Proteomics Core members (proteomics_grp_access=true) reuse the software already installed in /quobyte/proteomics-grp (DIA-NN .sif, pre-staged FASTAs).",
+    "HIVE users NOT in the Core must rebuild the toolchain in their own HIVE home — see references/access.md 'Rebuild on HIVE'.",
+    "No HIVE + no Core is fine: the skill installs its own toolchain locally and uses public engines (DIA-NN Academia, Sage).",
+    "hive_ssh='failed' usually means VPN off, wrong key path, or account not set up."
+  ]
+}
+JSON

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/hive_exec.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/hive_exec.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# =============================================================================
+# hive_exec.sh  --  Run a command on UC Davis HIVE over SSH using the user's
+# private key. Claude Code runs LOCALLY; this is how the HIVE steps execute.
+#
+#   Set once per session:
+#     export HIVE_USER=brettsp
+#     export HIVE_KEY=~/.ssh/id_ed25519     # the path the user gave you
+#
+#   Run a command on HIVE:
+#     bash hive_exec.sh 'sbatch ~/run/job.sh'
+#     bash hive_exec.sh 'ls -d /quobyte/proteomics-grp/dia-nn/*.sif'
+#
+#   Copy files to/from HIVE (helpers):
+#     bash hive_exec.sh --put  ./local/path   '~/remote/path'
+#     bash hive_exec.sh --get  '~/remote/path' ./local/path
+#
+# Heavy compute must go through SLURM (sbatch), never the login node.
+# =============================================================================
+set -uo pipefail
+HU="${HIVE_USER:?set HIVE_USER (ask the user for their HIVE username)}"
+KEY="${HIVE_KEY:?set HIVE_KEY to the private-key path the user gave you}"
+KEY="${KEY/#\~/$HOME}"
+HOST="${HIVE_HOST:-hive.hpc.ucdavis.edu}"
+[ -f "$KEY" ] || { echo "private key not found: $KEY" >&2; exit 2; }
+SSH=(ssh -i "$KEY" -o IdentitiesOnly=yes -o ConnectTimeout=20 "$HU@$HOST")
+
+case "${1:-}" in
+  --put) shift; rsync -e "ssh -i $KEY -o IdentitiesOnly=yes" -a "$1" "$HU@$HOST:$2" ;;
+  --get) shift; rsync -e "ssh -i $KEY -o IdentitiesOnly=yes" -a "$HU@$HOST:$1" "$2" ;;
+  "")    echo "usage: hive_exec.sh '<command>' | --put <local> <remote> | --get <remote> <local>" >&2; exit 2 ;;
+  *)     "${SSH[@]}" "$@" ;;
+esac


### PR DESCRIPTION
Step-0a access gate: asks (1) HIVE access + private-key path, (2) Core membership, then picks where to run. Model: Claude Code stays local; HIVE work is driven over SSH with the user key and submitted as SLURM jobs (never run Claude Code on an interactive node that times out). New check_access.sh + hive_exec.sh + references/access.md (full runbook incl. exact rebuild-on-HIVE steps for non-Core users). Core members reuse /quobyte/proteomics-grp software. v1.0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)