### PR TITLE
feat(skill): sample-quality checks, autonomous stall recovery, DIA-NN DDA/.raw (v1.0.9)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/README_GITHUB.md
+++ b/README_GITHUB.md
@@ -246,13 +246,17 @@ derived from your data type, then limpa/limma DE, and writes a biological analys
 report plus a full reproducibility bundle, all packaged into tidy session folders.
 It runs in **Claude Code** and **Claude Desktop**.
 
-**Install (one time):**
+**Install (one time)** — in **Claude Code**:
 ```
 /plugin marketplace add bsphinney/DE-LIMP
-/plugin install ucdavis-proteomics-core-pipeline
+/plugin install ucdavis-proteomics-core-pipeline@ucdavis-proteomics-core
 ```
-On **Claude Desktop**: *Customize → Plugins → Browse plugins*, add the marketplace
-`bsphinney/DE-LIMP`, then install **ucdavis-proteomics-core-pipeline**.
+On **Claude Desktop**: click the **+** button beside the prompt box → *Plugins* →
+*Add plugin*, add the marketplace `bsphinney/DE-LIMP`, then install
+**ucdavis-proteomics-core-pipeline**.
+
+📖 **[Step-by-step install guide](https://bsphinney.github.io/DE-LIMP/skill-install.html)** —
+written for biologists, covers both apps, first run, platform notes, and troubleshooting.
 
 **Use it:** just say *"analyze my proteomics data in `~/data/HeLaQC` — it's human,
 first 3 are control, last 3 treated."* It asks only for what it can't detect

--- a/docs/skill-install.html
+++ b/docs/skill-install.html
@@ -1,0 +1,702 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Install the UC Davis Proteomics Core pipeline for Claude</title>
+<meta name="description" content="Step-by-step guide to installing the ucdavis-proteomics-core-pipeline skill in Claude Code or Claude Desktop, and running your first proteomics analysis.">
+<style>
+:root {
+  --navy: #1e3a5f;
+  --navy-mid: #2c5282;
+  --navy-soft: #ebf4ff;
+  --green: #2f7d54;
+  --green-soft: #e8f5ee;
+  --amber: #b45309;
+  --amber-soft: #fdf6e7;
+  --text: #16212e;
+  --text-mid: #4a5a6d;
+  --text-dim: #6c7c8d;
+  --bg: #ffffff;
+  --bg-alt: #f5f8fb;
+  --border: #dde5ee;
+  --border-soft: #eaf0f6;
+  --term-bg: #16283d;
+  --term-text: #dce8f5;
+  --term-dim: #7d99b5;
+  --shadow: 0 1px 2px rgba(22,40,61,.06), 0 6px 18px rgba(22,40,61,.06);
+  --serif: "Iowan Old Style", "Charter", "Palatino Linotype", Palatino, Georgia, serif;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --col: 40rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --navy: #7fb2e0; --navy-mid: #9cc6ec; --navy-soft: #16304a;
+    --green: #6cc396; --green-soft: #14301f;
+    --amber: #e0a94a; --amber-soft: #31260f;
+    --text: #e7eef6; --text-mid: #b3c3d3; --text-dim: #8b9cae;
+    --bg: #0d1721; --bg-alt: #131f2b; --border: #253546; --border-soft: #1c2937;
+    --term-bg: #060d15; --term-text: #d7e5f3; --term-dim: #7089a3;
+    --shadow: 0 1px 2px rgba(0,0,0,.4), 0 6px 18px rgba(0,0,0,.3);
+  }
+}
+:root[data-theme="dark"] {
+  --navy: #7fb2e0; --navy-mid: #9cc6ec; --navy-soft: #16304a;
+  --green: #6cc396; --green-soft: #14301f;
+  --amber: #e0a94a; --amber-soft: #31260f;
+  --text: #e7eef6; --text-mid: #b3c3d3; --text-dim: #8b9cae;
+  --bg: #0d1721; --bg-alt: #131f2b; --border: #253546; --border-soft: #1c2937;
+  --term-bg: #060d15; --term-text: #d7e5f3; --term-dim: #7089a3;
+  --shadow: 0 1px 2px rgba(0,0,0,.4), 0 6px 18px rgba(0,0,0,.3);
+}
+:root[data-theme="light"] {
+  --navy: #1e3a5f; --navy-mid: #2c5282; --navy-soft: #ebf4ff;
+  --green: #2f7d54; --green-soft: #e8f5ee;
+  --amber: #b45309; --amber-soft: #fdf6e7;
+  --text: #16212e; --text-mid: #4a5a6d; --text-dim: #6c7c8d;
+  --bg: #ffffff; --bg-alt: #f5f8fb; --border: #dde5ee; --border-soft: #eaf0f6;
+  --term-bg: #16283d; --term-text: #dce8f5; --term-dim: #7d99b5;
+  --shadow: 0 1px 2px rgba(22,40,61,.06), 0 6px 18px rgba(22,40,61,.06);
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 17px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: var(--navy-mid); text-underline-offset: 3px; text-decoration-thickness: 1px; }
+a:hover { color: var(--green); }
+:focus-visible { outline: 2px solid var(--green); outline-offset: 3px; border-radius: 3px; }
+
+.wrap { max-width: 54rem; margin: 0 auto; padding: 0 1.5rem; }
+.prose { max-width: var(--col); }
+
+/* ---------- masthead ---------- */
+header.mast {
+  background: var(--bg-alt);
+  border-bottom: 1px solid var(--border);
+  padding: 3.25rem 0 2.5rem;
+}
+.eyebrow {
+  font-family: var(--mono);
+  font-size: .72rem;
+  letter-spacing: .13em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin: 0 0 1rem;
+}
+h1 {
+  font-family: var(--serif);
+  font-weight: 600;
+  font-size: clamp(2rem, 5vw, 2.9rem);
+  line-height: 1.12;
+  letter-spacing: -.015em;
+  text-wrap: balance;
+  margin: 0 0 .85rem;
+}
+.standfirst {
+  font-size: 1.13rem;
+  color: var(--text-mid);
+  max-width: var(--col);
+  margin: 0 0 1.6rem;
+}
+.chips { display: flex; flex-wrap: wrap; gap: .5rem; }
+.chip {
+  font-family: var(--mono);
+  font-size: .74rem;
+  letter-spacing: .04em;
+  padding: .3rem .6rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text-mid);
+}
+.chip.on { background: var(--green-soft); border-color: transparent; color: var(--green); }
+
+/* ---------- sections ---------- */
+main { padding: 0 0 5rem; }
+section { padding: 3rem 0 0; }
+h2 {
+  font-family: var(--serif);
+  font-size: 1.6rem;
+  font-weight: 600;
+  letter-spacing: -.01em;
+  text-wrap: balance;
+  margin: 0 0 .3rem;
+  padding-top: 1.4rem;
+  border-top: 2px solid var(--navy);
+}
+h3 {
+  font-size: 1.03rem;
+  font-weight: 650;
+  margin: 2rem 0 .5rem;
+  letter-spacing: -.005em;
+}
+.lede { color: var(--text-mid); max-width: var(--col); margin: .4rem 0 1.5rem; }
+p { max-width: var(--col); margin: 0 0 1rem; }
+ul.plain { max-width: var(--col); margin: 0 0 1rem; padding-left: 1.15rem; }
+ul.plain li { margin-bottom: .45rem; }
+strong { font-weight: 650; }
+code {
+  font-family: var(--mono);
+  font-size: .87em;
+  background: var(--bg-alt);
+  border: 1px solid var(--border-soft);
+  border-radius: 4px;
+  padding: .1em .35em;
+  word-break: break-word;
+}
+
+/* ---------- numbered steps ---------- */
+ol.steps { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2.25rem; }
+ol.steps > li { display: grid; grid-template-columns: 2.4rem 1fr; gap: 1.1rem; align-items: start; }
+.num {
+  font-family: var(--mono);
+  font-size: .8rem;
+  font-weight: 600;
+  color: var(--navy);
+  background: var(--navy-soft);
+  border-radius: 50%;
+  width: 2.1rem; height: 2.1rem;
+  display: flex; align-items: center; justify-content: center;
+  margin-top: .1rem;
+  font-variant-numeric: tabular-nums;
+}
+.step-body { min-width: 0; }
+.step-body > h3 { margin-top: 0; }
+.step-body > p:last-child { margin-bottom: 0; }
+
+/* ---------- command blocks ---------- */
+.cmd {
+  position: relative;
+  background: var(--term-bg);
+  color: var(--term-text);
+  border-radius: 8px;
+  margin: .9rem 0 1rem;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.cmd-label {
+  font-family: var(--mono);
+  font-size: .68rem;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--term-dim);
+  padding: .6rem .95rem .1rem;
+}
+.cmd pre {
+  margin: 0;
+  padding: .55rem .95rem 1rem;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: .88rem;
+  line-height: 1.75;
+}
+.cmd pre .p { color: var(--term-dim); user-select: none; }
+.copy {
+  position: absolute; top: .5rem; right: .5rem;
+  font-family: var(--sans); font-size: .72rem; font-weight: 600;
+  color: var(--term-dim); background: transparent;
+  border: 1px solid rgba(125,153,181,.35); border-radius: 5px;
+  padding: .25rem .55rem; cursor: pointer;
+  transition: color .15s, border-color .15s;
+}
+.copy:hover { color: var(--term-text); border-color: rgba(125,153,181,.8); }
+.copy.done { color: #6cc396; border-color: #6cc396; }
+
+/* say-this block (what to type to Claude, not a shell command) */
+.say {
+  border-left: 3px solid var(--green);
+  background: var(--green-soft);
+  border-radius: 0 8px 8px 0;
+  padding: 1rem 1.15rem;
+  margin: 1rem 0 1.25rem;
+  max-width: var(--col);
+}
+.say .cmd-label { padding: 0 0 .35rem; color: var(--green); }
+.say p { font-size: 1.02rem; margin: 0; color: var(--text); }
+
+/* ---------- cards ---------- */
+.two { display: grid; grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); gap: 1.1rem; margin: 1.25rem 0; }
+.card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.25rem 1.35rem 1.4rem;
+  background: var(--bg);
+}
+.card h3 { margin: 0 0 .15rem; font-size: 1.02rem; }
+.card .sub { font-size: .84rem; color: var(--text-dim); margin: 0 0 .9rem; }
+.card p, .card ul.plain { max-width: none; }
+.card .cmd { margin-bottom: .6rem; }
+
+/* ---------- callout ---------- */
+.note {
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--amber);
+  background: var(--amber-soft);
+  border-radius: 0 8px 8px 0;
+  padding: 1rem 1.2rem;
+  margin: 1.4rem 0;
+  max-width: var(--col);
+}
+.note p:last-child { margin-bottom: 0; }
+.note .tag {
+  font-family: var(--mono); font-size: .68rem; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--amber); display: block; margin-bottom: .35rem;
+}
+
+/* ---------- tables ---------- */
+.tw { overflow-x: auto; margin: 1.25rem 0; border: 1px solid var(--border); border-radius: 10px; }
+table { border-collapse: collapse; width: 100%; font-size: .93rem; }
+th, td { text-align: left; padding: .7rem .95rem; border-bottom: 1px solid var(--border-soft); vertical-align: top; }
+thead th {
+  font-family: var(--mono); font-size: .7rem; letter-spacing: .1em; text-transform: uppercase;
+  color: var(--text-dim); background: var(--bg-alt); border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+tbody tr:last-child td { border-bottom: none; }
+td code { background: transparent; border: none; padding: 0; }
+
+/* ---------- footer ---------- */
+footer {
+  border-top: 1px solid var(--border);
+  background: var(--bg-alt);
+  padding: 2.25rem 0 3rem;
+  font-size: .92rem;
+  color: var(--text-mid);
+}
+footer p { max-width: var(--col); }
+
+@media (max-width: 34rem) {
+  body { font-size: 16px; }
+  ol.steps > li { grid-template-columns: 1.9rem 1fr; gap: .8rem; }
+  .num { width: 1.75rem; height: 1.75rem; font-size: .72rem; }
+}
+@media print {
+  .copy { display: none; }
+  body { font-size: 11pt; }
+  .cmd { background: #f3f3f3; color: #111; box-shadow: none; border: 1px solid #ccc; }
+  .cmd pre .p, .cmd-label { color: #666; }
+}
+</style>
+</head>
+<body>
+
+<header class="mast">
+  <div class="wrap">
+    <p class="eyebrow">UC Davis Proteomics Core &middot; DE-LIMP</p>
+    <h1>Analyze your proteomics data by asking Claude</h1>
+    <p class="standfirst">
+      This guide installs a skill that takes you from raw mass-spec files to a list of
+      differentially expressed proteins &mdash; search, statistics, figures, and a written
+      report &mdash; without you assembling a pipeline. It takes about five minutes to set up,
+      and you only do it once.
+    </p>
+    <div class="chips">
+      <span class="chip on">ucdavis-proteomics-core-pipeline</span>
+      <span class="chip">macOS &middot; Windows &middot; Linux</span>
+      <span class="chip">No admin rights needed</span>
+    </div>
+  </div>
+</header>
+
+<main>
+
+<section id="what">
+  <div class="wrap">
+    <h2>What it does</h2>
+    <p class="lede">
+      You point it at a folder of raw files and describe your experiment in plain words. It
+      handles everything else.
+    </p>
+    <p>
+      The skill works out whether your data is DIA or DDA and which instrument produced it,
+      then pulls a validated workflow from the DE-LIMP repository rather than inventing
+      parameters. It installs its own search engine, fetches the right protein database for
+      your organism, runs the search, and carries the results through differential expression
+      analysis in <em>limpa</em>/<em>limma</em>.
+    </p>
+    <p>
+      What you get back is a folder containing volcano plots and PCA, a results table per
+      comparison, a written interpretation of your data in both Markdown and Word, a methods
+      paragraph you can paste into a manuscript, and a reproducibility bundle that lets
+      someone else re-run the exact analysis. It also audits your experimental design and
+      stops if something is wrong &mdash; a group with no replicates, a batch confounded with
+      your biology, or contamination that could masquerade as a real result.
+    </p>
+  </div>
+</section>
+
+<section id="before">
+  <div class="wrap">
+    <h2>Before you start</h2>
+    <p class="lede">Three things. Nothing else needs installing &mdash; the skill sets up its own toolchain the first time it runs.</p>
+
+    <h3>1. Claude, in one of two forms</h3>
+    <p>
+      Either <strong>Claude Code</strong> (runs in a terminal) or the <strong>Claude Desktop</strong>
+      app. Both work; the install steps differ slightly and both are covered below. If you have
+      neither and aren't sure which to pick, Claude Desktop is the gentler start.
+    </p>
+    <p>If you're going the terminal route and don't have Claude Code yet, install it first:</p>
+    <div class="cmd" data-copy="curl -fsSL https://claude.ai/install.sh | bash">
+      <button class="copy" type="button">Copy</button>
+      <div class="cmd-label">macOS and Linux</div>
+      <pre><code>curl -fsSL https://claude.ai/install.sh | bash</code></pre>
+    </div>
+    <div class="cmd" data-copy="irm https://claude.ai/install.ps1 | iex">
+      <button class="copy" type="button">Copy</button>
+      <div class="cmd-label">Windows, in PowerShell</div>
+      <pre><code>irm https://claude.ai/install.ps1 | iex</code></pre>
+    </div>
+    <p>Then run <code>claude</code> to start it, and <code>claude --version</code> if you want to confirm it's there.</p>
+
+    <h3>2. Your raw mass-spec files</h3>
+    <p>
+      Bruker <code>.d</code> folders, Thermo <code>.raw</code> files, or <code>.mzML</code>. Keep them
+      together in one folder. You do not need to convert or rename anything.
+    </p>
+
+    <h3>3. Two facts about your experiment</h3>
+    <p>
+      The <strong>organism</strong> (this determines the protein database, and it cannot be
+      detected from the files), and <strong>which samples belong to which group</strong>. You can
+      describe the groups in words or hand over a spreadsheet &mdash; whatever you already have.
+    </p>
+  </div>
+</section>
+
+<section id="install">
+  <div class="wrap">
+    <h2>Install the skill</h2>
+    <p class="lede">
+      Two commands, or a few clicks. You do this once; it stays installed.
+    </p>
+
+    <div class="two">
+      <div class="card">
+        <h3>In Claude Code</h3>
+        <p class="sub">The terminal version</p>
+        <p>Type these two commands at the Claude Code prompt, one after the other:</p>
+        <div class="cmd" data-copy="/plugin marketplace add bsphinney/DE-LIMP">
+          <button class="copy" type="button">Copy</button>
+          <div class="cmd-label">Step one &mdash; add the source</div>
+          <pre><code>/plugin marketplace add bsphinney/DE-LIMP</code></pre>
+        </div>
+        <div class="cmd" data-copy="/plugin install ucdavis-proteomics-core-pipeline@ucdavis-proteomics-core">
+          <button class="copy" type="button">Copy</button>
+          <div class="cmd-label">Step two &mdash; install</div>
+          <pre><code>/plugin install ucdavis-proteomics-core-pipeline@ucdavis-proteomics-core</code></pre>
+        </div>
+        <p>
+          Claude will ask you to confirm before trusting a new plugin source. Accept it, and
+          the skill is ready.
+        </p>
+      </div>
+
+      <div class="card">
+        <h3>In Claude Desktop</h3>
+        <p class="sub">The app, no terminal</p>
+        <p>Everything starts from the <strong>+</strong> button beside the prompt box:</p>
+        <ul class="plain">
+          <li>Click <strong>+</strong>, then choose <strong>Plugins</strong>.</li>
+          <li>Choose <strong>Add plugin</strong> to open the plugin browser.</li>
+          <li>Add the marketplace <code>bsphinney/DE-LIMP</code>.</li>
+          <li>Find <strong>ucdavis-proteomics-core-pipeline</strong> and click <strong>Install</strong>.</li>
+        </ul>
+        <p>
+          To check on it later, take the same route and choose <strong>Manage plugins</strong>. The
+          <strong>Customize</strong> item in the sidebar also reaches plugins, alongside skills and
+          connectors.
+        </p>
+      </div>
+    </div>
+
+    <h3>Confirming it's there, and keeping it current</h3>
+    <p>
+      In Claude Code, <code>/plugin list</code> shows what's installed. Running <code>/plugin</code>
+      on its own opens a browser with tabs for discovering plugins, managing the ones you have,
+      and viewing any errors. If the skill doesn't respond in the session where you installed it,
+      <code>/reload-plugins</code> activates it without restarting.
+    </p>
+    <p>
+      Updates arrive automatically unless you've turned that off. To pull the newest version
+      yourself:
+    </p>
+    <div class="cmd" data-copy="/plugin marketplace update ucdavis-proteomics-core">
+      <button class="copy" type="button">Copy</button>
+      <div class="cmd-label">Fetch the latest version</div>
+      <pre><code>/plugin marketplace update ucdavis-proteomics-core</code></pre>
+    </div>
+    <p>
+      Note the two different names: <code>bsphinney/DE-LIMP</code> is the GitHub repository you add,
+      while <code>ucdavis-proteomics-core</code> is the marketplace inside it that later commands
+      refer to.
+    </p>
+  </div>
+</section>
+
+<section id="first-run">
+  <div class="wrap">
+    <h2>Run your first analysis</h2>
+    <p class="lede">
+      There is no command to remember. Describe what you have, and the skill starts itself.
+    </p>
+
+    <div class="say">
+      <div class="cmd-label">Say something like</div>
+      <p>
+        &ldquo;Analyze my proteomics data in <code>~/data/HeLa_treated</code>. It's human &mdash; the
+        first three files are control and the last three are treated.&rdquo;
+      </p>
+    </div>
+
+    <p>Phrases that also start it: <em>search these raw files</em>, <em>find differentially expressed
+    proteins</em>, <em>process this timsTOF run</em>, or simply pointing at a folder and asking what's
+    in it. It will then work through the following with you.</p>
+
+    <ol class="steps">
+      <li>
+        <span class="num">1</span>
+        <div class="step-body">
+          <h3>It asks where you're running</h3>
+          <p>
+            Whether you have a UC Davis HIVE account, and whether you're in the Proteomics Core.
+            If you're neither &mdash; which is most people &mdash; say no to both and everything runs on
+            your own machine. HIVE is a shortcut for Core members, never a requirement.
+          </p>
+        </div>
+      </li>
+      <li>
+        <span class="num">2</span>
+        <div class="step-body">
+          <h3>It sets up its toolchain</h3>
+          <p>
+            On the first run only, it installs R, the statistics packages, and a search engine
+            into a single self-contained folder. This takes a few minutes and needs no admin
+            password. Later runs skip it in seconds.
+          </p>
+        </div>
+      </li>
+      <li>
+        <span class="num">3</span>
+        <div class="step-body">
+          <h3>It detects your data and confirms the plan</h3>
+          <p>
+            It reads the files to determine DIA or DDA and the instrument, matches a validated
+            workflow, and shows you what it intends to run. <strong>Nothing heavy starts without
+            your explicit go-ahead</strong> &mdash; a search can run for hours, so it always asks first.
+          </p>
+        </div>
+      </li>
+      <li>
+        <span class="num">4</span>
+        <div class="step-body">
+          <h3>It runs, watches itself, and fixes problems</h3>
+          <p>
+            Once the search is going it monitors progress and recovers on its own from the usual
+            failures &mdash; a job that runs out of memory, hits its time limit, or stalls on a bad
+            file. You don't need to babysit it. It reports what it recovered.
+          </p>
+        </div>
+      </li>
+      <li>
+        <span class="num">5</span>
+        <div class="step-body">
+          <h3>It checks the results before believing them</h3>
+          <p>
+            Before writing anything up it audits the design and the data: too few replicates,
+            a confounded batch, unusually low identification depth, or contamination that
+            could look like biology. Warnings are surfaced to you, and genuine problems stop
+            the analysis rather than producing a confident-looking wrong answer.
+          </p>
+        </div>
+      </li>
+      <li>
+        <span class="num">6</span>
+        <div class="step-body">
+          <h3>It writes everything up</h3>
+          <p>
+            Results land in a dated session folder next to your raw data (or anywhere else you
+            ask). Start with <code>README.md</code> inside it, then the analysis report.
+          </p>
+        </div>
+      </li>
+    </ol>
+  </div>
+</section>
+
+<section id="results">
+  <div class="wrap">
+    <h2>What you get back</h2>
+    <p class="lede">Everything from one run is collected in a single session folder, ready to share or archive.</p>
+    <div class="tw">
+      <table>
+        <thead>
+          <tr><th>File</th><th>What it is</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>README.md</code></td><td>Start here &mdash; a plain summary of the run and where everything is.</td></tr>
+          <tr><td><code>AI_Analysis_Report.md</code><br><code>AI_Analysis_Report.docx</code></td><td>The written interpretation: what changed, in which comparison, and what it may mean. Figures embedded, in Markdown and Word.</td></tr>
+          <tr><td><code>tables/</code></td><td>One differential expression table per comparison, plus the full expression matrix, as CSV.</td></tr>
+          <tr><td><code>figures/</code></td><td>Volcano plots, PCA, heatmap of top proteins, p-value distributions, per-sample protein counts.</td></tr>
+          <tr><td><code>tables/methods.txt</code></td><td>A methods paragraph describing what was actually run. Paste it into a manuscript verbatim.</td></tr>
+          <tr><td><code>AUDIT.md</code><br><code>SAMPLE_QUALITY.md</code></td><td>Design and data-quality findings, including anything that should temper your conclusions.</td></tr>
+          <tr><td><code>OUTPUT_FILES.md</code></td><td>Every file produced, with a plain-language description of each.</td></tr>
+          <tr><td><code>reproducibility/</code></td><td>Exact versions, parameters, checksums, and a runnable <code>reproduce.sh</code> so the analysis can be re-derived later.</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<section id="platform">
+  <div class="wrap">
+    <h2>Notes for your platform</h2>
+    <p class="lede">Most people need none of this. Check only the row that matches you.</p>
+    <div class="tw">
+      <table>
+        <thead>
+          <tr><th>You're on</th><th>What to know</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Linux</strong></td>
+            <td>Everything installs and runs automatically. Nothing extra to do.</td>
+          </tr>
+          <tr>
+            <td><strong>macOS</strong></td>
+            <td>DDA data and all statistics work out of the box. For <em>DIA</em> data, DIA-NN has no Mac build, so the skill runs it in Docker &mdash; you'll be asked once to install <a href="https://docs.docker.com/desktop/setup/install/mac-install/">Docker Desktop</a> and open it. That is the only manual step anywhere in this pipeline.</td>
+          </tr>
+          <tr>
+            <td><strong>Windows</strong></td>
+            <td>Two routes. WSL2 (<code>wsl --install</code>) is smoothest &mdash; run the skill inside it and everything follows the Linux path. Native Windows also works, since the search engines ship Windows builds; run the skill from a POSIX shell such as Git Bash.</td>
+          </tr>
+          <tr>
+            <td><strong>UC Davis HIVE</strong></td>
+            <td>Tell the skill you have an account and where your SSH key is. It drives HIVE from your laptop and submits searches as SLURM jobs &mdash; never on a login node. Core members additionally reuse the software already installed in the group directory.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="note">
+      <span class="tag">Check this if you're not at a university</span>
+      <p>
+        DIA-NN's free build is licensed for <strong>academic and non-profit use only</strong>. If you're
+        in a commercial setting, say so when asked and the skill will route your DIA data to
+        <strong>AlphaDIA</strong> (Apache-2.0) or <strong>Sage</strong> (MIT) instead. Both are free for
+        commercial use.
+      </p>
+    </div>
+  </div>
+</section>
+
+<section id="trouble">
+  <div class="wrap">
+    <h2>If something goes wrong</h2>
+    <p class="lede">
+      The short version: tell Claude what you're seeing, in plain words. It knows how to repair
+      its own environment. These are the few cases worth recognizing.
+    </p>
+    <div class="tw">
+      <table>
+        <thead>
+          <tr><th>What you see</th><th>What to do</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>The skill doesn't start when you describe your data</td>
+            <td>Confirm it's installed with <code>/plugin list</code> (or the plugins panel), and try <code>/reload-plugins</code>. If it is installed, name it directly: &ldquo;use the ucdavis-proteomics-core-pipeline skill on this folder&rdquo;.</td>
+          </tr>
+          <tr>
+            <td>Something about R, limpa, or a missing package</td>
+            <td>Ask Claude to re-run the setup step. Don't install R or Bioconductor by hand &mdash; the skill manages its own environment, and a system R won't be the one it uses.</td>
+          </tr>
+          <tr>
+            <td>&ldquo;Docker is missing&rdquo; on a Mac with DIA data</td>
+            <td>Install Docker Desktop, open it once so the whale icon settles in the menu bar, then tell Claude to continue.</td>
+          </tr>
+          <tr>
+            <td>It says no validated workflow exists for your organism</td>
+            <td>That's deliberate &mdash; it won't invent search parameters. Get in touch and a workflow can be added for your organism and instrument.</td>
+          </tr>
+          <tr>
+            <td>It stops and refuses to interpret your results</td>
+            <td>Read what it says carefully. It stops on designs it can't analyze honestly, such as a group with no replicate or contamination confounded with your comparison. This is the skill working, not failing.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h3>Turning it off or removing it</h3>
+    <p>
+      To switch the skill off without removing it, use
+      <code>/plugin disable ucdavis-proteomics-core-pipeline@ucdavis-proteomics-core</code>
+      (<code>enable</code> brings it back). To remove it entirely, uninstall from the same plugin
+      panel you installed it in.
+    </p>
+    <p>
+      To also remove the toolchain it installed, delete the folder
+      <code>~/.proteomics-pipeline/</code>. Nothing was installed system-wide, and your data and
+      results are untouched.
+    </p>
+  </div>
+</section>
+
+<section id="help">
+  <div class="wrap">
+    <h2>Questions</h2>
+    <p>
+      The skill's source, the validated workflows it draws on, and the issue tracker all live in
+      the DE-LIMP repository:
+      <a href="https://github.com/bsphinney/DE-LIMP">github.com/bsphinney/DE-LIMP</a>.
+      If something here is wrong or unclear, open an issue &mdash; that's the fastest way to get it
+      fixed for the next person.
+    </p>
+    <p>
+      UC Davis Proteomics Core users can also just email
+      <a href="mailto:bsphinney@ucdavis.edu">bsphinney@ucdavis.edu</a>.
+    </p>
+  </div>
+</section>
+
+</main>
+
+<footer>
+  <div class="wrap">
+    <p>
+      <strong>UC Davis Proteomics Core</strong> &mdash; part of the
+      <a href="https://github.com/bsphinney/DE-LIMP">DE-LIMP</a> project.
+      Searches run in DIA-NN or Sage; differential expression uses
+      <a href="https://bioconductor.org/packages/limpa/">limpa</a> and limma.
+      Every analysis ships with the provenance needed to reproduce it.
+    </p>
+  </div>
+</footer>
+
+<script>
+document.querySelectorAll(".cmd").forEach(function (block) {
+  var btn = block.querySelector(".copy");
+  if (!btn) return;
+  btn.addEventListener("click", function () {
+    var text = block.getAttribute("data-copy") || block.querySelector("code").textContent;
+    navigator.clipboard.writeText(text).then(function () {
+      btn.textContent = "Copied";
+      btn.classList.add("done");
+      setTimeout(function () { btn.textContent = "Copy"; btn.classList.remove("done"); }, 1800);
+    }).catch(function () {
+      btn.textContent = "Press ⌘C";
+    });
+  });
+});
+</script>
+
+</body>
+</html>

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -51,6 +51,15 @@ the spine.
    and output checksums, and a runnable `reproduce.sh`. Pin the registry to the
    commit SHA returned by `fetch_workflows.py` — never describe a result without
    the bundle that lets someone re-derive it. (DE-LIMP architectural rules #1, #4.)
+6. **Assume nothing about the user's environment — this skill runs for anyone.** Most
+   users are **not** UC Davis Core and **not** on HIVE: they're on macOS, Windows
+   (**WSL2** recommended, but **native Windows works too** — the engines ship Windows
+   builds), or generic Linux. HIVE / `/quobyte/proteomics-grp` is a Core **fast-path,
+   never a requirement**. For **every** program you have the user run, give a **public
+   source** anyone can obtain (download URL / `pip`/install command) and a path that
+   works on *their* OS — never hardcode an internal `/quobyte/...` path without its
+   public fallback. → `references/search-engines.md` ("Public program sources") +
+   `references/install.md`.
 
 ## Audience: assume nothing is installed
 
@@ -313,12 +322,25 @@ bash scripts/watch_run.sh --log <search log>
 # SLURM on HIVE:
 bash scripts/watch_run.sh --slurm <jobid> --log <job log> --hive   # (HIVE_USER/HIVE_KEY set)
 ```
-It returns `{state, done, failed, error_class, fix}`. While `done` is false, keep
-polling (sleep ~60s between polls; for long SLURM jobs use a scheduled wake-up). **If
-`failed` is true, apply the `fix`** (raise `--mem`/`--time`, switch DIA-NN container,
-fix a path, move to a GPU node, etc. — see `references/watcher.md`) and **resubmit**,
-then watch again. Report progress and any auto-fixes to the user. Only proceed to DE
-once the run is `COMPLETED` and `report.parquet` exists. → detail: `references/watcher.md`.
+It returns `{state, done, failed, stalled, error_class, fix}`. While `done` is false,
+keep polling (sleep ~60s between polls; for long SLURM jobs use a scheduled wake-up).
+Pass `--log` so it can also catch **stalls** — a job stuck in `RUNNING` with its log
+frozen (a hung file; `sacct` will show RUNNING forever). **If `failed` OR `stalled` is
+true, apply the `fix` and resubmit AUTONOMOUSLY — do not wait for the user.** Starting
+the search needed confirmation (golden rule #1); recovering a run that's already in
+flight does not. Common auto-fixes (→ `references/watcher.md` playbook):
+- **stalled/hung file:** `scancel` that task, retry once on a fresh node; if it stalls
+  again, **drop that one file** and continue (step 4 of the parallel chain auto-skips a
+  file with no `.quant`); note the dropped file in **Data Quality Notes**.
+- **failed step in the 5-step chain:** resubmit from the earliest incomplete step,
+  **reusing completed `.quant` and `step1.predicted.speclib`** — never restart the whole
+  cohort; broken `afterok` after a killed task → resubmit steps 3→4→5 fresh.
+- OOM → raise `--mem`; timeout → raise `--time`; missing temp dir → `mkdir -p` first.
+
+**Every search — single-shot or parallel array — must run under this watch loop.** Stop
+and tell the user only after 2 failed auto-fixes of the same class (dropping 1 pathological
+file out of many is success, not a failure). Report what you recovered. Only proceed to DE
+once `COMPLETED` and `report.parquet` exists. → detail: `references/watcher.md`.
 
 ### 8. Differential expression
 ```
@@ -353,6 +375,34 @@ replicate, or a batch confounded with the biology) until they resolve it — don
 let a new user over-interpret a broken design. The findings also go into the
 report's "Audit & caveats" section. → detail: `references/audit.md`.
 
+Then run the **biological sample-quality** check (contamination that mimics biology —
+hemolysis, tissue cross-contamination, skin) — and **read `references/anomaly-checks.md`
+and walk its decision tree** (the judgment branches `audit_results.py` can't automate:
+intensity-distribution outliers, replicate/condition ID overlap, mass/RT/CCS shifts,
+p-value-distribution shape, largest-FC-in-low-abundance, log2FC>5 artefacts, PCA sample
+swaps, GSEA background; plus XL-MS / phospho / non-model branches):
+```
+python3 scripts/sample_quality.py --matrix ./de_results/Expression_Matrix.csv \
+    --conditions ./conditions.csv --report ./search_out/report.parquet --out SAMPLE_QUALITY.md
+```
+**If a contamination panel is confounded with a group, STOP** — DE may be contamination,
+not biology, and protein-level filtering will not fix it (→ `references/anomaly-checks.md`).
+**If the sample IS keratin** (nail/hair/wool/skin/feather), pass **`--keratin-sample`** to
+`sample_quality.py` **and** `audit_results.py` — keratin is the analyte there, not a
+contaminant, and must not be flagged.
+Flag every anomaly in the 5-part format (*what · where · why · likely cause · fix*); the
+report **always** gets a **Data Quality Notes** section, even if "nothing anomalous observed."
+
+### 8d. Conditional expert review (spawn only on triggers)
+Most analyses don't need a panel. If **any** trigger fires — a statistical claim goes to a
+collaborator; any `log2FC > 5` or `p < 1e-10`; a new organism/instrument/reagent; cross-tool
+discordance; or the user asks — spawn **three reviewers in parallel** (one message, three
+`Agent` calls; each gets the report + data paths + context): **proteomics**, **biology**
+("could contamination explain this?"), **statistics**. Consolidate their findings (dedupe,
+sort by severity) into a `## Expert Review Notes` section and surface every **critical**
+issue to the user before finalizing. Skip for format conversion / FASTA prep / exploratory
+looks with no formal report. → detail: `references/anomaly-checks.md`.
+
 ### 9. Analyze the data (you write the report)
 Generate the analysis brief (it lists the figures to embed), then **do the analysis
 yourself** — you are the consultant the brief addresses:
@@ -367,7 +417,10 @@ Then **read `ANALYSIS_PROMPT.md` and every data file + figure it lists, and writ
 complete `AI_Analysis_Report.md`** with ALL its OUTPUT sections (Overview, QC, Key
 Findings Per Comparison, Cross-Comparison Biomarkers, High-Confidence Biomarkers,
 Pathway/GSEA if present, Biological Interpretation, How This Analysis Works, Methods
-& Reproducibility) **plus an "Audit & caveats" section from `AUDIT.md`**. **Embed
+& Reproducibility) **plus an "Audit & caveats" section from `AUDIT.md`**, a **Data
+Quality Notes** section (the 5-part anomalies from steps 8c/8d + `SAMPLE_QUALITY.md`,
+even if "nothing anomalous observed"), and — if a review panel ran (8d) — an **Expert
+Review Notes** section. **Embed
 every figure** (`![caption](figures/<file>.png)`) with an expert interpretation of
 what it shows for THIS data. Compute significant proteins, up/down splits,
 cross-comparison overlaps, and lowest-CV proteins directly from the CSVs — cite

--- a/skill/ucdavis-proteomics-core-pipeline/references/anomaly-checks.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/anomaly-checks.md
@@ -1,0 +1,141 @@
+# Anomaly checks, expert review & analysis principles
+
+The UC Davis Proteomics Core's data-analysis methodology, ported into the skill. Apply
+it during **step 8c (audit)** and **step 9 (write the report)**. `audit_results.py` and
+`sample_quality.py` automate the deterministic checks; **you apply the judgment branches
+below** on the tables/figures you already have. Anything you flag goes into the report's
+**Data Quality Notes** section and — if it changes a conclusion — is surfaced to the user
+immediately, not buried.
+
+## Core principles
+
+- **Ask before assuming.** Experimental design, instrument, organism, reagents, and the
+  biological question are confirmed with the user *before* analysis. Filenames are not
+  authoritative ("SM2"/"SM4" could be cross-linkers, samples, or instruments). A 30-second
+  clarification prevents hours of rework. (This is golden rule #1 — it applies here too.)
+- **Verify tool flags against the binary, not memory.** Order of trust: `tool --help` on
+  the exact binary → official docs for the exact version → source → third-party guides.
+  Don't assume a flag exists because a sibling tool has it.
+- **Flag anomalies as they appear**, in a **5-part format**: *what* (the specific anomaly)
+  · *where* (rows/columns/files/samples) · *why it matters* (impact on the result) ·
+  *likely cause* · *suggested fix*.
+- **Trust observation over documentation.** If a path/convention here conflicts with what
+  `ls`/`head`/the file shows, trust the file.
+- **Every report gets a "Data Quality Notes" section**, even if it just says "nothing
+  anomalous observed."
+
+## Anomaly-check decision tree — run only the branches that apply
+
+**Always (any dataset):**
+- Missing values — pattern (random vs. systematic per condition), count per sample,
+  unexpected NAs. *(automated: `audit_results.py` missingness)*
+- Intensity distributions — one sample far off in median/spread ⇒ failed injection or
+  loading error. *(judgment: read the signal-distribution / per-sample figures)*
+- Identifier sanity — organism match, deprecated accessions, mixed naming, duplicate IDs.
+- Contaminants in the top-20 by intensity (keratin, trypsin autolysis, BSA) ⇒ prep issue.
+  *(automated: `audit_results.py` contamination; deeper: `sample_quality.py`)*
+- File-format sanity — delimiter, encoding, column-count consistency, header alignment
+  across files meant to be compared.
+
+**If multiple files / conditions:**
+- Replicate ID overlap < 60%, or between-condition overlap < 40% ⇒ investigate before DE.
+- Systematic mass / RT / CCS shifts between files ⇒ different reagent or method, **not**
+  biology — flag immediately.
+- **Batch confounded with condition** (all treatment day 1, all control day 2) ⇒ DE is
+  invalid. *(automated: `audit_results.py` confounding — a FAIL)*
+- Unbalanced group sizes (e.g. 5 vs 2) ⇒ note the power implication. *(automated: group_balance)*
+
+**If statistical testing (DE, enrichment):**
+- P-value distribution shape — flat = no signal; spike at 0 **and** 1 = model problem.
+- Largest fold-changes all in low-abundance proteins ⇒ noise-driven.
+- log2FC > 5 in a non-knockout experiment ⇒ probably imputation or single-replicate artifact.
+- No FDR correction reported ⇒ flag.
+- PCA/MDS shows a sample clustering with the wrong group ⇒ possible **sample swap** — flag
+  immediately. *(judgment: read the PCA figure vs. conditions)*
+- ORA/GSEA without an explicit background ⇒ inflated significance.
+
+**If XL-MS:** bridge mass consistent across files? (same pair, different mass = different
+cross-linker) · decoy-implied FDR > ~10% is too hot even for XL-MS · one lysine in
+disproportionately many links = hyperreactive site, not many true contacts · structure-mapped
+distance violations > 30% = problem.
+
+**If phospho / PTM:** localization probability < 0.75 ⇒ don't report as confidently
+assigned · non-phosphopeptides dominant ⇒ enrichment failed · known active-pathway sites
+absent ⇒ sanity-check the experiment.
+
+**If non-model organism:** using human/mouse GO/KEGG without ortholog mapping ⇒ annotation
+mismatch (map orthologs first).
+
+## Contamination diagnostics — `sample_quality.py`
+
+Beyond lab contaminants (keratin/trypsin), the **sample-level biological contaminations**
+that repeatedly produce wrong-but-plausible DE:
+```
+python3 scripts/sample_quality.py --matrix de_results/Expression_Matrix.csv \
+    --conditions conditions.csv --report search_out/report.parquet --out SAMPLE_QUALITY.md
+```
+- **HEMOLYSIS** (plasma/serum RBC lysis: hemoglobin, carbonic anhydrase, catalase,
+  peroxiredoxin, spectrin) — drove artefactual plasma DE in real cases.
+- **SKELETAL_MUSCLE** (muscle debris in a non-muscle biopsy: myosins, troponins, CK-M,
+  myoglobin) — in one cow-liver study, uniform muscle contamination of one breed's biopsies
+  produced 3,045 "DE" proteins that were contamination, not biology.
+- **EPIDERMIS** (skin/hair squames).
+
+It scores each panel per sample (z across samples) and checks whether the score is
+**confounded with group**. Two hard-won lessons it encodes:
+- **A contamination panel that separates the groups is the danger signal** — DE between
+  those groups may be the contamination gradient. **Protein-level marker removal does NOT
+  fix a confounded contrast** (dropping muscle markers once *increased* the DE count); the
+  fix is at the sample/design level (drop/flag the confounded samples, or model it).
+- **The limpa/DPC-Quant "complete matrix" depth trap:** a DPC-Quant expression matrix has
+  ~no NAs (the detection model fills every cell), so counting non-empty cells gives a
+  **constant**, not per-sample depth. Real depth = detected protein groups per run
+  (`--report report.parquet`).
+
+### ⚠ Keratin-matrix samples — keratin is the ANALYTE, not a contaminant
+
+For **nail, hair, wool, skin, feather** (and other epidermal/keratinaceous) samples,
+keratins (KRT/KRTAP) are *what you are measuring* — **never flag them as contamination.**
+Pass **`--keratin-sample`** to both `sample_quality.py` and `audit_results.py`: the
+EPIDERMIS/keratin panel is then reported for QC but excluded from contamination flags,
+and the audit stops warning on KRT/KRTAP/keratin (trypsin/casein/BSA are still flagged).
+The generic "contaminants in the top-20 by intensity (keratin, trypsin, BSA)" check means
+prep contamination **only for non-keratin matrices**; on a keratin sample, keratin at the
+top is expected biology. (Blood/hemolysis and muscle panels still apply — a nail sample
+can still be blood-contaminated.)
+
+## Conditional expert review — spawn only on triggers
+
+Most analyses don't need a review panel. Spawn one when **any** trigger fires:
+- the session produces a **statistical claim going to a collaborator** (DE, enrichment,
+  interaction claims);
+- any **log2FC > 5** or **p < 1e-10** is reported;
+- a **new organism, instrument, or reagent** combination for this project;
+- **cross-tool discordance** surfaced (DIA-NN vs. Spectronaut, etc.);
+- the user asks for review.
+
+When triggered, spawn **three agents in parallel** (one message, three `Agent` calls),
+each given the report + input/output paths + experimental context. Each returns a bulleted
+list of *issue · severity (critical/warning/note) · suggested action*:
+- **Proteomics reviewer** — search-output interpretation, FDR/decoy handling, quantification
+  fit, instrument-specific artifacts, mass/RT/CCS consistency, acquisition-vs-processing match.
+- **Biology reviewer** — do the results make sense for this sample/organism? Expected proteins
+  present? Contradictions with known biology? **Could contamination explain the finding?**
+- **Statistics reviewer** — normalization fit, multiple-testing correction, confounding /
+  pseudoreplication, sample size, missing-value handling, test choice, PCA/MDS for swaps.
+
+Consolidate (dedupe, sort by severity) into a **`## Expert Review Notes`** section of the
+report; surface every **critical** issue to the user before finalizing. **Skip review** for
+format conversion, single-column extraction, exploratory looks with no formal report, FASTA
+prep, and annotation correction against a single reference.
+
+(These three lenses also match the release-review agents the project runs; here they are
+gated to per-analysis triggers rather than run every time.)
+
+## Collaborator deliverable — 3 reproduction options
+
+The reproducibility bundle (step 10) is mandatory; when the deliverable is collaborator-facing,
+its `REPRODUCE.md` should offer **three** explicit paths: **(A)** re-fit the statistics only,
+**(B)** re-render every figure and rebuild the report, **(C)** inspect the raw data without
+re-running anything — plus background, headline findings, next steps, provenance (cluster
+paths/md5 for raw `.d`/`.raw`), and a contact email.

--- a/skill/ucdavis-proteomics-core-pipeline/references/diann_parallel.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/diann_parallel.md
@@ -32,6 +32,14 @@ empirical-library round-trip.
 - **No MBR** (`--reanalyse` is dropped) — the 5-step replaces it.
 - **`--quant-ori-names`** on every step so `.quant` files are `<basename>.quant`.
 - Step 4 **skips** files that failed step 2 (missing `.quant`).
+- **The `--temp` folders MUST pre-exist.** DIA-NN aborts immediately with
+  `ERROR: cannot find the temp folder .../quant_step2. Specify an existing folder` if
+  the `--temp` dir is missing — it will **not** create it. `submit.sh` therefore does
+  `mkdir -p <out>/quant_step2 <out>/quant_step4` before submitting. (This bit us on the
+  first DDA cohort run — every first-pass array task died in ~7 s until the dirs existed.
+  If you ever hand-edit or hand-run a step script, create the temp dirs first.)
+- **DDA:** put `--dda` in the `--cfg` (it is not stripped, so it flows into every step);
+  `.raw` inputs get a `.NET 8` export prefix automatically (see `ensure_dotnet8.sh`).
 
 ## Usage
 ```
@@ -49,6 +57,72 @@ It writes `file_list.txt`, `step{1..5}_*.sbatch`, and `submit.sh` (which submits
 five with dependencies and prints the job ids). **Watch the final job** with
 `watch_run.sh --slurm <jid5> --log <out>/s5_report_<jid5>.log --hive`. When step 5
 completes, point `run_de.R` at `<out>/report.parquet`.
+
+## Parallelizing semi-tryptic / non-specific / InfinDIA searches (`--seed-lib`)
+
+A **semi-tryptic** or **non-specific** DIA-NN search can't use the normal Step-1
+predicted library — the predicted semi/non-specific library is enormous (a human
+semi-tryptic `.speclib` was **19.6 GB**; searching it directly is impractical and
+hogs the cluster). DIA-NN's answer is **InfinDIA** (`--pre-search`): an index-based
+engine that builds a *small empirical* library from the data itself. It also
+processes **DDA** (`--dda`, DIA-NN ≥2.3) — confirmed on the UC Davis nail cohort.
+
+> **InfinDIA DDA is beta and can SEGFAULT on a single file.** On the 66-file nail
+> cohort a single-shot `--pre-search --dda --semi` over all 66 crashed with
+> `Segmentation fault (core dumped)` at file 20 — losing **all** work. Worse, the
+> sbatch's trailing `echo "...exit $?"` masked the crash's non-zero code, so SLURM
+> reported `State=COMPLETED exit 0:0` with **no `report.parquet`** (verify the output
+> file, never trust State — and never end an sbatch with a bare `echo`; make the tool
+> the last line or `rc=$?; …; exit $rc`). **This is the core reason to run InfinDIA
+> DDA via the two-phase array below:** Phase 2 processes each file as an independent
+> array task, so one bad file kills only its own task (the chain skips files with no
+> `.quant`) instead of nuking the whole run.
+
+**InfinDIA does NOT fan out per-file** like the 5-step chain. Its empirical library
+is built from the whole experiment, so if you split `--pre-search` per file you'd get
+N *different* libraries whose `.quant` files can't be merged. So parallelize in **two
+phases**:
+
+1. **Phase 1 — build the empirical library (one InfinDIA job).** Run
+   `--pre-search --dda --semi --out-lib empirical.parquet` over a **representative
+   subset** (DIA-NN's own tip: 20–100 high-quality runs) to keep it quick. InfinDIA
+   **forces MBR + empirical-library generation** even without `--reanalyse` (it logs
+   `enabling MBR and empirical spectral library generation, as required by InfinDIA
+   pre-search`), so you always get a refined empirical library. Give it a fixed
+   `--mass-acc`/`--mass-acc-ms1` (well-calibrated data) or a small `--ref` calibration
+   library. For a search that's stuck **PENDING on `low`** (publicgrp is preemptible /
+   congested), move it to `high`: `scontrol update jobid=<id> partition=high
+   qos=genome-center-grp-high-qos account=genome-center-grp`.
+2. **Phase 2 — fan the per-file passes out (`diann_parallel.py --seed-lib`).** Feed
+   the empirical library from Phase 1 as the seed; Step 1 (prediction) is skipped and
+   the small library drives the per-file first pass → assembly → final pass →
+   cross-run, exactly the tested Steps 2–5. Fully parallel; this is where the speed is.
+   **Do NOT put `--semi` in the Phase-2 `--cfg`** — the semi precursors are already in
+   the empirical library, and re-adding `--semi` would re-expand the giant FASTA space
+   you just avoided. Phase-2 cfg is a plain library search: `--dda` + `--mass-acc` +
+   `--qvalue` + the var-mods that match the library.
+   ```
+   python3 scripts/diann_parallel.py \
+     --raw-list all_runs.txt --fasta search.fasta --out ./p2 --diann '<binary>' \
+     --cfg p2.cfg --seed-lib ./empirical.parquet \
+     --seed-dep <phase1_jobid> \          # optional: first pass waits afterok on Phase 1
+     --partition low --account publicgrp --qos publicgrp-low-qos \
+     --threads-per-file 8 --max-simultaneous 66
+   bash ./p2/submit.sh
+   ```
+   `--seed-dep` chains Phase 2 to start when Phase 1 finishes. **Verify the empirical
+   library exists and is non-empty first** (State=COMPLETED ≠ a valid file) — a small
+   launcher that globs for the `.parquet`, checks `>1 MB`, then generates+submits is the
+   robust pattern (a watcher can trigger it on Phase-1 completion, no intervention).
+- **`--qos`** is required to target `low`/publicgrp (`publicgrp-low-qos`); `high`/
+  genome-center-grp uses its default qos. `--seed-lib` skips Step 1; combine with
+  `--seed-dep` to auto-chain onto the InfinDIA lib-build job.
+
+**Fairness note for cross-engine comparisons:** a subset-derived library, then used to
+search all runs, does not bias detection of anything that recurs across samples (e.g.
+keratin in hair/nail — the same peptides appear in every run). It can under-sample rare
+precursors unique to un-subsetted runs. When that matters, build Phase 1 over all runs
+(slower) or cross-check against a full single-shot InfinDIA run.
 
 ## Notes
 - The generator emits **real absolute paths** (the HIVE DIA-NN 2.6 build is a native

--- a/skill/ucdavis-proteomics-core-pipeline/references/install.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/install.md
@@ -64,6 +64,17 @@ is already in mzML never touches Docker at all.
 
 ## Windows
 
-Run inside **WSL2** (the DE-LIMP-recommended path) and follow the Linux flow — the
-conda env, Sage, and the DIA-NN Linux binary all work there. Native Windows is not
-a target for this skill.
+Two supported routes — pick per the user:
+
+1. **WSL2 (recommended, smoothest).** `wsl --install` (Ubuntu), then run the skill
+   inside it and follow the Linux flow — the conda env, the bash orchestration scripts,
+   Sage, and the DIA-NN Linux binary all work as-is.
+2. **Native Windows.** The engines themselves ship **native Windows builds** — DIA-NN
+   (Windows GUI + CLI, and it reads Thermo `.raw` natively, so the Linux-only `.NET 8`
+   step is not needed), Sage, FragPipe, and ProteoWizard/`msconvert` (originally a
+   Windows tool). Python + R + limpa run natively too. The skill's *orchestration
+   scripts are bash*, so run them from a POSIX shell — **Git Bash** or **MSYS2** — or
+   drive the engines directly per their Windows docs. Docker Desktop is a third route.
+
+Public download links for every program are in `references/search-engines.md`
+("Public program sources"), so a user on any OS can obtain them without HIVE access.

--- a/skill/ucdavis-proteomics-core-pipeline/references/search-engines.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/search-engines.md
@@ -39,14 +39,68 @@ bundle names it or the user asks) because MSFragger/IonQuant are license-gated.
 instead of DIA-NN — same job, no license problem. Ask "academic or commercial?" before
 a DIA run if it isn't already clear.
 
+## Public program sources (anyone, any OS — cite these for non-Core / external users)
+
+This skill is used **outside** UC Davis and the Core. Never assume the internal
+`/quobyte/proteomics-grp` copy of a tool exists — **always point the user to the public
+source** and a way to run it on *their* OS (macOS, Windows via WSL2 **or** native
+Windows, or Linux). `setup.sh`/`acquire_tools.sh` fetch the free ones automatically.
+
+| Program | Public source | Platforms | Install / note |
+|---|---|---|---|
+| **DIA-NN** (Academia) | https://github.com/vdemichev/DiaNN/releases | Windows, Linux | Windows GUI+CLI, or Linux binary; academic / non-profit only. `acquire_tools.sh` fetches the Linux build. DDA since 2.3 (`--dda`). |
+| **Sage** | https://github.com/lazear/sage/releases | Win, macOS, Linux | MIT; single static binary. |
+| **AlphaDIA** | https://github.com/MannLabs/alphadia | Win, macOS, Linux | Apache-2.0 (commercial-OK); `pip install alphadia`, GPU recommended. |
+| **FragPipe** (MSFragger/IonQuant) | https://github.com/Nesvilab/FragPipe/releases | Win, macOS, Linux | Java GUI; MSFragger/IonQuant need the user's own (free-academic) license. |
+| **ThermoRawFileParser** | https://github.com/compomics/ThermoRawFileParser/releases | Win, macOS, Linux | `.raw`→mzML; cross-platform .NET. |
+| **ProteoWizard / msconvert** | https://proteowizard.sourceforge.io/ | Windows (native); Linux/macOS via Docker | vendor→mzML; Linux via the `chambm/pwiz-...` Docker image. |
+| **.NET 8 runtime** | https://dotnet.microsoft.com/download/dotnet/8.0 · installer script https://dot.net/v1/dotnet-install.sh | Win, macOS, Linux | needed only so the **Linux** DIA-NN binary can read `.raw`; `ensure_dotnet8.sh` installs 8.0.latest. **Native Windows doesn't need it.** |
+| **UniProt proteomes (FASTA)** | https://www.uniprot.org/proteomes/ | web / REST | e.g. `UP000005640` (human); `fetch_fasta.py` streams it. |
+| **Contaminants (cRAP)** | https://www.thegpm.org/crap/ | web | `fetch_fasta.py --add-contaminants` appends a maintained set. |
+
+**Rule:** whenever you tell a user to run a program, give the public link **+** the exact
+command **+** an OS-appropriate path — not a HIVE/`/quobyte` path they can't reach.
+
 ## Per-engine invocation & output adapter (`run_search.py`)
 
 ### DIA-NN (native contract — no adapter)
 ```
 <cmd> --cfg <bundle diann.cfg> --f <file> [--f <file> ...] \
-      --fasta <fasta> --out report.parquet --threads N
+      --fasta <fasta> --out report.parquet --threads N [--dda]
 ```
 `report.parquet` is already the DE contract — `run_de.R` reads it directly.
+
+**DDA data (DIA-NN 2.6+).** DIA-NN 2.3+ can search DDA / DDA-PASEF with **`--dda`**
+(`run_search.py` adds it automatically when the bundle's acquisition is `DDA`). Notes:
+- `--dda` **must** be used with DDA and **must not** be used with DIA data.
+- QuantUMS is auto-disabled on DDA; PTM-localisation probabilities are unreliable on DDA.
+- For DDA **quant**, DIA-NN recommends extra MS1 filtering on `Ms1.Global.Q.Value`
+  (< 0.0001–0.01) and `Ms1.Global.Quality` (> 0.5–0.9), optionally `Ms1.Q.Value` /
+  `Averagine`. Standard DIA/DDA q-value filters still apply.
+- It's officially "beta", but performs strongly — on UC Davis nail (Exploris, 67 runs)
+  it matched/beat the delivered FragPipe/Scaffold result at ~equal keratin coverage.
+- Default routing still sends DDA → Sage (validated); use `--engine diann` (or a
+  DDA+DIA-NN workflow) to search DDA with DIA-NN.
+
+**Reading Thermo `.raw` directly (the .NET 8 gotcha — Linux only).** On **native
+Windows** DIA-NN reads `.raw` out of the box (skip this whole section). On **Linux**
+(incl. WSL2 and HIVE) the 2.6 *native* binary reads `.raw` via a bundled .NET
+(ThermoFisher.CommonCore) component and needs a **.NET 8 runtime ≥ 8.0.17** on PATH. Without it, DIA-NN prints
+`ERROR: cannot read .raw files ... .NET Runtime 8: 8.0.17 or later` and processes **0
+files**. It does a HARD ≥ 8.0.17 check: an older 8.0.x (e.g. a cluster's `8.0.4`
+module) is **rejected**, and a .NET 9 runtime is **not** used (rollForward is
+LatestMinor — it won't cross the major version). Fix, done for you by
+**`scripts/ensure_dotnet8.sh`** (idempotent; run it on a login node — it needs
+internet, compute nodes usually don't):
+```
+export DOTNET_ROOT="$(bash scripts/ensure_dotnet8.sh | tail -1)"   # installs 8.0.latest if missing
+export PATH="$DOTNET_ROOT:$PATH"
+```
+`run_search.py` calls this automatically whenever DIA-NN inputs include `.raw` (inline
+run, and baked into the emitted sbatch as a preamble). When it's right, DIA-NN logs
+`.NET runtime found, Thermo .raw support enabled`. Alternative with **no** .NET: feed
+`.mzML` (DIA-NN reads those natively) — convert `.raw`→mzML with ThermoRawFileParser /
+msconvert if you don't already have them.
 
 ### AlphaDIA (commercial-OK DIA; adapter required)
 Apache-2.0 — the open-source alternative to DIA-NN for non-academic users. Library-free:
@@ -87,6 +141,26 @@ Apache-2.0 — the open-source alternative to DIA-NN for non-academic users. Lib
 - **Adapter:** `combined_protein.tsv` per-sample `MaxLFQ Intensity` columns →
   DIA-NN-shaped `report.parquet`.
 - Needs Java 9+; MSFragger/IonQuant must already be licensed/present.
+- **Reading Thermo `.raw`:** MSFragger reads `.raw` directly via
+  `tools/ext/thermo/BatmassIoThermoServer.exe` — a **Windows .NET-Framework** exe that on
+  **Linux needs `mono` on PATH** (the .NET 8 runtime does NOT run it — Framework ≠ Core).
+  Native Windows/macOS: works out of the box. On a mono-less Linux cluster you get
+  *"Could not find Batmass-IO Thermo binary"* + `Scans = 0` → either install mono
+  (conda-forge `mono`, then `export PATH=<monoenv>/bin:$PATH` in the job) or pre-centroid
+  to mzML. (On HIVE, mono 6.12 is installed at `/quobyte/proteomics-grp/conda_envs/mono`.)
+- **Other DDA gotchas:** IonQuant MBR needs experiment groups in the manifest — set
+  `ionquant.mbr=0` if you only want peptide/protein IDs; **profile-mode mzML** fail
+  `CheckCentroid` (centroid during conversion, or read `.raw` so MSFragger vendor-centroids);
+  the LFQ-MBR template ships **without** a `database.db-path` line (add one); and the
+  headless run's exit code can read 0 even on a crash — **verify the output file exists**.
+- **Which output file to verify (don't false-alarm):** the file depends on the run
+  type. A **single-experiment / peptide-ID run** (`ionquant.mbr=0`, one experiment)
+  writes **`psm.tsv` + `peptide.tsv` + `protein.tsv` + `ion.tsv`** — there is **no**
+  `combined_peptide.tsv`/`combined_protein.tsv` (those only appear with **multi-experiment
+  IonQuant LFQ**). A watcher that checks for `combined_*.tsv` will wrongly report
+  "no output" on a perfectly good ID run. Success check = `peptide.tsv` (and `psm.tsv`)
+  present and non-empty; use `combined_protein.tsv` only when the manifest defines ≥2
+  experiment groups and you asked for the cross-run LFQ matrix.
 
 ## The adapters are the test surface
 

--- a/skill/ucdavis-proteomics-core-pipeline/references/watcher.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/watcher.md
@@ -1,9 +1,24 @@
 # Run watcher — monitor searches and auto-correct errors
 
 A search is long (often hours) and runs detached (a background process locally, a
-SLURM job on HIVE). **Always watch it** — the orchestrator must not start a search
-and walk away. `watch_run.sh` does one poll + diagnosis; loop it until the run
-finishes, and on failure apply the fix and resubmit.
+SLURM job on HIVE). **Always watch every search — this is mandatory, not optional.**
+The orchestrator must never start a search and walk away, and must **auto-correct
+stalls and failures on its own, without waiting for the user** (the user has standing
+authorization for this — see golden rule #1's compute confirmation is for *starting*
+the search, not for recovering a run that's already approved and in flight). Surface
+what you did afterwards; don't ask permission to unstick a job.
+
+`watch_run.sh` does one poll + diagnosis (state, **stall**, error class, fix); loop it
+until the run finishes, and on `failed` **or** `stalled` apply the fix and resubmit.
+
+## Two failure modes it catches
+1. **Hard failure** — `sacct` reports FAILED / TIMEOUT / OUT_OF_MEMORY / NODE_FAIL /
+   CANCELLED. Matched against known error signatures → a fix.
+2. **Stall** — the job stays **RUNNING** but its log stops advancing (a hung file, e.g. a
+   pathological DIA-NN run whose RT-window/search phase never returns). `sacct`/`squeue`
+   will happily show RUNNING forever. `watch_run.sh --log <log> [--stall-min N]` flags
+   this when the log's mtime is older than N minutes (default 15) while RUNNING, emitting
+   `stalled: true`. **This is the NA41-class failure the first nail cohort hit.**
 
 ## Loop pattern
 ```
@@ -30,6 +45,8 @@ any auto-fix you applied to the user.
 | `sage_no_mzml` | msconvert not found / needs mzML | convert `.d`/`.raw` → mzML first (Linux/HIVE), then re-run Sage |
 | `disk` | Disk quota / No space left | free space or point `--out` elsewhere; resubmit |
 | `missing_input` | No such file / fasta/raw not found | a path is wrong — re-check Windows→WSL/HIVE path translation; resubmit |
+| `stalled` | job **RUNNING** but log frozen > `--stall-min` (default 15 min) | a hung file. `scancel` the task/job, **retry it once on a fresh node**; if it stalls again, **drop that file** and continue (see playbook), note it in Data Quality Notes |
+| `dependency_failed` | job PENDING with reason **`DependencyNeverSatisfied`** (an upstream step failed) | the chain is dead but **sits PENDING forever** (never leaves the queue). `sacct -j <arrayjob>` to find the failed step, fix it, resubmit downstream steps reusing completed outputs |
 | `unknown_failure` | job FAILED with no known signature | read the full log; diagnose; fix; resubmit (and add the new signature here) |
 
 ## SLURM specifics (HIVE)
@@ -41,8 +58,33 @@ any auto-fix you applied to the user.
 - When resubmitting after a fix, edit the sbatch (`--mem`/`--time`/`--gres`) and note
   the change in `commands.log` so the reproducibility bundle records what happened.
 
+## Auto-recovery playbook (apply autonomously; log every action to `commands.log`)
+- **`stalled` (hung file):** `scancel <arrayjob>_<taskid>` (or the job). Retry that one file
+  once on a fresh node. If it stalls again, **drop it** — it's pathological (often a file
+  the facility itself re-ran). In the 5-step parallel chain, step 4 already auto-skips a
+  file with no step-2 `.quant`; just remove it from step 3/step 5's `--f` list and resume.
+- **Broken `afterok` after you killed/dropped an array task:** the downstream steps go
+  `DependencyNeverSatisfied`. Cancel them and **resubmit steps 3→4→5 fresh, reusing the
+  completed `.quant`** (don't re-run step 1/library-prediction — reuse `step1.predicted.speclib`).
+- **`out_of_memory`:** raise `--mem` and resubmit only the failed step (reuse prior `.quant`).
+- **Missing `--temp` dir** (`cannot find the temp folder`): the temp dirs must pre-exist —
+  `mkdir -p <out>/quant_step2 <out>/quant_step4` and resubmit (the generator now does this).
+- **Whole-cohort restart is rarely needed** — resume from the earliest incomplete step,
+  reusing everything already computed.
+
 ## Don't
 - Don't declare a run "done" on a non-COMPLETED state, and don't proceed to DE until
   `report.parquet` exists.
 - Don't silently retry forever — after 2 failed auto-fix attempts of the same class,
-  stop and tell the user what's wrong.
+  stop and tell the user what's wrong. (Dropping 1 pathological file out of many and
+  continuing is *success*, not a failed retry.)
+- Don't wait for the user to notice a stall/failure — you are the monitor; recover, then
+  report what you did.
+- **Don't use a passive "wait until the job leaves the queue" monitor for a chain.** If an
+  upstream step fails, the downstream job sits **PENDING forever** (`DependencyNeverSatisfied`)
+  and such a monitor hangs indefinitely and never alerts — a whole overnight chain can die
+  silently. The monitor must poll **STATE** (incl. `squeue -o %r` reason) and exit/act on
+  `failed` / `dependency_failed` / `stalled`, not just on queue-exit.
+- **A job's SLURM State=COMPLETED does NOT mean the tool succeeded.** If the sbatch's last
+  line is `echo ...` (exit 0), FragPipe/DIA-NN can crash yet the job shows COMPLETED. Verify
+  the expected OUTPUT file exists (`report.parquet`, `combined_peptide.tsv`), not just the state.

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/audit_results.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/audit_results.py
@@ -113,7 +113,7 @@ def audit_acquisition(findings, acq_json):
         add(findings, "instrument_mix", "PASS", f"Single instrument: {instr[0]}.")
 
 
-def audit_matrix(findings, em_path, min_proteins, max_missing):
+def audit_matrix(findings, em_path, min_proteins, max_missing, keratin_sample=False):
     rows = read_csv(em_path)
     if not rows:
         add(findings, "id_depth", "WARN", "Expression matrix is empty.")
@@ -142,20 +142,29 @@ def audit_matrix(findings, em_path, min_proteins, max_missing):
             "weakens quantification; check sample quality and whether missingness differs by group.")
     else:
         add(findings, "missingness", "PASS", f"{frac*100:.0f}% missing values.")
-    # contamination
+    # contamination. Keratin is a contaminant for MOST matrices, but is the ANALYTE
+    # for keratin samples (nail / hair / wool / skin / feather) — never flag it there.
+    # (see references/anomaly-checks.md "Keratin-matrix samples").
+    pats = tuple(p for p in CONTAMINANT_PATTERNS if not (keratin_sample and p in ("KRT", "KRTAP")))
+    words = tuple(w for w in CONTAMINANT_WORDS if not (keratin_sample and w == "keratin"))
     glab = "Genes" if "Genes" in rows[0] else ("Protein.Names" if "Protein.Names" in rows[0] else None)
     if glab:
         names = [(r.get(glab) or "").upper() for r in rows]
-        hits = [n for n in names if any(n.startswith(p) or p in n for p in CONTAMINANT_PATTERNS)
-                or any(w.upper() in n for w in CONTAMINANT_WORDS)]
+        hits = [n for n in names if any(n.startswith(p) or p in n for p in pats)
+                or any(w.upper() in n for w in words)]
+        label = "trypsin/casein" if keratin_sample else "keratins/trypsin/casein"
         if hits:
             frac_c = len(hits) / n_prot
             status = "WARN" if frac_c >= 0.02 or len(hits) >= 10 else "PASS"
             add(findings, "contamination", status,
-                f"{len(hits)} likely contaminant protein(s) detected (keratins/trypsin/casein). "
+                f"{len(hits)} likely contaminant protein(s) detected ({label}). "
                 + ("A high contaminant load can distort normalization and quant — consider filtering them."
-                   if status == "WARN" else "Low level; usually fine."),
+                   if status == "WARN" else "Low level; usually fine.")
+                + (" [keratin-matrix sample: keratins treated as the analyte, not flagged]" if keratin_sample else ""),
                 {"examples": sorted(set(hits))[:10]})
+        elif keratin_sample:
+            add(findings, "contamination", "PASS",
+                "Keratin-matrix sample — keratins are the analyte (not flagged); no trypsin/casein issue.")
 
 
 def audit_de(findings, de_dir, adjp, logfc):
@@ -198,6 +207,9 @@ def main():
     ap.add_argument("--logfc", type=float, default=1.0)
     ap.add_argument("--min-proteins", type=int, default=500)
     ap.add_argument("--max-missing", type=float, default=0.5)
+    ap.add_argument("--keratin-sample", action="store_true",
+                    help="sample IS keratin (nail/hair/wool/skin/feather) — keratin is the analyte, "
+                         "not a contaminant; do not flag KRT/KRTAP/keratin")
     a = ap.parse_args()
 
     findings = []
@@ -206,7 +218,7 @@ def main():
     if a.acquisition_json and os.path.exists(a.acquisition_json):
         audit_acquisition(findings, a.acquisition_json)
     if a.de_dir and os.path.exists(os.path.join(a.de_dir, "Expression_Matrix.csv")):
-        audit_matrix(findings, os.path.join(a.de_dir, "Expression_Matrix.csv"), a.min_proteins, a.max_missing)
+        audit_matrix(findings, os.path.join(a.de_dir, "Expression_Matrix.csv"), a.min_proteins, a.max_missing, a.keratin_sample)
     if a.de_dir and os.path.isdir(a.de_dir):
         audit_de(findings, a.de_dir, a.adjp, a.logfc)
 

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
@@ -28,12 +28,32 @@ Usage:
       [--assembly-cpus 64] [--assembly-mem 128] [--assembly-time 12] \
       [--partition high] [--account genome-center-grp] [--max-simultaneous 20] [--no-norm]
 """
-import os, sys, glob, argparse
+import os, sys, glob, argparse, shlex, subprocess
 
-# flags that are step-specific or auto-determined — never carry them into every step
+# flags that are step-specific or auto-determined — never carry them into every step.
+# NOTE: --dda is intentionally NOT stripped — for DDA data put --dda in the --cfg and it
+# flows into every step (DIA-NN 2.6 searches DDA per file exactly as it does DIA).
 STRIP = ("--fasta-search", "--predictor", "--gen-spec-lib", "--matrices", "--reanalyse",
          "--rt-profiling", "--no-norm", "--xic", "--out-lib", "--lib", "--out", "--f",
          "--fasta", "--threads", "--temp")
+
+
+def dotnet_prefix(raws):
+    """If any input is Thermo .raw, the DIA-NN 2.6 native binary needs a .NET 8 runtime
+    (>= 8.0.17) on PATH to read it. Resolve/install via ensure_dotnet8.sh and return an
+    'export DOTNET_ROOT=...; export PATH=...; ' prefix to put in front of every DIA-NN
+    invocation (each array task/step runs it; the shared install is read on the node).
+    Returns "" for mzML/.d-only inputs. Run the generator on a login node (internet)."""
+    if not any(r.lower().endswith(".raw") for r in raws):
+        return ""
+    helper = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ensure_dotnet8.sh")
+    try:
+        root = subprocess.check_output(["bash", helper], text=True).strip().splitlines()[-1]
+    except Exception as e:
+        sys.stderr.write(f"[diann_parallel] ensure_dotnet8.sh failed ({e}); DIA-NN may not "
+                         "read .raw. Provide mzML or install .NET 8 >= 8.0.17.\n")
+        return ""
+    return f'export DOTNET_ROOT={root}; export PATH={root}:"$PATH"; '
 
 
 def read_cfg_flags(cfg):
@@ -51,15 +71,17 @@ def read_cfg_flags(cfg):
     return " ".join(out)
 
 
-def header(name, cpus, mem_gb, hours, partition, account, array=None):
+def header(name, cpus, mem_gb, hours, partition, account, qos=None, array=None):
     h = ["#!/bin/bash -l",
          f"#SBATCH --job-name={name}",
          f"#SBATCH --cpus-per-task={cpus}",
          f"#SBATCH --mem={mem_gb}G",
          f"#SBATCH --time={hours}:00:00",
          f"#SBATCH --partition={partition}",
-         f"#SBATCH --account={account}",
-         f"#SBATCH -o {name}_%j.log", f"#SBATCH -e {name}_%j.log"]
+         f"#SBATCH --account={account}"]
+    if qos:
+        h.append(f"#SBATCH --qos={qos}")
+    h += [f"#SBATCH -o {name}_%j.log", f"#SBATCH -e {name}_%j.log"]
     if array:
         h.insert(2, f"#SBATCH --array={array}")
         h = [x.replace("_%j.log", "_%A_%a.log") for x in h]
@@ -69,7 +91,8 @@ def header(name, cpus, mem_gb, hours, partition, account, array=None):
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--diann", required=True, help="DIA-NN command (native binary path, or 'apptainer exec --bind … <sif> /diann-*/diann-linux')")
-    ap.add_argument("--raw", nargs="+", required=True)
+    ap.add_argument("--raw", nargs="+", default=[], help="raw paths/globs (or use --raw-list)")
+    ap.add_argument("--raw-list", help="file with one raw path per line — handles spaces in paths")
     ap.add_argument("--fasta", required=True)
     ap.add_argument("--out", required=True)
     ap.add_argument("--cfg", help="diann.cfg with the search params (estimate_params.py output)")
@@ -82,22 +105,35 @@ def main():
     ap.add_argument("--libpred-cpus", type=int, default=16)
     ap.add_argument("--libpred-mem", type=int, default=64)
     ap.add_argument("--libpred-time", type=int, default=4)
+    ap.add_argument("--seed-lib", help="Skip step-1 prediction; use this existing library "
+                    "(e.g. an InfinDIA empirical .parquet/.speclib) as the first-pass seed. "
+                    "This is how you PARALLELIZE a semi-tryptic / non-specific / InfinDIA search: "
+                    "build the small empirical library once (InfinDIA --pre-search), then fan the "
+                    "per-file passes out across the cluster against it.")
+    ap.add_argument("--seed-dep", help="SLURM job id the first pass should wait for (afterok) — "
+                    "e.g. the InfinDIA lib-build job that produces --seed-lib.")
     ap.add_argument("--partition", default="high")
     ap.add_argument("--account", default="genome-center-grp")
+    ap.add_argument("--qos", default=None, help="SLURM QOS. Needed for publicgrp/low "
+                    "(publicgrp-low-qos); high/genome-center-grp uses its default.")
     ap.add_argument("--max-simultaneous", type=int, default=20)
     ap.add_argument("--no-norm", action="store_true")
     a = ap.parse_args()
 
     raws = []
+    if a.raw_list:
+        with open(a.raw_list) as fh:
+            raws.extend(line.strip() for line in fh if line.strip())
     for p in a.raw:
         raws.extend(sorted(glob.glob(p)) or [p])
     raws = [os.path.abspath(r.rstrip("/")) for r in raws]
     n = len(raws)
     if n < 2:
-        sys.exit("Parallel search needs >= 2 raw files; use the single-shot run_search.py for 1.")
+        sys.exit("Parallel search needs >= 2 raw files (pass --raw or --raw-list); "
+                 "use the single-shot run_search.py for 1.")
     out = os.path.abspath(a.out); os.makedirs(out, exist_ok=True)
     fasta = os.path.abspath(a.fasta)
-    DN = a.diann
+    DN = dotnet_prefix(raws) + a.diann     # .NET 8 export prefix when inputs are Thermo .raw
     flags = read_cfg_flags(a.cfg)
     D = out  # all DIA-NN intermediate/output lives here (real paths; native binary reads them directly)
     report = "no_norm_report.parquet" if a.no_norm else "report.parquet"
@@ -105,9 +141,10 @@ def main():
 
     # file list (1 raw path per line) — array tasks index into it
     open(os.path.join(out, "file_list.txt"), "w").write("\n".join(raws) + "\n")
-    all_f = " ".join(f"--f {r}" for r in raws)
+    all_f = " ".join(f"--f {shlex.quote(r)}" for r in raws)   # quote — data paths may contain spaces
     array = f"0-{n-1}%{a.max_simultaneous}"
-    predicted = f"{D}/step1.predicted.speclib"
+    seed = os.path.abspath(a.seed_lib) if a.seed_lib else None
+    predicted = seed if seed else f"{D}/step1.predicted.speclib"
     empirical = f"{D}/empirical.parquet"
 
     def write(name, body):
@@ -119,17 +156,19 @@ def main():
             'if [ -z "$FILE" ]; then echo "no file for task $SLURM_ARRAY_TASK_ID"; exit 1; fi\n'
             'echo "Processing: $FILE"\n')
 
-    # Step 1 — library prediction (single job)
-    s1 = write("step1_libpred.sbatch", "\n".join([
-        header("s1_libpred", a.libpred_cpus, a.libpred_mem, a.libpred_time, a.partition, a.account), "",
-        f'echo "Step 1/5 library prediction"; date',
-        f'{DN} --fasta {fasta} --fasta-search --predictor --gen-spec-lib \\',
-        f'  --out-lib {D}/step1.speclib --out {D}/step1_lib.parquet \\',
-        f'  --threads {a.libpred_cpus} {flags}']))
+    # Step 1 — library prediction (single job) — SKIPPED when --seed-lib is given
+    s1 = None
+    if not seed:
+        s1 = write("step1_libpred.sbatch", "\n".join([
+            header("s1_libpred", a.libpred_cpus, a.libpred_mem, a.libpred_time, a.partition, a.account, qos=a.qos), "",
+            f'echo "Step 1/5 library prediction"; date',
+            f'{DN} --fasta {fasta} --fasta-search --predictor --gen-spec-lib \\',
+            f'  --out-lib {D}/step1.speclib --out {D}/step1_lib.parquet \\',
+            f'  --threads {a.libpred_cpus} {flags}']))
 
     # Step 2 — first pass (array): predicted lib -> per-file .quant
     s2 = write("step2_firstpass.sbatch", "\n".join([
-        header("s2_firstpass", a.threads_per_file, a.mem_per_file, a.time_per_file, a.partition, a.account, array=array), "",
+        header("s2_firstpass", a.threads_per_file, a.mem_per_file, a.time_per_file, a.partition, a.account, qos=a.qos, array=array), "",
         f'echo "Step 2/5 first pass, task ${{SLURM_ARRAY_TASK_ID}} of {n}"; date', pick,
         f'{DN} --f "$FILE" --fasta {fasta} --lib {predicted} \\',
         f'  --temp {D}/quant_step2 --rt-profiling --gen-spec-lib --quant-ori-names \\',
@@ -137,7 +176,7 @@ def main():
 
     # Step 3 — empirical library assembly (single job, --use-quant)
     s3 = write("step3_assembly.sbatch", "\n".join([
-        header("s3_assembly", a.assembly_cpus, a.assembly_mem, a.assembly_time, a.partition, a.account), "",
+        header("s3_assembly", a.assembly_cpus, a.assembly_mem, a.assembly_time, a.partition, a.account, qos=a.qos), "",
         f'echo "Step 3/5 empirical library assembly"; date',
         f'cp -r {D}/quant_step2 {D}/quant_step2_orig 2>/dev/null || true   # backup for resume',
         f'{DN} {all_f} --fasta {fasta} --lib {predicted} --use-quant --quant-ori-names \\',
@@ -147,7 +186,7 @@ def main():
 
     # Step 4 — final pass (array): empirical lib -> per-file .quant
     s4 = write("step4_finalpass.sbatch", "\n".join([
-        header("s4_finalpass", a.threads_per_file, a.mem_per_file, a.time_per_file, a.partition, a.account, array=array), "",
+        header("s4_finalpass", a.threads_per_file, a.mem_per_file, a.time_per_file, a.partition, a.account, qos=a.qos, array=array), "",
         f'echo "Step 4/5 final pass, task ${{SLURM_ARRAY_TASK_ID}} of {n}"; date', pick,
         'QUANT="${FILE##*/}"; QUANT="${QUANT%.*}.quant"',
         f'if [ ! -f "{D}/quant_step2/$QUANT" ]; then echo "SKIP: no step-2 quant for $QUANT"; exit 0; fi',
@@ -157,28 +196,39 @@ def main():
 
     # Step 5 — cross-run report (single job, --use-quant --matrices)
     s5 = write("step5_report.sbatch", "\n".join([
-        header("s5_report", a.assembly_cpus, a.assembly_mem, a.assembly_time, a.partition, a.account), "",
+        header("s5_report", a.assembly_cpus, a.assembly_mem, a.assembly_time, a.partition, a.account, qos=a.qos), "",
         f'echo "Step 5/5 cross-run report"; date',
         f'{DN} {all_f} --fasta {fasta} --lib {empirical} --use-quant --quant-ori-names \\',
         f'  --temp {D}/quant_step4 --matrices --out {D}/{report} \\',
         f'  --threads {a.assembly_cpus} {norm} {flags}']))
 
-    # submit.sh — chain the 5 steps with afterok dependencies
-    submit = "\n".join([
-        "#!/bin/bash", "set -euo pipefail", f'cd "{out}"',
-        'jid1=$(sbatch --parsable %s)' % s1,
-        'jid2=$(sbatch --parsable --dependency=afterok:$jid1 %s)' % s2,
+    # submit.sh — chain the steps with afterok dependencies
+    sub_lines = ["#!/bin/bash", "set -euo pipefail", f'cd "{out}"',
+                 f'mkdir -p "{D}/quant_step2" "{D}/quant_step4"   # DIA-NN --temp dirs MUST pre-exist']
+    if seed:
+        # Step 1 skipped — the InfinDIA/empirical seed library IS the first-pass lib.
+        # First pass optionally waits (afterok) on the lib-build job that produces it.
+        dep2 = f'--dependency=afterok:{a.seed_dep} ' if a.seed_dep else ''
+        sub_lines += [
+            f'echo "Step 1/5 SKIPPED — seeding first pass with {predicted}"',
+            'jid2=$(sbatch --parsable %s%s)' % (dep2, s2)]
+    else:
+        sub_lines += [
+            'jid1=$(sbatch --parsable %s)' % s1,
+            'jid2=$(sbatch --parsable --dependency=afterok:$jid1 %s)' % s2]
+    sub_lines += [
         'jid3=$(sbatch --parsable --dependency=afterok:$jid2 %s)' % s3,
         'jid4=$(sbatch --parsable --dependency=afterok:$jid3 %s)' % s4,
         'jid5=$(sbatch --parsable --dependency=afterok:$jid4 %s)' % s5,
-        'echo "submitted: lib=$jid1 firstpass=$jid2 assembly=$jid3 finalpass=$jid4 report=$jid5"',
-        f'echo "final report will be {D}/{report}; watch with: watch_run.sh --slurm $jid5 --log {D}/s5_report_${{jid5}}.log"'])
-    write("submit.sh", submit)
+        'echo "submitted: firstpass=$jid2 assembly=$jid3 finalpass=$jid4 report=$jid5"',
+        f'echo "final report will be {D}/{report}; watch with: watch_run.sh --slurm $jid5 --log {D}/s5_report_${{jid5}}.log"']
+    write("submit.sh", "\n".join(sub_lines))
 
     import json
     print(json.dumps({
         "out": out, "n_files": n, "report": f"{D}/{report}",
-        "scripts": [s1, s2, s3, s4, s5, "submit.sh"],
+        "seeded": bool(seed), "seed_lib": predicted if seed else None,
+        "scripts": [x for x in [s1, s2, s3, s4, s5, "submit.sh"] if x],
         "submit": f"bash {out}/submit.sh   (or: hive_exec.sh 'bash {out}/submit.sh')",
         "report_jobid_var": "jid5",
         "note": "5-step DIA-NN parallel chain. Mass accuracy is fixed (manual) — ensure --cfg has --mass-acc/--mass-acc-ms1 set, not 0/auto. Watch the run with watch_run.sh. Then point run_de.R at the report.",

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/ensure_dotnet8.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/ensure_dotnet8.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# ensure_dotnet8.sh -- make a .NET 8 runtime (>= 8.0.17) available so the DIA-NN 2.6
+# NATIVE binary can read Thermo .raw files directly (no mzML conversion).
+#
+# Why this exists: DIA-NN 2.6's .raw reader is a bundled .NET (ThermoFisher.CommonCore)
+# component. Without a suitable runtime it aborts with:
+#   "ERROR: cannot read .raw files, please download and install .NET Runtime 8:
+#    8.0.17 or later"
+# and processes 0 files. DIA-NN does a HARD check for >= 8.0.17 -- an older 8.0.x
+# (e.g. a cluster's 8.0.4 module) is REJECTED even though the app's runtimeconfig
+# only asks for 8.0.0, and a .NET 9 runtime is NOT used (rollForward is LatestMinor,
+# it won't cross the major version). So we need an actual 8.0.>=17 runtime.
+#
+# When it works, DIA-NN logs: ".NET runtime found, Thermo .raw support enabled".
+#
+# Idempotent: reuses an existing good runtime; only downloads if none is found.
+# Run it on a machine with internet (an HPC LOGIN node) -- compute nodes often
+# have none. It installs to a shared path so compute nodes can read it at run time.
+#
+# Prints DOTNET_ROOT on the LAST stdout line (diagnostics go to stderr):
+#   eval "$(bash ensure_dotnet8.sh)"            # not this -- it prints a path, not exports
+#   export DOTNET_ROOT="$(bash ensure_dotnet8.sh | tail -1)"; export PATH="$DOTNET_ROOT:$PATH"
+#
+# Override the install location with PROTEOMICS_DOTNET_DIR (default ~/.proteomics-pipeline/dotnet8).
+set -euo pipefail
+MIN_MINOR=17
+DEST="${PROTEOMICS_DOTNET_DIR:-$HOME/.proteomics-pipeline/dotnet8}"
+
+# true if $1/dotnet exposes a Microsoft.NETCore.App 8.0.<minor>  with minor >= MIN_MINOR
+have_ok() {
+  local root="$1"
+  [ -x "$root/dotnet" ] || return 1
+  "$root/dotnet" --list-runtimes 2>/dev/null | awk -v m="$MIN_MINOR" '
+    /Microsoft.NETCore.App 8\.0\./ { split($2, a, "."); if (a[3]+0 >= m) ok=1 }
+    END { exit ok?0:1 }'
+}
+
+# 1) already installed where we put it
+if have_ok "$DEST"; then echo "reusing .NET 8 at $DEST" >&2; echo "$DEST"; exit 0; fi
+
+# 2) a system/module dotnet that already satisfies >= 8.0.17
+if command -v dotnet >/dev/null 2>&1; then
+  sysroot="$(dirname "$(readlink -f "$(command -v dotnet)")")"
+  if have_ok "$sysroot"; then echo "system .NET 8 ok at $sysroot" >&2; echo "$sysroot"; exit 0; fi
+fi
+
+# 3) install the latest 8.0 runtime into DEST (needs internet -- run on a login node)
+echo "installing .NET 8 runtime (>= 8.0.$MIN_MINOR) into $DEST ..." >&2
+mkdir -p "$DEST"
+tmp="$(mktemp)"
+curl -sSL https://dot.net/v1/dotnet-install.sh -o "$tmp"
+bash "$tmp" --channel 8.0 --runtime dotnet --install-dir "$DEST" >&2
+rm -f "$tmp"
+have_ok "$DEST" || { echo "ERROR: .NET 8 install did not yield a >= 8.0.$MIN_MINOR runtime" >&2; exit 1; }
+echo "installed .NET 8 at $DEST" >&2
+echo "$DEST"

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_search.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_search.py
@@ -11,6 +11,8 @@ Routing (PLAN.md §7b):
 Per engine:
   diann    <cmd> --cfg <bundle .cfg> --f <files> --fasta <fasta>
            --out report.parquet --threads N        (native contract, no adapter)
+           adds --dda for DDA acquisition (DIA-NN 2.6+); if inputs are Thermo .raw,
+           auto-provisions a .NET 8 runtime (ensure_dotnet8.sh) so 2.6 can read them
   sage     convert .d/.raw -> mzML if needed (msconvert), then
            <cmd> <bundle sage_config.json> -f <fasta> -o <out> --parquet
            --disable-telemetry-i-dont-want-to-improve-sage
@@ -58,20 +60,48 @@ def pick_engine(args, bundle):
 
 
 # ----------------------------------------------------------------- DIA-NN -----
-def run_diann(cmd, params, files, fasta, out, threads, sbatch):
+def dotnet_env_for(files):
+    """DIA-NN 2.6's NATIVE binary needs a .NET 8 runtime (>= 8.0.17) to read Thermo
+    .raw. If any input is .raw, resolve/install one via ensure_dotnet8.sh and return
+    a shell snippet ('export DOTNET_ROOT=...; export PATH=...;') to prepend to the
+    DIA-NN command (inline) or the sbatch (compute node reads the shared install).
+    Returns "" for mzML/.d-only inputs (no .NET needed). Runs the helper where
+    run_search.py runs -- i.e. on the HIVE login node in the hive_remote model."""
+    if not any(f.lower().endswith(".raw") for f in files):
+        return ""
+    helper = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ensure_dotnet8.sh")
+    try:
+        root = subprocess.check_output(["bash", helper], text=True).strip().splitlines()[-1]
+    except Exception as e:
+        sys.stderr.write(
+            f"[run_diann] ensure_dotnet8.sh could not provide a .NET 8 runtime ({e}).\n"
+            "  DIA-NN 2.6 will not read .raw. Options: run ensure_dotnet8.sh on a login\n"
+            "  node (needs internet), or feed mzML instead of .raw.\n")
+        return ""
+    return (f"export DOTNET_ROOT={shlex.quote(root)}; "
+            f'export PATH={shlex.quote(root)}:"$PATH";')
+
+
+def run_diann(cmd, params, files, fasta, out, threads, sbatch, acquisition=""):
     os.makedirs(out, exist_ok=True)
     report = os.path.join(out, "report.parquet")
     f_args = " ".join(f"--f {shlex.quote(f)}" for f in files)
+    # DIA-NN 2.6 supports DDA via --dda (must NOT be used on DIA data). QuantUMS is
+    # auto-disabled on DDA; for DDA quant DIA-NN recommends extra MS1 filtering on
+    # Ms1.Global.Q.Value / Ms1.Global.Quality (see references/search-engines.md).
+    dda = " --dda" if (acquisition or "").upper() == "DDA" else ""
     full = (f"{cmd} --cfg {shlex.quote(params)} {f_args} "
             f"--fasta {shlex.quote(fasta)} --out {shlex.quote(report)} "
-            f"--threads {threads}")
+            f"--threads {threads}{dda}")
+    dnet = dotnet_env_for(files)          # .NET 8 for reading Thermo .raw, if needed
     if sbatch:
-        emit_sbatch(sbatch, full, out, threads, job="diann_search")
-        return {"engine": "diann", "report": report, "submitted": sbatch, "ran": False}
-    sh(full)
+        emit_sbatch(sbatch, full, out, threads, job="diann_search", preamble=dnet)
+        return {"engine": "diann", "report": report, "submitted": sbatch,
+                "ran": False, "dda": bool(dda), "raw_dotnet": bool(dnet)}
+    sh((dnet + " " if dnet else "") + full)
     if not os.path.exists(report):
         sys.exit(f"DIA-NN finished but {report} is missing.")
-    return {"engine": "diann", "report": report, "ran": True}
+    return {"engine": "diann", "report": report, "ran": True, "dda": bool(dda)}
 
 
 # --------------------------------------------------------------- AlphaDIA -----
@@ -306,10 +336,13 @@ def _find(root, names):
     return None
 
 
-def emit_sbatch(path, command, out, threads, job):
+def emit_sbatch(path, command, out, threads, job, preamble=""):
     """Emit a minimal SLURM script (login-node-safe). Orchestrator submits it.
-    Mirrors DE-LIMP queue policy: genome-center-grp/high, publicgrp/low fallback."""
-    script = f"""#!/bin/bash
+    Mirrors DE-LIMP queue policy: genome-center-grp/high, publicgrp/low fallback.
+    `preamble` runs before the command (e.g. the DOTNET_ROOT exports that let
+    DIA-NN 2.6 read Thermo .raw)."""
+    pre = (preamble + "\n") if preamble else ""
+    script = f"""#!/bin/bash -l
 #SBATCH --job-name={job}
 #SBATCH --output={os.path.join(out, job)}_%j.log
 #SBATCH --cpus-per-task={threads}
@@ -319,7 +352,7 @@ def emit_sbatch(path, command, out, threads, job):
 #SBATCH --qos=genome-center-grp-high-qos
 set -euo pipefail
 cd {shlex.quote(os.path.abspath(out))}
-{command}
+{pre}{command}
 """
     with open(path, "w") as fh:
         fh.write(script)
@@ -361,7 +394,8 @@ def main():
     print(f"[run_search] engine={engine}  files={len(files)}  threads={a.threads}  "
           f"{'(emit sbatch)' if a.sbatch else '(inline)'}")
     if engine == "diann":
-        res = run_diann(cmd, a.params, files, a.fasta, a.out, a.threads, a.sbatch)
+        res = run_diann(cmd, a.params, files, a.fasta, a.out, a.threads, a.sbatch,
+                        acquisition=bundle.get("acquisition", ""))
     elif engine == "alphadia":
         res = run_alphadia(cmd, a.params, files, a.fasta, a.out, a.threads, a.sbatch)
     elif engine == "sage":

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/sample_quality.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/sample_quality.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""
+sample_quality.py -- biological sample-quality / contamination diagnostics.
+
+Goes beyond audit_results.py's lab-contaminant check (keratin/trypsin) to the
+sample-level biological contaminations that repeatedly produce WRONG-but-plausible
+DE in real core-facility work (see references/sample-quality.md, distilled from the
+UC Davis Proteomics Core analysis log):
+
+  * HEMOLYSIS      red-cell lysis in plasma/serum (hemoglobin, carbonic anhydrase,
+                   catalase, peroxiredoxin, spectrin ...). Drove artefactual
+                   plasma DE (Taha dog P1-vs-P2; Pcal GZ1).
+  * SKELETAL_MUSCLE muscle debris in a non-muscle tissue biopsy (myosins, troponins,
+                   CK-M, myoglobin ...). In the Vining cow-liver study, uniform
+                   muscle contamination of one breed's biopsies produced 3,045 "DE"
+                   proteins that were contamination, NOT biology.
+  * EPIDERMIS      skin/hair squames (epidermal keratins + FLG/LOR/IVL).
+
+For each panel it computes a per-sample abundance score (z across samples) and --
+crucially -- checks whether that score is CONFOUNDED WITH GROUP. When a
+contamination panel separates the groups with little/no overlap, DE between those
+groups may just be the contamination gradient; protein-level marker removal does
+NOT fix a confounded contrast (proven in the Vining study -- dropping muscle
+markers INCREASED the DE count). The fix is at the sample/design level.
+
+Also flags the limpa/DPC-Quant "complete matrix" depth trap: a DPC-Quant expression
+matrix has ~no NAs (the detection model fills every cell), so counting non-empty
+cells is a CONSTANT, not per-sample depth -- real depth needs detected-precursor
+counts. Pass --report report.parquet for true per-run detected protein-group depth.
+
+Usage:
+  python3 sample_quality.py --matrix Expression_Matrix.csv [--conditions conditions.csv]
+      [--report report.parquet] [--out SAMPLE_QUALITY.md] [--z 1.5]
+
+Reads/writes plain files; stdlib only (pyarrow optional, just for --report).
+"""
+import sys, os, csv, json, math, argparse, re
+
+# Curated gene-symbol panels (case-insensitive; matched against the matrix's gene /
+# protein-name column). Deliberately specific markers -- avoid ubiquitous glycolytic
+# enzymes. Extend per tissue as needed; document additions in references/sample-quality.md.
+PANELS = {
+    "HEMOLYSIS": ["HBA1", "HBA2", "HBA", "HBB", "HBD", "CA1", "CA2", "CAT", "PRDX2",
+                  "BLVRB", "SPTA1", "SPTB", "ANK1", "SLC4A1", "EPB42", "PKLR", "BPGM",
+                  "ALAS2", "AHSP", "CATALASE"],
+    "SKELETAL_MUSCLE": ["MYH1", "MYH2", "MYH7", "MYBPC1", "MYBPC2", "ACTN2", "ACTN3",
+                        "CKM", "MB", "TNNI1", "TNNI2", "TNNT3", "TNNC2", "PYGM", "ENO3",
+                        "TPM1", "TPM2", "MYOM1", "MYOM2", "MYOM3", "DES", "MYL1", "MYL2",
+                        "ATP2A1", "NEB", "TTN", "CASQ1", "SLN"],
+    "EPIDERMIS": ["KRT1", "KRT2", "KRT9", "KRT10", "KRT5", "KRT14", "KRT16", "KRT6A",
+                  "FLG", "LOR", "IVL", "DSP", "JUP", "SBSN"],
+}
+
+
+def read_matrix(path):
+    """Return (samples, rows) where each row = {'genes': set, 'vals': {sample: float|None}}."""
+    with open(path, newline="") as fh:
+        rd = csv.reader(fh)
+        header = next(rd)
+        # gene/id column: prefer an explicit gene column, else first text column
+        gi = next((i for i, h in enumerate(header)
+                   if h.strip().lower() in ("genes", "gene", "protein.names", "protein_names",
+                                            "protein.group", "protein.ids", "protein")), 0)
+        # sample columns = everything that parses as numeric on the first data row
+        rows, sample_idx = [], None
+        for rec in rd:
+            if sample_idx is None:
+                sample_idx = [i for i in range(len(rec))
+                              if i != gi and _num(rec[i]) is not None]
+                if not sample_idx:                    # header-only numeric detection fallback
+                    sample_idx = [i for i in range(len(rec)) if i != gi]
+            genes = _genes(rec[gi]) if gi < len(rec) else set()
+            vals = {header[i]: _num(rec[i]) for i in sample_idx if i < len(rec)}
+            rows.append({"genes": genes, "vals": vals})
+        samples = [header[i] for i in sample_idx]
+    return samples, rows
+
+
+def _num(x):
+    try:
+        v = float(x)
+        return v if not math.isnan(v) else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _genes(cell):
+    return {g.upper() for g in re.split(r"[;,/\s]+", (cell or "").strip()) if g and g not in (".", "NA")}
+
+
+def _to_log2(rows, samples):
+    """DE matrices may be raw intensity or log2. If values look like raw intensity
+    (95th pct > 100), log2-transform so panel means are comparable."""
+    allv = [v for r in rows for v in r["vals"].values() if v is not None and v > 0]
+    if not allv:
+        return
+    allv.sort()
+    if allv[int(0.95 * (len(allv) - 1))] > 100:        # raw intensities -> log2
+        for r in rows:
+            for s in list(r["vals"]):
+                v = r["vals"][s]
+                r["vals"][s] = math.log2(v) if (v is not None and v > 0) else None
+
+
+def panel_scores(rows, samples, panel_genes):
+    pg = set(g.upper() for g in panel_genes)
+    hits = [r for r in rows if r["genes"] & pg]
+    per = {}
+    for s in samples:
+        vals = [r["vals"].get(s) for r in hits]
+        vals = [v for v in vals if v is not None]
+        per[s] = (sum(vals) / len(vals)) if vals else None
+    matched = sorted({g for r in hits for g in (r["genes"] & pg)})
+    return per, len(hits), matched
+
+
+def zscore(per, samples):
+    xs = [per[s] for s in samples if per[s] is not None]
+    if len(xs) < 2:
+        return {s: None for s in samples}
+    m = sum(xs) / len(xs)
+    sd = (sum((x - m) ** 2 for x in xs) / (len(xs) - 1)) ** 0.5 or 1e-9
+    return {s: ((per[s] - m) / sd if per[s] is not None else None) for s in samples}
+
+
+def load_conditions(path, samples):
+    """Map matrix sample columns -> group via conditions.csv (fuzzy basename-stem)."""
+    if not path or not os.path.exists(path):
+        return {}
+    pairs = []
+    with open(path, newline="") as fh:
+        rd = csv.DictReader(fh)
+        fcol = next((c for c in rd.fieldnames if "file" in c.lower() or "run" in c.lower() or "sample" in c.lower()), rd.fieldnames[0])
+        gcol = next((c for c in rd.fieldnames if "group" in c.lower() or "condition" in c.lower()), rd.fieldnames[-1])
+        for r in rd:
+            pairs.append((_stem(r.get(fcol, "")), r.get(gcol, "").strip()))
+    gmap = {}
+    for s in samples:
+        ss = _stem(s)
+        hit = next((g for stem, g in pairs if stem and (stem == ss or stem in ss or ss in stem)), None)
+        if hit:
+            gmap[s] = hit
+    return gmap
+
+
+def _stem(x):
+    b = os.path.basename(str(x).strip().rstrip("/"))
+    for ext in (".mzml", ".raw", ".d", ".dia", ".parquet"):
+        if b.lower().endswith(ext):
+            b = b[: -len(ext)]
+    return b.lower()
+
+
+def confound_check(z, gmap, samples, thr):
+    """Return (confounded: bool, detail) -- is the panel score separated by group with
+    little overlap? That is the danger signal: DE may be contamination, not biology."""
+    if not gmap:
+        return False, "no conditions.csv -- group-confounding not assessed"
+    groups = {}
+    for s in samples:
+        if s in gmap and z.get(s) is not None:
+            groups.setdefault(gmap[s], []).append(z[s])
+    if len(groups) < 2:
+        return False, "fewer than 2 groups with panel data"
+    means = {g: sum(v) / len(v) for g, v in groups.items()}
+    hi = max(means, key=means.get); lo = min(means, key=means.get)
+    gap = means[hi] - means[lo]
+    overlap = max(min(groups[hi]), min(groups[lo])) <= min(max(groups[hi]), max(groups[lo]))  # crude
+    # strong signal: group means differ by > ~1.5 SD of z (i.e. > thr) AND ranges barely overlap
+    separated = (gap >= thr) and (min(groups[hi]) > max(groups[lo]) - 0.25 * gap)
+    detail = "; ".join(f"{g}: mean z {means[g]:+.2f} (n={len(groups[g])})" for g in sorted(means))
+    return bool(separated), f"{detail}  [gap {gap:+.2f}]"
+
+
+def detected_depth(report):
+    """Per-run distinct protein groups at Q<=0.01 from a DIA-NN report.parquet -- the
+    REAL per-sample depth (a DPC-Quant expression matrix is complete, so counting its
+    non-empty cells gives a constant, not depth)."""
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:
+        return None, "pyarrow not available"
+    t = pq.read_table(report)
+    cols = {c.lower(): c for c in t.column_names}
+    run = cols.get("run"); pg = cols.get("protein.group") or cols.get("protein.ids")
+    q = cols.get("q.value") or cols.get("global.q.value")
+    if not (run and pg):
+        return None, "report.parquet missing Run/Protein.Group"
+    runs = t.column(run).to_pylist(); pgs = t.column(pg).to_pylist()
+    qs = t.column(q).to_pylist() if q else [0.0] * len(runs)
+    seen = {}
+    for r, p, qv in zip(runs, pgs, qs):
+        if qv is None or qv <= 0.01:
+            seen.setdefault(str(r), set()).add(str(p))
+    return {r: len(v) for r, v in seen.items()}, None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--matrix", required=True, help="expression matrix CSV (proteins x samples; a gene/id column + numeric sample columns)")
+    ap.add_argument("--conditions", help="conditions.csv (File.Name,Group) to test group-confounding")
+    ap.add_argument("--report", help="DIA-NN report.parquet for TRUE per-sample detected depth")
+    ap.add_argument("--out", default="SAMPLE_QUALITY.md")
+    ap.add_argument("--z", type=float, default=1.5, help="|z| threshold to flag an elevated sample (default 1.5)")
+    ap.add_argument("--keratin-sample", action="store_true",
+                    help="sample IS keratin (nail/hair/wool/skin/feather) — keratin is the ANALYTE, "
+                         "so the EPIDERMIS panel is reported for QC but never flagged as contamination")
+    a = ap.parse_args()
+
+    samples, rows = read_matrix(a.matrix)
+    _to_log2(rows, samples)
+    gmap = load_conditions(a.conditions, samples)
+
+    na = sum(1 for r in rows for s in samples if r["vals"].get(s) is None)
+    complete = na / max(1, len(rows) * len(samples)) < 0.005
+
+    results, flags = {}, []
+    for name, genes in PANELS.items():
+        per, nhit, matched = panel_scores(rows, samples, genes)
+        z = zscore(per, samples)
+        elevated = sorted(s for s in samples if z.get(s) is not None and z[s] >= a.z)
+        confounded, detail = confound_check(z, gmap, samples, a.z)
+        expected = a.keratin_sample and name == "EPIDERMIS"
+        results[name] = {"n_panel_proteins": nhit, "matched_genes": matched,
+                         "z": {s: (round(z[s], 2) if z[s] is not None else None) for s in samples},
+                         "elevated_samples": elevated, "group_confounded": confounded,
+                         "group_detail": detail, "expected_analyte": expected}
+        if expected:
+            pass   # keratin IS the analyte for a keratin-matrix sample: report for QC, never flag
+        elif confounded:
+            flags.append(f"**{name} is CONFOUNDED WITH GROUP** ({detail}). DE between these "
+                         "groups may be contamination, not biology; protein-level marker removal "
+                         "will NOT fix a confounded contrast -- resolve at the sample/design level.")
+        elif elevated:
+            flags.append(f"{name}: elevated in {', '.join(elevated)} (|z|>={a.z}) -- possible "
+                         "per-sample contamination; check before interpreting these samples.")
+
+    depth, depth_note = (None, None)
+    if a.report and os.path.exists(a.report):
+        depth, depth_note = detected_depth(a.report)
+
+    # ---- write report ----
+    with open(a.out, "w") as fh:
+        fh.write("# Sample-quality & contamination diagnostics\n\n")
+        if not flags:
+            fh.write("No contamination panel is group-confounded or per-sample elevated at the "
+                     f"current threshold (|z|>={a.z}).\n\n")
+        for f in flags:
+            fh.write(f"- {f}\n")
+        fh.write("\n")
+        for name, r in results.items():
+            fh.write(f"## {name}  ({r['n_panel_proteins']} panel proteins detected)\n\n")
+            if r.get("expected_analyte"):
+                fh.write("_This is the **analyte** for a keratin-matrix sample (nail/hair/wool/skin/"
+                         "feather) — reported for QC, **not** treated as contamination._\n\n")
+            if not r["matched_genes"]:
+                fh.write("_None of this panel's markers were detected — not assessable._\n\n")
+                continue
+            fh.write(f"markers: {', '.join(r['matched_genes'])}\n\n")
+            fh.write("| sample | group | z (panel abundance) |\n|---|---|---|\n")
+            for s in samples:
+                zz = r["z"][s]
+                fh.write(f"| {s} | {gmap.get(s,'?')} | {zz if zz is not None else 'NA'} |\n")
+            fh.write(f"\n_group-confounding:_ {r['group_detail']}\n\n")
+        if complete:
+            fh.write("## ⚠ Per-sample depth\n\nThe expression matrix is **complete "
+                     "(~no missing values)** — consistent with DPC-Quant/limpa, whose detection "
+                     "model fills every cell. **Do not** use non-empty cell counts as per-sample "
+                     "depth (it is a constant). ")
+            if depth:
+                fh.write("True detected protein groups per run (Q≤0.01, from report.parquet):\n\n")
+                fh.write("| run | detected protein groups |\n|---|---|\n")
+                for r in sorted(depth):
+                    fh.write(f"| {r} | {depth[r]} |\n")
+            else:
+                fh.write("Pass `--report report.parquet` for true detected-precursor depth"
+                         + (f" ({depth_note})" if depth_note else "") + ".\n")
+            fh.write("\n")
+    with open(os.path.splitext(a.out)[0].lower().replace("sample_quality", "sample_quality") + ".json"
+             if False else a.out.replace(".md", ".json"), "w") as jf:
+        json.dump({"samples": samples, "groups": gmap, "matrix_complete": complete,
+                   "panels": results, "detected_depth": depth, "flags": flags}, jf, indent=2)
+
+    print(json.dumps({"out": a.out, "flags": flags,
+                      "group_confounded": [n for n, r in results.items() if r["group_confounded"]],
+                      "matrix_complete": complete}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # =============================================================================
 # watch_run.sh  --  One poll of a running search: report its state, detect known
-# errors, and suggest the fix. The orchestrator MUST watch every search it starts:
-# loop this until the run finishes, and on failure apply the fix (and resubmit) —
-# never leave a multi-hour search unmonitored.
+# errors AND stalls, and suggest the fix. The orchestrator MUST watch every search it
+# starts: loop this until the run finishes, and on failure OR stall apply the fix and
+# resubmit AUTONOMOUSLY (no user prompt) — never leave a multi-hour search unmonitored.
+# Detects both hard failures (sacct state) and STALLS (job RUNNING but log frozen,
+# which sacct/squeue cannot see) — see --stall-min and references/watcher.md.
 #
 # Usage:
 #   watch_run.sh --log <logfile>                 # local run: the search log
@@ -14,11 +16,12 @@
 #   while not done: watch_run.sh ...; sleep 60; done   # then act on failed/fix
 # =============================================================================
 set -uo pipefail
-MODE="local"; JOB=""; LOG=""; HIVE=false
+MODE="local"; JOB=""; LOG=""; HIVE=false; STALL_MIN=15
 while [ $# -gt 0 ]; do case "$1" in
-  --slurm) MODE="slurm"; JOB="$2"; shift 2;;
-  --log)   LOG="$2"; shift 2;;
-  --hive)  HIVE=true; shift;;
+  --slurm)     MODE="slurm"; JOB="$2"; shift 2;;
+  --log)       LOG="$2"; shift 2;;
+  --hive)      HIVE=true; shift;;
+  --stall-min) STALL_MIN="$2"; shift 2;;   # RUNNING + log frozen this long ⇒ stalled
   *) shift;;
 esac; done
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -29,11 +32,19 @@ if [ "$MODE" = "slurm" ] && [ -n "$JOB" ]; then
   st="$(run "sacct -j $JOB --noheader -o State 2>/dev/null | head -1 | tr -d ' '" 2>/dev/null)"
   [ -z "$st" ] && st="$(run "squeue -j $JOB -h -o %T 2>/dev/null" 2>/dev/null)"
   state="${st:-PENDING}"
+  reason="$(run "squeue -j $JOB -h -o %R 2>/dev/null" 2>/dev/null)"
   case "$state" in
     COMPLETED)                                   done=true;;
     FAILED|TIMEOUT|OUT_OF_MEMORY|NODE_FAIL)       done=true; failed=true;;
     CANCELLED*)                                   done=true; failed=true;;
   esac
+  # An upstream failure leaves a CHAINED job PENDING FOREVER with this reason. A naive
+  # "wait until the job leaves the queue" monitor hangs here indefinitely and never fires
+  # — so treat it as a terminal FAILURE that needs recovery. (This is exactly what silently
+  # ate the first nail semi-tryptic chain overnight.)
+  if printf '%s' "$reason" | grep -qiE "DependencyNeverSatisfied|launch failed"; then
+    done=true; failed=true; dep_failed=true
+  fi
 fi
 
 tail_txt=""
@@ -52,15 +63,33 @@ elif m "CUDA|no kernel image|cuDNN|device-side|GPU.*not";                       
 elif m "msconvert.*not found|requires mzML|no mzML";                                then err_class="sage_no_mzml";  fix="Sage needs mzML. Convert .d/.raw with msconvert first (Linux/HIVE), then re-run.";
 elif m "Disk quota exceeded|No space left";                                         then err_class="disk";          fix="Out of disk/quota. Free space or point --out elsewhere and resubmit.";
 elif m "No such file|cannot open|does not exist|not found.*(fasta|\\.d|\\.raw)";     then err_class="missing_input"; fix="An input path is wrong (fasta/raw). Re-check paths (Windows→WSL/HIVE translation) and resubmit.";
+elif [ "${dep_failed:-false}" = true ];                                              then err_class="dependency_failed"; fix="An UPSTREAM job in the chain failed, so this one is stuck PENDING with DependencyNeverSatisfied (it will NEVER run and never leave the queue). Find the failed step (sacct -j <arrayjob>), apply that step's fix, and resubmit the downstream steps reusing already-computed outputs (.quant, step1.predicted.speclib) — don't restart the whole chain.";
 elif $failed;                                                                        then err_class="unknown_failure"; fix="Read the full log; diagnose via references/watcher.md; fix and resubmit.";
 fi
 
-STATE="$state" DONE="$done" FAILED="$failed" JOB="$JOB" MODE="$MODE" \
+# STALL detection: job RUNNING but its log has not advanced in STALL_MIN minutes.
+# A hung file (e.g. a pathological DIA-NN run) keeps the job in RUNNING while the log
+# freezes — sacct/squeue will NOT flag it. This is the "NA41-class" failure.
+stalled=false
+if [ -z "$err_class" ] && [ -n "$LOG" ] && printf '%s' "$state" | grep -qiE "RUNNING|^R$"; then
+  now="$(run "date +%s" 2>/dev/null)"
+  mt="$(run "stat -c %Y $(printf %q "$LOG") 2>/dev/null" 2>/dev/null | tr -dc 0-9)"
+  if [ -n "$now" ] && [ -n "$mt" ]; then
+    age=$(( now - mt ))
+    if [ "$age" -ge $(( STALL_MIN * 60 )) ]; then
+      stalled=true; err_class="stalled"
+      fix="RUNNING but log frozen ${age}s (> ${STALL_MIN} min) — likely a hung file (pathological DIA-NN run). Auto-recover: scancel this task/job, retry it ONCE on a fresh node; if it stalls again, DROP that file and continue (the 5-step chain's step 4 auto-skips a file with no .quant), then resubmit downstream steps reusing the completed .quant. Log the dropped file in Data Quality Notes."
+    fi
+  fi
+fi
+
+STATE="$state" DONE="$done" FAILED="$failed" STALLED="$stalled" JOB="$JOB" MODE="$MODE" \
 ECLASS="$err_class" FIX="$fix" TAIL="$tail_txt" python3 - <<'PY'
 import os, json
 print(json.dumps({
     "mode": os.environ["MODE"], "job": os.environ["JOB"], "state": os.environ["STATE"],
     "done": os.environ["DONE"] == "true", "failed": os.environ["FAILED"] == "true",
+    "stalled": os.environ.get("STALLED") == "true",
     "error_class": os.environ["ECLASS"], "fix": os.environ["FIX"],
     "log_tail": os.environ["TAIL"][-1500:],
 }, indent=2))


### PR DESCRIPTION
Ships skill v1.0.9 to the plugin marketplace. Everything below was sitting uncommitted; the marketplace has been serving v1.0.8.

## Search & monitoring
- `watch_run.sh` now reports `stalled` — a job stuck in `RUNNING` with a frozen log — not just outright failure. The skill applies the returned fix and resubmits **autonomously**; only starting a search needs user confirmation, recovering one in flight does not.
- The 5-step parallel chain resumes from the earliest incomplete step, reusing completed `.quant` files and `step1.predicted.speclib` instead of restarting the cohort. A file that hangs twice is dropped and recorded in Data Quality Notes.
- `run_search.py` passes `--dda` for DDA acquisition (DIA-NN 2.6+) and auto-provisions a .NET 8 runtime via the new `ensure_dotnet8.sh` when inputs are Thermo `.raw`.

## Result QA
- New `sample_quality.py` catches contamination that mimics biology — hemolysis, tissue cross-contamination, skin. If a contamination panel is confounded with a group the pipeline stops, since protein-level filtering won't fix it. `--keratin-sample` treats keratin as the analyte for nail/hair/wool/feather work.
- New `references/anomaly-checks.md` holds the judgment calls `audit_results.py` can't automate (intensity outliers, mass/RT/CCS shifts, p-value shape, log2FC>5 artefacts, PCA sample swaps, GSEA background) plus the triggers for the conditional three-reviewer panel.

## Portability
- Golden rule 6: assume nothing about the user's environment. Most users are neither UC Davis Core nor on HIVE. Every program needs a public source and a path that works on their OS; `/quobyte/proteomics-grp` is a fast-path, never a requirement.

Verified: all Python compiles, both shell scripts pass `bash -n`, and the three previously-untracked files SKILL.md references (`sample_quality.py`, `anomaly-checks.md`, `ensure_dotnet8.sh`) are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Msrj7b5cPXYz9Sn1FtJidB