### PR TITLE
fix(skill): unblock run_de.R on DIA-NN input, fix heatmap, add mouse timsTOF DIA workflow (v1.0.10)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/make_figures.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/make_figures.R
@@ -155,16 +155,23 @@ if (file.exists(em_path)) {
     } else pick <- head(pick[order(match(pick, rownames(Mi)))], top_n)
     H <- Mi[pick, , drop = FALSE]
     lab <- gene_label(em[match(rownames(H), em$Protein.Group), , drop = FALSE])
-    rownames(H) <- make.unique(ifelse(is.na(lab), rownames(H), lab))
+    lab <- ifelse(is.na(lab), rownames(H), lab)
+    # Semicolon-joined protein groups (e.g. "H2ac12;H2ac13;H2ac15;...") overflow the
+    # device and clip the title and sample columns. Keep the first symbol, cap length.
+    lab <- vapply(strsplit(lab, ";"), function(x) x[1], character(1))
+    lab <- ifelse(nchar(lab) > 16, paste0(substr(lab, 1, 15), "~"), lab)
+    rownames(H) <- make.unique(lab)
     fn <- file.path(outdir, "heatmap_top.png")
     ann <- if (!is.null(grp)) data.frame(Group = grp, row.names = colnames(H)) else NA
     if (has_pheat) {
-      grDevices::png(fn, width = 1700, height = 2200, res = 200)
+      # pheatmap manages its own device; passing filename= avoids the clipped output
+      # produced by wrapping it in png()/dev.off().
       pheatmap::pheatmap(H, scale = "row", annotation_col = ann,
                          show_rownames = nrow(H) <= 60, show_colnames = TRUE,
+                         fontsize_row = 8, fontsize_col = 9,
                          main = sprintf("Top %d differential proteins (row z-score)", nrow(H)),
-                         color = grDevices::colorRampPalette(c("#4393c3", "white", "#d6604d"))(100))
-      grDevices::dev.off()
+                         color = grDevices::colorRampPalette(c("#4393c3", "white", "#d6604d"))(100),
+                         width = 11, height = 11, filename = fn)
     } else {  # base-R fallback heatmap
       grDevices::png(fn, width = 1700, height = 2200, res = 200)
       stats::heatmap(t(scale(t(H))), col = grDevices::colorRampPalette(c("#4393c3","white","#d6604d"))(100),

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
@@ -168,7 +168,14 @@ fit <- limma::eBayes(fit)
 
 # ---- write per-contrast results ---------------------------------------------
 gene_cols <- intersect(c("Genes", "Protein.Names"), names(genes))
-ann <- if (length(gene_cols)) genes[, c(if ("Protein.Group" %in% names(genes)) "Protein.Group", gene_cols), drop = FALSE] else NULL
+# limpa returns the protein identifier in rownames(genes), not as a column. Guarding
+# the merge key on its presence silently dropped it, so the merges below failed with
+# "'by' must specify a uniquely valid column" AFTER quantification had completed.
+ann <- if (length(gene_cols)) {
+  .a <- genes[, gene_cols, drop = FALSE]
+  .a$Protein.Group <- if ("Protein.Group" %in% names(genes)) as.character(genes$Protein.Group) else rownames(genes)
+  .a[, c("Protein.Group", gene_cols), drop = FALSE]
+} else NULL
 
 # Expression matrix (proteins x samples, log2) — feeds figures (PCA/heatmap) and
 # the report; mirrors DE-LIMP's Expression_Matrix.csv export.
@@ -183,7 +190,13 @@ all_sig <- list()
 for (cn in forms) {
   tt <- limma::topTable(fit, coef = cn, number = Inf, adjust.method = "BH")
   tt$Protein.Group <- rownames(tt)
-  if (!is.null(ann)) tt <- merge(tt, ann, by = "Protein.Group", all.x = TRUE, sort = FALSE)
+  # topTable() already carries fit$genes, so merging ann in wholesale produced
+  # Genes.x/Genes.y duplicates. Only bring across columns that aren't there yet.
+  if (!is.null(ann)) {
+    .miss <- setdiff(names(ann), c("Protein.Group", names(tt)))
+    if (length(.miss)) tt <- merge(tt, ann[, c("Protein.Group", .miss), drop = FALSE],
+                                   by = "Protein.Group", all.x = TRUE, sort = FALSE)
+  }
   tt <- tt[order(tt$adj.P.Val), ]
   fn <- file.path(outdir, sprintf("DE_%s_%s.csv", method, make.names(cn)))
   utils::write.csv(tt, fn, row.names = FALSE)

--- a/workflows/diann_timstof_dia_mouse/workflow.yaml
+++ b/workflows/diann_timstof_dia_mouse/workflow.yaml
@@ -1,0 +1,53 @@
+# =============================================================================
+# Validated workflow: DIA-NN, Bruker timsTOF dia-PASEF, mouse.
+# Default DE-LIMP path (limpa DPC-Quant + limma).
+#
+# Added because the registry had no mouse entry and no timsTOF DIA entry at all,
+# so mouse dia-PASEF data — the UC Davis short-course dataset — could not match
+# any workflow and fell through to bare estimator defaults.
+#
+# Provenance: parameters are the estimator's DIA-NN-recommended timsTOF values
+# (MS1/MS2 15 ppm), exercised end-to-end on 10 mouse dia-PASEF files (100 SPD,
+# timsTOF HT) on 2026-07-28. Values marked (CONFIRM) still need validation
+# against ground truth before this is treated as a site SOP.
+# =============================================================================
+id: diann_timstof_dia_mouse
+name: "DIA-NN — Bruker timsTOF dia-PASEF (mouse)"
+description: >
+  Library-free DIA-NN search of mouse dia-PASEF data acquired on a Bruker
+  timsTOF, followed by the limpa DPC-Quant + limma differential expression
+  pipeline. For cohorts of roughly 8 or more files, run the 5-step parallel
+  SLURM chain (diann_parallel.py) rather than a single job.
+
+match:
+  acquisition: DIA
+  instruments: ["timsTOF HT", "timsTOF Pro", "timsTOF Pro 2", "timsTOF SCP", "timsTOF Ultra"]
+  instrument_aliases: ["timstof", "tims"]   # lowercase substrings matched against detected name
+  organism: "Mus musculus"
+  organism_taxid: 10090                     # hard filter
+
+engine:
+  name: diann
+  version: "2.3.0"                          # pinned; acquire step installs/uses exactly this
+
+fasta:
+  uniprot_proteome: UP000000589             # mouse reference proteome
+  add_contaminants: true                    # append universal contaminants
+
+search:
+  estimate_params: true                     # timsTOF -> MS1/MS2 15 ppm via estimate_params.py
+  var_mods: ""                              # none for relative quant (DIA-NN recommendation)
+  # NOTE (CONFIRM): for UREA in-solution digests, consider adding carbamylation
+  # (+43.0058, peptide N-term and K). Urea decomposes to isocyanate at room
+  # temperature; leaving it unsearched silently loses urea-arm peptides and can
+  # masquerade as a sample-prep effect.
+
+de:
+  method: dpc                               # limpa DPC-Quant + limma (DE-LIMP default)
+  q_cutoff: 0.01
+  logfc: 1.0
+  adjp: 0.05
+
+notes:
+  - "Use diann_parallel.py for >=8 files; mass accuracy must be FIXED (not auto) for the chain."
+  - "Report protein counts from report.stats.tsv, not from the post-DPC matrix (which is complete by construction)."

--- a/workflows/index.json
+++ b/workflows/index.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "repo": "bsphinney/DE-LIMP",
-  "generated": "2026-06-17",
+  "generated": "2026-07-28",
   "workflows": [
     {
       "id": "diann_astral_dia_human",
@@ -45,6 +45,49 @@
         "dataset": "HeLa QC, 3 technical replicates (CONFIRM)",
         "notes": "Matches Proteomics Core DIA SOP (CONFIRM version). Auto mass accuracy."
       }
+    },
+    {
+      "id": "diann_timstof_dia_mouse",
+      "name": "DIA-NN — Bruker timsTOF dia-PASEF (mouse)",
+      "path": "workflows/diann_timstof_dia_mouse",
+      "match": {
+        "acquisition": "DIA",
+        "instruments": [
+          "timsTOF HT",
+          "timsTOF Pro",
+          "timsTOF Pro 2",
+          "timsTOF SCP",
+          "timsTOF Ultra"
+        ],
+        "instrument_aliases": [
+          "timstof",
+          "tims"
+        ],
+        "organism": "Mus musculus",
+        "organism_taxid": 10090
+      },
+      "engine": {
+        "name": "diann",
+        "version": "2.3.0"
+      },
+      "fasta": {
+        "uniprot_proteome": "UP000000589",
+        "add_contaminants": true
+      },
+      "search": {
+        "estimate_params": true,
+        "var_mods": "",
+        "param_overrides": {},
+        "params_file": null,
+        "extra_files": []
+      },
+      "de": {
+        "method": "dpc",
+        "q_cutoff": 0.01,
+        "logfc": 1.0,
+        "adjp": 0.05
+      },
+      "validated": {}
     },
     {
       "id": "sage_timstof_dda_human",


### PR DESCRIPTION
Found while running the pipeline end-to-end for the first time on mouse timsTOF dia-PASEF data — 10 files, 100 SPD, on HIVE as a short-course guest account.

## Blocking: `run_de.R` failed on every DIA-NN input

Two bugs in the annotation merge, the first fatal:

1. **Missing merge key.** Line 171 included `Protein.Group` in the annotation frame only *if* that column existed in limpa's `genes` object. limpa keeps the protein identifier in `rownames(genes)`, so the guard silently dropped the key — and lines 176/186 then merged *by* it, dying with `'by' must specify a uniquely valid column`. The failure lands **after** `dpcQuant` completes, so the expensive work is done and discarded. Now populated from `rownames(genes)` when the column is absent.

2. **Duplicate annotation columns.** `topTable()` already carries `fit$genes`, so re-merging `ann` produced `Genes.x`/`Genes.y` and `Protein.Names.x`/`.y` — nothing called `Genes` existed in the output for downstream code or students to read. Now only columns not already present are merged.

## `heatmap_top.png` rendered unusably

Semicolon-joined protein groups (`H2ac12;H2ac13;H2ac15;…`) overflowed the device, clipping the title and roughly half the sample columns. Labels are now reduced to the first gene symbol and capped at 16 characters, and `pheatmap` writes via `filename=` with an explicit size rather than being wrapped in `png()`/`dev.off()`, which was producing the clipped output.

## New workflow: `diann_timstof_dia_mouse`

The registry had **no mouse entry and no timsTOF DIA entry**, so mouse dia-PASEF data matched nothing and fell through to bare estimator defaults. The new workflow pins DIA-NN 2.3.0, mouse `UP000000589` + contaminants, and the estimator's timsTOF 15 ppm values. It carries a `CONFIRM` note about **urea carbamylation** — an unsearched, arm-specific chemical artefact that can masquerade as a sample-prep effect in in-solution urea digests.

## Validation

The two `run_de.R` fixes were applied live and the full pipeline then ran clean: 56,491 precursors → 4,785 protein groups across 10 files, DE completed, figures and provenance generated. A null-contrast check (splitting one group 2-vs-3, five times) returned **0 false positives**, so the DE machinery itself is sound.

## Not included here — follow-ups worth filing

- `qc_protein_counts.png` counts non-missing cells in the DPC matrix, which is complete by construction, so every bar is identical and real depth differences are invisible. DE-LIMP's own Data Completeness panel already does this correctly by splitting **detected vs inferred**; the skill should reuse that logic.
- The skill should emit a **DE-LIMP-loadable `.rds`** (`raw_data`, `metadata`, `fit`, `y_protein`, `dpc_fit`, `design`, `qc_stats`, `repro_log` — the `server_session.R` schema) so results drop straight into the GUI.
- Thresholding uses BH against H0: log2FC = 0 and *then* filters on `|log2FC| >= 1`, which does not control FDR for the composite null actually reported. On this dataset `treat(lfc = 1)` gives **241** significant vs **1,372** from the post-hoc filter. `topTreat` should be an option.
- Group colours are inconsistent between figures (PCA vs heatmap).
- Nothing warns when a small selection is drawn from a much larger cohort; here 5 of 31 beads replicates happened to sit at the 12th percentile for tightness, which materially inflated an apparent reproducibility difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4E3rNmy5noGLyiJL9RWv5