### PR TITLE
feat(skill): auto-route DIA-NN to the 5-step parallel chain above 5 files (v1.0.12)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -302,11 +302,21 @@ python3 scripts/run_search.py --tools ~/.proteomics-pipeline/tools/tools.json \
   DIA-NN's official recommended per-instrument mass tolerances (timsTOF → MS1/MS2 15
   ppm; Orbitrap Astral → 4/10 ppm; Orbitrap by resolution 240k→4, 120k→7, 60k→10,
   30k→15). Don't override these unless the user gives a validated SOP value.
-- **DIA-NN parallel (many DIA files on a cluster):** for ≳8–10 DIA files on HIVE, use
-  the **5-step parallel chain** instead of a single job — much faster (per-file passes
-  run as a SLURM array). Generate it with `diann_parallel.py` (pass the estimated
-  `--cfg`, which must have a **fixed** mass-acc — a known instrument), then submit
-  `submit.sh` over `hive_exec.sh`; it produces `report.parquet`. → `references/diann_parallel.md`.
+- **DIA-NN parallel — AUTOMATIC above 5 files.** `run_search.py` routes to the **5-step
+  parallel chain** by itself whenever the run is DIA-NN with **more than 5 files** on a
+  machine that has SLURM and a `--cfg` with **fixed** mass accuracy. You don't decide
+  this; it prints `parallel routing: YES|no -- <reason>` and records the reason in
+  `search_provenance.json`. This matches facility practice in DE-LIMP: per-file passes
+  run as a SLURM array instead of one long single-node job.
+  - It falls back to a single search, with the reason printed, when there's **no SLURM**
+    (the chain is job arrays — nothing to fall back to) or when **mass accuracy is on
+    auto**. Mass accuracy is the one you can fix: steps 3/5 reuse the `.quant` files, so
+    auto-calibration would differ between passes. Re-run `estimate_params.py` with the
+    **real instrument** (step 6b) to pin it and parallel turns itself on.
+  - Override either way with `--no-parallel` (force one job) or `--parallel-threshold N`.
+  - It **generates** the chain but does not submit it. Submit `<out>/submit.sh` (over
+    `hive_exec.sh` on HIVE), then watch the **step-5** job — that's the one that writes
+    `report.parquet`. → `references/diann_parallel.md`.
 - **On `hpc`:** add `--sbatch job.sh`, then `sbatch job.sh` (over `hive_exec.sh` for a
   remote HIVE run). Re-run with `--adapt-only` afterward for Sage/FragPipe/AlphaDIA to
   build `report.parquet`.

--- a/skill/ucdavis-proteomics-core-pipeline/references/diann_parallel.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/diann_parallel.md
@@ -2,8 +2,28 @@
 
 DIA-NN's high-throughput workflow — **poorly documented upstream**, so it is encoded
 here (`diann_parallel.py`), ported faithfully from DE-LIMP's `generate_parallel_scripts()`.
-Use it for **many DIA files on a cluster** (roughly ≥ ~8–10, or whenever a single
-job would be too slow). For a few files, the single-shot `run_search.py` is fine.
+
+## When it is used — automatic above 5 files
+
+`run_search.py` decides this for you; you rarely call `diann_parallel.py` by hand. It
+routes to the chain when **all** of these hold, and prints the reason either way:
+
+| Condition | Why it's required |
+|---|---|
+| engine is **DIA-NN** | the chain is DIA-NN-specific |
+| **more than 5 files** (`--parallel-threshold`, default 5) | below that, chain overhead (library prediction + two array round-trips) outweighs the win |
+| **SLURM present** (`sbatch` on PATH) | steps 2 and 4 are job arrays — there is no non-cluster equivalent |
+| **mass accuracy fixed** in the `--cfg` | steps 3/5 reuse the `.quant` files from 2/4; auto-calibration would differ between passes and corrupt the cross-run report |
+
+Any condition unmet → single-shot search, reason printed and written to
+`search_provenance.json` (`search_mode`, `parallel_routing_reason`). The fixable one is
+almost always mass accuracy: re-run `estimate_params.py` with the **real instrument** so
+it pins the DIA-NN recommended values, and parallel enables itself. Force the decision
+with `--no-parallel` or `--parallel-threshold N`.
+
+`diann_parallel.py` **refuses to run** on an auto/0 mass-accuracy cfg rather than
+producing a silently inconsistent report (`--allow-auto-mass-acc` overrides, for testing
+only).
 
 ## The 5 steps (chained with `afterok` dependencies)
 1. **Library prediction** — single job, no raw: predict a spectral library from the

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
@@ -71,6 +71,39 @@ def read_cfg_flags(cfg):
     return " ".join(out)
 
 
+def mass_acc_status(cfg):
+    """Is mass accuracy FIXED (manual) in this cfg? Steps 3/5 reuse the .quant files
+    from steps 2/4, so auto-calibration would be applied inconsistently between passes
+    (per DIA-NN dev guidance) -- the chain is only valid with pinned values. This is the
+    single definition of "is this cfg parallel-safe"; run_search.py imports it to decide
+    whether it may auto-route. Returns {fixed, ms2, ms1, reason}."""
+    vals = {"--mass-acc": None, "--mass-acc-ms1": None}
+    if cfg and os.path.exists(cfg):
+        try:
+            toks = shlex.split(open(cfg).read(), comments=True)
+        except ValueError:                      # unbalanced quotes -- fall back to raw split
+            toks = open(cfg).read().split()
+        for i, t in enumerate(toks):
+            if t in vals and i + 1 < len(toks):
+                try:
+                    vals[t] = float(toks[i + 1])
+                except ValueError:
+                    pass
+    ms2, ms1 = vals["--mass-acc"], vals["--mass-acc-ms1"]
+    pairs = (("--mass-acc", ms2), ("--mass-acc-ms1", ms1))
+    missing = [k for k, v in pairs if v is None]
+    auto = [k for k, v in pairs if v == 0]
+    if missing or auto:
+        why = []
+        if missing:
+            why.append("not set: " + ", ".join(missing))
+        if auto:
+            why.append("auto (0): " + ", ".join(auto))
+        return {"fixed": False, "ms2": ms2, "ms1": ms1, "reason": "; ".join(why)}
+    return {"fixed": True, "ms2": ms2, "ms1": ms1,
+            "reason": f"fixed (MS1 {ms1} ppm / MS2 {ms2} ppm)"}
+
+
 def header(name, cpus, mem_gb, hours, partition, account, qos=None, array=None):
     h = ["#!/bin/bash -l",
          f"#SBATCH --job-name={name}",
@@ -118,6 +151,9 @@ def main():
                     "(publicgrp-low-qos); high/genome-center-grp uses its default.")
     ap.add_argument("--max-simultaneous", type=int, default=20)
     ap.add_argument("--no-norm", action="store_true")
+    ap.add_argument("--allow-auto-mass-acc", action="store_true",
+                    help="proceed even though the cfg leaves mass accuracy on auto. Results "
+                         "across steps become inconsistent -- only for deliberate testing.")
     a = ap.parse_args()
 
     raws = []
@@ -135,6 +171,21 @@ def main():
     fasta = os.path.abspath(a.fasta)
     DN = dotnet_prefix(raws) + a.diann     # .NET 8 export prefix when inputs are Thermo .raw
     flags = read_cfg_flags(a.cfg)
+
+    # The chain is only valid with pinned mass accuracy (steps 3/5 reuse .quant files).
+    ma = mass_acc_status(a.cfg)
+    if not ma["fixed"] and not a.allow_auto_mass_acc:
+        sys.exit(
+            f"Mass accuracy is not fixed in {a.cfg or '(no --cfg given)'} -- {ma['reason']}.\n"
+            "The 5-step chain reuses .quant files across steps, so auto-calibration would be\n"
+            "applied inconsistently between passes and the cross-run report would be wrong.\n"
+            "Fix by re-running estimate_params.py with the real instrument so it pins the\n"
+            "DIA-NN recommended values (timsTOF 15/15, Astral 4/10, Orbitrap by resolution),\n"
+            "or run the single-shot search instead, which calibrates safely on its own.\n"
+            "To override deliberately: --allow-auto-mass-acc.")
+    if not ma["fixed"]:
+        sys.stderr.write(f"[diann_parallel] WARNING: proceeding with auto mass accuracy "
+                         f"({ma['reason']}) -- steps will not be mutually consistent.\n")
     D = out  # all DIA-NN intermediate/output lives here (real paths; native binary reads them directly)
     report = "no_norm_report.parquet" if a.no_norm else "report.parquet"
     norm = "--no-norm" if a.no_norm else ""
@@ -227,6 +278,7 @@ def main():
     import json
     print(json.dumps({
         "out": out, "n_files": n, "report": f"{D}/{report}",
+        "mass_acc": ma,
         "seeded": bool(seed), "seed_lib": predicted if seed else None,
         "scripts": [x for x in [s1, s2, s3, s4, s5, "submit.sh"] if x],
         "submit": f"bash {out}/submit.sh   (or: hive_exec.sh 'bash {out}/submit.sh')",

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_search.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_search.py
@@ -82,6 +82,71 @@ def dotnet_env_for(files):
             f'export PATH={shlex.quote(root)}:"$PATH";')
 
 
+def slurm_available():
+    return shutil.which("sbatch") is not None
+
+
+def _diann_parallel_mod():
+    """Import the sibling generator so the parallel-safety rule has ONE definition."""
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    import diann_parallel
+    return diann_parallel
+
+
+def parallel_decision(engine, files, params, a):
+    """Should this DIA-NN run use the 5-step SLURM chain instead of one job?
+
+    Automatic above --parallel-threshold files (default 5, matching the facility's
+    DE-LIMP practice), but only where the chain is actually valid: it needs a cluster
+    and it needs pinned mass accuracy. When a precondition fails we fall back to the
+    single-shot search rather than erroring -- routing was our choice, not the user's.
+    Returns (use_parallel, reason)."""
+    n = len(files)
+    if engine != "diann":
+        return False, f"engine is {engine}; the chain is DIA-NN only"
+    if a.no_parallel:
+        return False, "--no-parallel was given"
+    if n <= a.parallel_threshold:
+        return False, f"{n} file(s), at or below the threshold of {a.parallel_threshold}"
+    if not slurm_available():
+        return False, (f"{n} files, but no SLURM here (sbatch not on PATH) -- the 5-step "
+                       "chain runs as job arrays, so a single search is the only option")
+    ma = _diann_parallel_mod().mass_acc_status(params)
+    if not ma["fixed"]:
+        return False, (f"{n} files, but mass accuracy is not pinned in {params} "
+                       f"({ma['reason']}); steps 3/5 reuse .quant files, so the chain needs "
+                       "fixed --mass-acc/--mass-acc-ms1. Re-run estimate_params.py with the "
+                       "real instrument to enable parallel")
+    return True, (f"{n} files > {a.parallel_threshold}, SLURM present, mass accuracy "
+                  f"{ma['reason']}")
+
+
+def run_diann_parallel(cmd, params, files, fasta, out, threads, a):
+    """Generate DIA-NN's 5-step SLURM chain (does not submit -- the orchestrator does,
+    then watches the step-5 job with watch_run.sh)."""
+    os.makedirs(out, exist_ok=True)
+    listing = os.path.join(out, "parallel_input_files.txt")
+    with open(listing, "w") as fh:                    # a list file survives spaces in paths
+        fh.write("\n".join(files) + "\n")
+    argv = [sys.executable,
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), "diann_parallel.py"),
+            "--diann", cmd, "--raw-list", listing, "--fasta", fasta,
+            "--out", out, "--cfg", params, "--threads-per-file", str(threads)]
+    for flag, val in (("--partition", a.partition), ("--account", a.account),
+                      ("--qos", a.qos), ("--max-simultaneous", a.max_simultaneous)):
+        if val:
+            argv += [flag, str(val)]
+    res = subprocess.run(argv, capture_output=True, text=True)
+    if res.stderr:
+        sys.stderr.write(res.stderr)
+    if res.returncode != 0:
+        sys.exit(f"diann_parallel.py failed (exit {res.returncode}). "
+                 "Re-run with --no-parallel to fall back to a single search.")
+    info = json.loads(res.stdout)
+    info.update({"engine": "diann", "mode": "parallel_5step", "ran": False})
+    return info
+
+
 def run_diann(cmd, params, files, fasta, out, threads, sbatch, acquisition=""):
     os.makedirs(out, exist_ok=True)
     report = os.path.join(out, "report.parquet")
@@ -370,6 +435,15 @@ def main():
     ap.add_argument("--threads", type=int, default=8)
     ap.add_argument("--engine", choices=["diann", "alphadia", "sage", "fragpipe"])
     ap.add_argument("--sbatch", help="emit an sbatch script at this path instead of running inline")
+    ap.add_argument("--parallel-threshold", type=int, default=5,
+                    help="DIA-NN: use the 5-step SLURM chain above this many files (default 5)")
+    ap.add_argument("--no-parallel", action="store_true",
+                    help="force a single-shot DIA-NN search regardless of file count")
+    ap.add_argument("--partition", help="SLURM partition for the parallel chain")
+    ap.add_argument("--account", help="SLURM account for the parallel chain")
+    ap.add_argument("--qos", help="SLURM QOS for the parallel chain")
+    ap.add_argument("--max-simultaneous", type=int,
+                    help="cap concurrent array tasks in the parallel chain")
     ap.add_argument("--adapt-only", action="store_true",
                     help="skip the search; just build report.parquet from an existing engine output dir")
     a = ap.parse_args()
@@ -391,9 +465,15 @@ def main():
                  f"Re-run acquire_tools.sh, or check its notes:\n  "
                  + "\n  ".join(tools.get("notes", [])))
 
-    print(f"[run_search] engine={engine}  files={len(files)}  threads={a.threads}  "
-          f"{'(emit sbatch)' if a.sbatch else '(inline)'}")
+    use_parallel, why = parallel_decision(engine, files, a.params, a)
     if engine == "diann":
+        print(f"[run_search] parallel routing: {'YES' if use_parallel else 'no'} -- {why}")
+
+    print(f"[run_search] engine={engine}  files={len(files)}  threads={a.threads}  "
+          f"{'(5-step chain)' if use_parallel else '(emit sbatch)' if a.sbatch else '(inline)'}")
+    if use_parallel:
+        res = run_diann_parallel(cmd, a.params, files, a.fasta, a.out, a.threads, a)
+    elif engine == "diann":
         res = run_diann(cmd, a.params, files, a.fasta, a.out, a.threads, a.sbatch,
                         acquisition=bundle.get("acquisition", ""))
     elif engine == "alphadia":
@@ -414,6 +494,8 @@ def main():
             json.dump({"engine": engine, "version": version, "resolved_command": cmd,
                        "params_file": a.params, "fasta": a.fasta, "threads": a.threads,
                        "n_files": len(files), "files": files,
+                       "search_mode": "parallel_5step" if use_parallel else "single_shot",
+                       "parallel_routing_reason": why,
                        "submitted_sbatch": a.sbatch or None, "result": res}, fh, indent=2)
     except Exception as e:
         sys.stderr.write(f"[run_search] could not write search_provenance.json: {e}\n")

--- a/workflows/diann_timstof_dia_mouse/workflow.yaml
+++ b/workflows/diann_timstof_dia_mouse/workflow.yaml
@@ -16,8 +16,8 @@ name: "DIA-NN — Bruker timsTOF dia-PASEF (mouse)"
 description: >
   Library-free DIA-NN search of mouse dia-PASEF data acquired on a Bruker
   timsTOF, followed by the limpa DPC-Quant + limma differential expression
-  pipeline. For cohorts of roughly 8 or more files, run the 5-step parallel
-  SLURM chain (diann_parallel.py) rather than a single job.
+  pipeline. Cohorts of more than 5 files are routed to the 5-step parallel
+  SLURM chain automatically by run_search.py.
 
 match:
   acquisition: DIA
@@ -49,5 +49,5 @@ de:
   adjp: 0.05
 
 notes:
-  - "Use diann_parallel.py for >=8 files; mass accuracy must be FIXED (not auto) for the chain."
+  - "run_search.py auto-routes >5 files to the 5-step chain. The estimator's timsTOF 15/15 ppm satisfies the chain's fixed-mass-accuracy requirement, so parallel engages for this workflow."
   - "Report protein counts from report.stats.tsv, not from the post-DPC matrix (which is complete by construction)."


### PR DESCRIPTION
Makes the DIA-NN parallel workflow automatic instead of a judgment call, at the threshold the facility actually uses.

## What changed

`run_search.py` now decides routing itself. More than **5** DIA-NN files → the 5-step SLURM chain; otherwise a single search. Previously `SKILL.md` merely suggested the chain "for roughly ≥8–10 files", leaving it to the model to notice.

Routing needs all four to hold:

| Condition | Why |
|---|---|
| engine is DIA-NN | the chain is DIA-NN-specific |
| more than `--parallel-threshold` files (default 5) | below that, library prediction + two array round-trips cost more than they save |
| SLURM present (`sbatch` on PATH) | steps 2 and 4 are job arrays |
| mass accuracy pinned in the cfg | steps 3/5 reuse `.quant` from 2/4 |

Anything unmet **falls back to a single search** rather than failing — the routing was our decision, not the user's — and the reason is printed and stored in `search_provenance.json` (`search_mode`, `parallel_routing_reason`). `--no-parallel` and `--parallel-threshold N` override.

## The mass-accuracy rule is now enforced

This precondition was documented but unchecked, and making routing automatic turns it load-bearing. Steps 3 and 5 reuse the `.quant` files from 2 and 4, so a cfg left on auto-calibration applies different tolerances between passes and yields a quietly wrong cross-run report — no crash, just bad numbers.

`diann_parallel.py` now refuses such a cfg outright (`--allow-auto-mass-acc` overrides for deliberate testing). `run_search.py` treats it as "don't parallelize" and names the fix: re-run `estimate_params.py` with the real instrument so it pins the DIA-NN recommended values, after which parallel enables itself. `mass_acc_status()` is the one definition of that rule, imported rather than duplicated.

## Verification

Exercised against stub files with a fake `sbatch` on PATH: routes at 6 and 20 files, holds single-shot at 1 and 5, declines without SLURM, declines on auto/absent mass accuracy, declines for Sage, and honors `--no-parallel` and a raised threshold. Confirmed the generated `step2` array is `0-6%20` and carries `--mass-acc 15 --mass-acc-ms1 15` into the step commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Msrj7b5cPXYz9Sn1FtJidB