### PR TITLE
fix: DIA-NN 2.6 on HIVE + run watcher + AlphaDIA timsTOF limit (v1.0.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -276,11 +276,33 @@ python3 scripts/run_search.py --tools ~/.proteomics-pipeline/tools/tools.json \
   commercial-OK). A quick question: *"Is this academic/non-profit, or commercial?"* —
   commercial → AlphaDIA. (AlphaDIA is deep-learning based; a GPU is strongly
   recommended — best on a HIVE GPU node or a GPU workstation.)
-- **On `hpc`:** add `--sbatch job.sh`, then `sbatch job.sh` and wait for it (poll
-  the log). Re-run with `--adapt-only` afterward for Sage/FragPipe/AlphaDIA to build
-  `report.parquet`.
+- **⚠ AlphaDIA limitation — timsTOF whole-proteome directDIA:** AlphaDIA does **not**
+  work on **timsTOF** `.d` files for **whole-proteome library-free (directDIA)**
+  searches. So for timsTOF + whole-proteome + library-free, AlphaDIA is NOT an option.
+  In that case: academic → DIA-NN; commercial → use a **spectral-library** approach
+  (predicted/empirical library) rather than directDIA, or Sage — and tell the user the
+  constraint. (Non-timsTOF instruments, or library-based timsTOF runs, are fine for AlphaDIA.)
+- **On `hpc`:** add `--sbatch job.sh`, then `sbatch job.sh` (over `hive_exec.sh` for a
+  remote HIVE run). Re-run with `--adapt-only` afterward for Sage/FragPipe/AlphaDIA to
+  build `report.parquet`.
 - Output is normalized to the **DE contract**: a DIA-NN-shaped `report.parquet`.
 → detail: `references/search-engines.md`.
+
+### 7b. Watch the run — MANDATORY, auto-correct errors
+**The moment a search starts, watch it — never leave a multi-hour search
+unmonitored.** Poll with `watch_run.sh` in a loop until it finishes:
+```
+# local: python3 scripts/run_search.py ... run_in_background, then loop:
+bash scripts/watch_run.sh --log <search log>
+# SLURM on HIVE:
+bash scripts/watch_run.sh --slurm <jobid> --log <job log> --hive   # (HIVE_USER/HIVE_KEY set)
+```
+It returns `{state, done, failed, error_class, fix}`. While `done` is false, keep
+polling (sleep ~60s between polls; for long SLURM jobs use a scheduled wake-up). **If
+`failed` is true, apply the `fix`** (raise `--mem`/`--time`, switch DIA-NN container,
+fix a path, move to a GPU node, etc. — see `references/watcher.md`) and **resubmit**,
+then watch again. Report progress and any auto-fixes to the user. Only proceed to DE
+once the run is `COMPLETED` and `report.parquet` exists. → detail: `references/watcher.md`.
 
 ### 8. Differential expression
 ```

--- a/skill/ucdavis-proteomics-core-pipeline/references/environment.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/environment.md
@@ -20,10 +20,14 @@ Container runtime preference: hpc→apptainer, mac→docker, linux→native.
 - **No native macOS build exists.** On mac you must run DIA-NN through Docker. Set
   `DIANN_DOCKER_IMAGE` to a built image, or build one from the Academia Linux zip's
   bundled Dockerfile. `acquire_tools.sh` writes a note when this is unresolved.
-- **HIVE:** reuse `/quobyte/proteomics-grp/dia-nn/*.sif` (the `dia-nn/` image has
-  .NET and reads `.raw`; the `apptainers/` one does not — always prefer `dia-nn/`).
-  `acquire_tools.sh` picks the `.sif` whose name contains the pinned version, else
-  the newest.
+- **HIVE (Proteomics Core):** DIA-NN is kept under `/quobyte/proteomics-grp/dia-nn/`.
+  Recent versions are **native builds**, e.g. DIA-NN **2.6.0** at
+  `build_260/diann-2.6.0/diann-linux`; older 2.3.0 is a `.sif`. `acquire_tools.sh`
+  resolves the **pinned** version by looking for `build_*/diann-<version>/diann-linux`
+  first, then a version-matched `.sif`, and **never silently substitutes a different
+  version** (reproducibility). The facility's `run_diann_*.sbatch` in that folder is
+  the reference invocation. AlphaDIA is also on HIVE at
+  `/quobyte/proteomics-grp/apptainers/alphadia.sif` (auto-reused).
 - **Linux native:** needs glibc ≥ Linux Mint 21.2 and .NET 8. If missing, prefer
   Docker/Apptainer.
 - DIA-NN reads `.raw`/`.d` natively from 2.1+.

--- a/skill/ucdavis-proteomics-core-pipeline/references/search-engines.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/search-engines.md
@@ -61,6 +61,12 @@ Apache-2.0 — the open-source alternative to DIA-NN for non-academic users. Lib
   the matrix → DIA-NN-shaped `report.parquet` (Run, Protein.Group, PG.MaxLFQ; Q-values
   zeroed since AlphaDIA already FDR-filtered). Like the Sage adapter, confirm it on real
   data the first time.
+- **⚠ Limitation — timsTOF whole-proteome directDIA:** AlphaDIA does **not** work on
+  **timsTOF** `.d` for **whole-proteome library-free (directDIA)** searches. For that
+  case it is not a valid substitute for DIA-NN. Options: academic → DIA-NN; commercial →
+  run AlphaDIA **library-based** (a predicted/empirical spectral library, `--library`)
+  instead of directDIA, or use Sage. Non-timsTOF instruments and library-based timsTOF
+  runs are unaffected.
 
 ### Sage (mzML-first; adapter required)
 1. Convert `.d`/`.raw` → mzML with `msconvert` if needed (fails loudly if msconvert

--- a/skill/ucdavis-proteomics-core-pipeline/references/watcher.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/watcher.md
@@ -1,0 +1,48 @@
+# Run watcher — monitor searches and auto-correct errors
+
+A search is long (often hours) and runs detached (a background process locally, a
+SLURM job on HIVE). **Always watch it** — the orchestrator must not start a search
+and walk away. `watch_run.sh` does one poll + diagnosis; loop it until the run
+finishes, and on failure apply the fix and resubmit.
+
+## Loop pattern
+```
+# start the search (background locally, or sbatch on HIVE), capture the log path / job id
+while true; do
+  status=$(bash scripts/watch_run.sh --slurm <jobid> --log <log> --hive)   # or --log <log> locally
+  done=$(echo "$status" | python3 -c 'import sys,json;print(json.load(sys.stdin)["done"])')
+  [ "$done" = "True" ] && break
+  sleep 60        # for long SLURM jobs, schedule a wake-up instead of busy-waiting
+done
+# if failed: read error_class + fix, apply it, resubmit, watch again.
+```
+The agent itself is the watcher — `watch_run.sh` is its eyes. Surface progress and
+any auto-fix you applied to the user.
+
+## Error classes → fixes (what `watch_run.sh` detects)
+| error_class | signal | fix |
+|---|---|---|
+| `out_of_memory` | oom-kill, `std::bad_alloc`, OUT_OF_MEMORY | raise sbatch `--mem` (e.g. 64G→128G); DIA-NN: fewer threads; resubmit |
+| `timeout` | TIMEOUT / "DUE TO TIME LIMIT" | raise `--time`, or split the run; resubmit |
+| `diann_no_dotnet` | `dotnet: not found` | wrong DIA-NN container (no .NET → `.raw` silently skipped). Use the HIVE **native** build `build_<v>/diann-<v>/diann-linux` or a .NET image |
+| `empty_results` | 0 proteins / no fragment ions | FASTA/organism mismatch, mass-accuracy, or wrong acquisition type — check inputs |
+| `gpu` | CUDA / no kernel image | AlphaDIA needs a GPU: submit to a GPU node (`--gres=gpu:1`) or reduce batch size |
+| `sage_no_mzml` | msconvert not found / needs mzML | convert `.d`/`.raw` → mzML first (Linux/HIVE), then re-run Sage |
+| `disk` | Disk quota / No space left | free space or point `--out` elsewhere; resubmit |
+| `missing_input` | No such file / fasta/raw not found | a path is wrong — re-check Windows→WSL/HIVE path translation; resubmit |
+| `unknown_failure` | job FAILED with no known signature | read the full log; diagnose; fix; resubmit (and add the new signature here) |
+
+## SLURM specifics (HIVE)
+- State comes from `sacct -j <jobid> -o State` (falls back to `squeue`). Terminal
+  states: COMPLETED (done), FAILED / TIMEOUT / OUT_OF_MEMORY / NODE_FAIL / CANCELLED
+  (done + failed).
+- The job log is the sbatch `--output` file (the skill's `emit_sbatch` names it
+  `<out>/<job>_<jobid>.log`).
+- When resubmitting after a fix, edit the sbatch (`--mem`/`--time`/`--gres`) and note
+  the change in `commands.log` so the reproducibility bundle records what happened.
+
+## Don't
+- Don't declare a run "done" on a non-COMPLETED state, and don't proceed to DE until
+  `report.parquet` exists.
+- Don't silently retry forever — after 2 failed auto-fix attempts of the same class,
+  stop and tell the user what's wrong.

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/acquire_tools.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/acquire_tools.sh
@@ -87,16 +87,29 @@ acquire_diann() {
   DIANN_VER="$ver"
   case "$CLASS" in
     hpc)
-      # prefer a .sif whose name contains the pinned version; else newest.
-      local sif
-      if [ -n "${ver}" ] && [ "$ver" != "latest" ]; then
-        sif="$(ls -1 /quobyte/proteomics-grp/dia-nn/*"${ver}"*.sif 2>/dev/null | sort -V | tail -n1)"
+      # On HIVE the Proteomics Core keeps DIA-NN as NATIVE builds, e.g. 2.6.0 at
+      #   /quobyte/proteomics-grp/dia-nn/build_260/diann-2.6.0/diann-linux
+      # (older 2.3.0 is a .sif). Match the PINNED version exactly — never silently
+      # substitute a different version (reproducibility).
+      local DN=/quobyte/proteomics-grp/dia-nn bin="" sif=""
+      if [ "$ver" != "latest" ]; then
+        bin="$(ls -1 "$DN"/*/diann-"$ver"/diann-linux 2>/dev/null | head -n1)"
+        [ -z "$bin" ] && bin="$(find "$DN" -maxdepth 3 -path "*diann-$ver*/diann-linux" -type f 2>/dev/null | head -n1)"
+        [ -z "$bin" ] && sif="$(ls -1 "$DN"/*"$ver"*.sif 2>/dev/null | sort -V | tail -n1)"
+      else
+        bin="$(find "$DN" -maxdepth 3 -name diann-linux -type f 2>/dev/null | sort -V | tail -n1)"
+        [ -z "$bin" ] && sif="$(ls -1 "$DN"/*.sif 2>/dev/null | sort -V | tail -n1)"
       fi
-      [ -z "${sif:-}" ] && sif="$(ls -1 /quobyte/proteomics-grp/dia-nn/*.sif 2>/dev/null | sort -V | tail -n1)"
-      if [ -n "${sif:-}" ] && have apptainer; then
-        DIANN_CMD="apptainer exec --bind /quobyte:/quobyte $sif /diann-*/diann-linux"
-        NOTES+=("DIA-NN: reusing Apptainer image $sif on HIVE (requested version '$ver').")
+      if [ -n "$bin" ]; then
+        DIANN_CMD="$bin"
+        NOTES+=("DIA-NN $ver: using the HIVE Proteomics Core native build $bin. Reference invocation: $DN/run_diann_*.sbatch.")
         return
+      elif [ -n "$sif" ] && have apptainer && { [ "$ver" = "latest" ] || printf '%s' "$sif" | grep -q "$ver"; }; then
+        DIANN_CMD="apptainer exec --bind /quobyte:/quobyte $sif /diann-*/diann-linux"
+        NOTES+=("DIA-NN $ver: reusing HIVE container $sif.")
+        return
+      else
+        NOTES+=("DIA-NN $ver NOT found on HIVE under $DN — NOT substituting a different version. Present: $(ls -d "$DN"/*.sif "$DN"/build_*/diann-* 2>/dev/null | xargs -n1 basename 2>/dev/null | tr '\n' ' '). Will fetch the pinned Academia build into your space instead (or build $ver).")
       fi ;;
     mac)
       if [ -n "${DIANN_DOCKER_IMAGE:-}" ] && have docker; then
@@ -154,6 +167,14 @@ acquire_fragpipe() {
 # whose free "Academia" build is academic/non-profit only. pip-installed into the
 # active env. Deep-learning based: a GPU is strongly recommended (CPU is slow).
 acquire_alphadia() {
+  # On HIVE the Proteomics Core keeps an AlphaDIA container.
+  if [ "$CLASS" = "hpc" ]; then
+    local asif=/quobyte/proteomics-grp/apptainers/alphadia.sif
+    if [ -f "$asif" ] && have apptainer; then
+      ALPHADIA_CMD="apptainer exec --bind /quobyte:/quobyte $asif alphadia"
+      NOTES+=("AlphaDIA: reusing the HIVE container $asif (Apache-2.0, commercial-OK)."); return
+    fi
+  fi
   if have alphadia; then ALPHADIA_CMD="$(command -v alphadia)"
     NOTES+=("AlphaDIA: using the alphadia on PATH ($ALPHADIA_CMD). Apache-2.0 (commercial use OK)."); return; fi
   local spec="alphadia"; pin_for alphadia && spec="alphadia==$PIN_VERSION"
@@ -170,8 +191,12 @@ echo "[acquire] platform=$CLASS  os=$OS arch=$ARCH  root=$ROOT  pin=${PIN_ENGINE
 acquire_sage
 acquire_diann
 acquire_fragpipe
-# AlphaDIA only when asked for (it's a large GPU package) — pinned or already present.
-if [ "${PIN_ENGINE:-}" = "alphadia" ] || have alphadia; then acquire_alphadia; fi
+# AlphaDIA: discover the HIVE container automatically; otherwise only acquire when
+# pinned/requested or already present (it's a large GPU pip package — don't auto-install).
+if [ "${PIN_ENGINE:-}" = "alphadia" ] || have alphadia \
+   || { [ "$CLASS" = "hpc" ] && [ -f /quobyte/proteomics-grp/apptainers/alphadia.sif ]; }; then
+  acquire_alphadia
+fi
 
 # ---- write manifest ----------------------------------------------------------
 esc() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# =============================================================================
+# watch_run.sh  --  One poll of a running search: report its state, detect known
+# errors, and suggest the fix. The orchestrator MUST watch every search it starts:
+# loop this until the run finishes, and on failure apply the fix (and resubmit) —
+# never leave a multi-hour search unmonitored.
+#
+# Usage:
+#   watch_run.sh --log <logfile>                 # local run: the search log
+#   watch_run.sh --slurm <jobid> [--log <file>]  # SLURM job
+#   add --hive to query HIVE over SSH (needs HIVE_USER/HIVE_KEY; uses hive_exec.sh)
+#
+# Emits JSON: {state, done, failed, error_class, fix, log_tail}. Loop pattern:
+#   while not done: watch_run.sh ...; sleep 60; done   # then act on failed/fix
+# =============================================================================
+set -uo pipefail
+MODE="local"; JOB=""; LOG=""; HIVE=false
+while [ $# -gt 0 ]; do case "$1" in
+  --slurm) MODE="slurm"; JOB="$2"; shift 2;;
+  --log)   LOG="$2"; shift 2;;
+  --hive)  HIVE=true; shift;;
+  *) shift;;
+esac; done
+HERE="$(cd "$(dirname "$0")" && pwd)"
+run() { if $HIVE; then bash "$HERE/hive_exec.sh" "$*"; else bash -c "$*"; fi; }
+
+state="unknown"; done=false; failed=false
+if [ "$MODE" = "slurm" ] && [ -n "$JOB" ]; then
+  st="$(run "sacct -j $JOB --noheader -o State 2>/dev/null | head -1 | tr -d ' '" 2>/dev/null)"
+  [ -z "$st" ] && st="$(run "squeue -j $JOB -h -o %T 2>/dev/null" 2>/dev/null)"
+  state="${st:-PENDING}"
+  case "$state" in
+    COMPLETED)                                   done=true;;
+    FAILED|TIMEOUT|OUT_OF_MEMORY|NODE_FAIL)       done=true; failed=true;;
+    CANCELLED*)                                   done=true; failed=true;;
+  esac
+fi
+
+tail_txt=""
+[ -n "$LOG" ] && tail_txt="$(run "tail -n 100 $(printf %q "$LOG") 2>/dev/null" 2>/dev/null)"
+
+# error signatures -> (class, fix). First match wins.
+err_class=""; fix=""
+hay="$tail_txt
+$state"
+m() { printf '%s' "$hay" | grep -qiE "$1"; }
+if   m "out.of.memory|oom-kill|OUT_OF_MEMORY|std::bad_alloc|cannot allocate";       then err_class="out_of_memory"; fix="Raise the sbatch --mem (e.g. 64G→128G) and resubmit; for DIA-NN try fewer threads or --min-corr.";
+elif m "TIMEOUT|DUE TO TIME LIMIT|CANCELLED.*TIME";                                  then err_class="timeout";       fix="Raise --time in the sbatch (or split the run) and resubmit.";
+elif m "dotnet: not found|dotnet: command not found";                               then err_class="diann_no_dotnet";fix="Wrong DIA-NN container (no .NET → .raw silently skipped). Use the HIVE native build (build_<v>/diann-<v>/diann-linux) or a .NET-enabled image.";
+elif m "0 proteins|No fragment ions|No precursors|no spectra|empty";                then err_class="empty_results"; fix="Check the FASTA matches the organism, the mass-accuracy setting, and that the raw files are the expected acquisition type.";
+elif m "CUDA|no kernel image|cuDNN|device-side|GPU.*not";                           then err_class="gpu";           fix="AlphaDIA needs a GPU. Submit to a GPU node (sbatch --gres=gpu:1) or reduce batch size.";
+elif m "msconvert.*not found|requires mzML|no mzML";                                then err_class="sage_no_mzml";  fix="Sage needs mzML. Convert .d/.raw with msconvert first (Linux/HIVE), then re-run.";
+elif m "Disk quota exceeded|No space left";                                         then err_class="disk";          fix="Out of disk/quota. Free space or point --out elsewhere and resubmit.";
+elif m "No such file|cannot open|does not exist|not found.*(fasta|\\.d|\\.raw)";     then err_class="missing_input"; fix="An input path is wrong (fasta/raw). Re-check paths (Windows→WSL/HIVE translation) and resubmit.";
+elif $failed;                                                                        then err_class="unknown_failure"; fix="Read the full log; diagnose via references/watcher.md; fix and resubmit.";
+fi
+
+STATE="$state" DONE="$done" FAILED="$failed" JOB="$JOB" MODE="$MODE" \
+ECLASS="$err_class" FIX="$fix" TAIL="$tail_txt" python3 - <<'PY'
+import os, json
+print(json.dumps({
+    "mode": os.environ["MODE"], "job": os.environ["JOB"], "state": os.environ["STATE"],
+    "done": os.environ["DONE"] == "true", "failed": os.environ["FAILED"] == "true",
+    "error_class": os.environ["ECLASS"], "fix": os.environ["FIX"],
+    "log_tail": os.environ["TAIL"][-1500:],
+}, indent=2))
+PY


### PR DESCRIPTION
(1) acquire_tools.sh now finds DIA-NN 2.6.0 on HIVE at the real native path build_260/diann-2.6.0/diann-linux (version-matched, no silent fallback to old 2.3.0 .sif) — verified on live HIVE — and reuses the HIVE alphadia.sif. (2) New watch_run.sh + mandatory step 7b: watch every search, detect common errors (OOM/timeout/no-.NET/empty/GPU/msconvert/disk/missing-input) and auto-fix+resubmit (references/watcher.md). (3) AlphaDIA timsTOF whole-proteome directDIA limitation documented + routed around. v1.0.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)