### PR TITLE
docs: never run heavy compute on a cluster login node (any scheduler) (v1.0.7)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -33,8 +33,15 @@ the spine.
 2. **Never fabricate parameters.** If a value isn't in the workflow bundle or given
    by the user, say so — don't invent an FDR, organism, or instrument. (DE-LIMP
    architectural rule #2.)
-3. **Never run heavy compute on an HPC login node.** On `platform_class: hpc`, emit
-   an sbatch script (`run_search.py --sbatch`) and submit it — don't run inline.
+3. **Never run computationally intensive work on a cluster login/head node — EVER.**
+   On any cluster (HIVE/SLURM, or any other scheduler), **every** heavy step — the
+   search, and any large DE / figure / conversion (e.g. msconvert) — must run as a
+   **scheduled job** (`run_search.py --sbatch` → `sbatch`), not inline on the login
+   node. Login nodes are shared; running compute there gets the user flagged/killed.
+   The **only** things allowed on the login node are tiny orchestration commands —
+   submitting jobs, `squeue`/`sacct` polling (`watch_run.sh`), and small file moves.
+   If you're unsure whether a step is heavy, submit it as a job. (No SLURM but a big
+   dataset locally? Warn the user it may be slow rather than hammering a shared host.)
 4. **Organism is a hard filter** (it defines the FASTA). Instrument is only a
    tiebreaker. Acquisition is auto-detected and confirmed.
 5. **Every run must be completely reproducible.** This is not optional. As you go,

--- a/skill/ucdavis-proteomics-core-pipeline/references/access.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/access.md
@@ -95,7 +95,10 @@ your own copy in your HIVE home. Run all of this **on HIVE** (via `hive_exec.sh`
    reproducibility) is identical to a local run.
 
 ## Notes
-- Heavy compute **must** go through `sbatch` — never run a search on the login node.
+- **Never run computationally intensive work on the login/head node** — the search
+  and any heavy DE/figure/conversion step go through `sbatch`. The login node is only
+  for submitting jobs, `squeue`/`sacct` polling, and small file moves. Holds on HIVE
+  and any other cluster/scheduler.
 - "Core member" = read access to `/quobyte/proteomics-grp`. If `check_access.sh` shows
   `proteomics_grp_access: false` over SSH, the account isn't in the group yet — request
   it from the Core.


### PR DESCRIPTION
Strengthens golden rule #3 + references/access.md: every heavy step (search + any large DE/figure/conversion) runs as a scheduled job on HIVE/SLURM or any other cluster; the login node is only for submitting jobs, squeue/sacct polling, and small file moves. v1.0.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)