### PR TITLE
feat(skill): DE-LIMP session .rds, detected-vs-inferred QC, figures in .docx (v1.0.11)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/make_figures.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/make_figures.R
@@ -114,6 +114,35 @@ if (file.exists(em_path)) {
     add_fig(fn, "qc", "Proteins quantified per sample — a loading/QC check. Large differences between samples (or systematic differences between groups) flag uneven input or sample-quality problems.")
   }, error = function(e) message("[figures] QC counts failed: ", e$message))
 
+  # ---- detected vs inferred (the QC view that actually works after DPC) ----
+  # The plot above counts non-missing cells, but a DPC matrix is complete by
+  # construction, so every bar comes out identical and real depth differences
+  # are invisible. run_de.R writes QC_detected_vs_inferred.csv for this reason;
+  # plot it when present. Mirrors DE-LIMP's Data Completeness panel.
+  tryCatch({
+    qcf <- file.path(de_dir, "QC_detected_vs_inferred.csv")
+    if (file.exists(qcf)) {
+      q <- utils::read.csv(qcf, stringsAsFactors = FALSE, check.names = FALSE)
+      q <- q[order(q$Detected), ]
+      long <- rbind(
+        data.frame(Sample = q$Sample, n = q$Detected, Kind = "Detected"),
+        data.frame(Sample = q$Sample, n = q$Inferred, Kind = "Inferred"))
+      long$Sample <- factor(long$Sample, levels = q$Sample)
+      long$Kind   <- factor(long$Kind, levels = c("Detected", "Inferred"))
+      p2 <- ggplot2::ggplot(long, ggplot2::aes(n, Sample, fill = Kind)) +
+        ggplot2::geom_col(width = 0.72) +
+        ggplot2::scale_fill_manual(values = c(Detected = "#12866f", Inferred = "#e8a33d")) +
+        ggplot2::labs(title = "Detected vs inferred proteins per sample",
+                      subtitle = "Inferred values come from the DPC detection model, not measurement",
+                      x = "proteins", y = NULL, fill = NULL) +
+        ggplot2::theme_minimal(base_size = 11) +
+        ggplot2::theme(legend.position = "top")
+      fn2 <- file.path(outdir, "qc_detected_vs_inferred.png")
+      ggsave(fn2, p2, width = 9, height = max(3, 0.34 * nrow(q) + 1.6), dpi = 200)
+      add_fig(fn2, "qc", sprintf("Detected vs inferred proteins per sample (%.0f%%-%.0f%% detected). Detected means at least one precursor was actually observed in that run; inferred means the value came from the DPC detection-probability model. Samples with a large inferred fraction contribute weaker evidence, and fold-changes for proteins inferred in one whole group should be read as detection events rather than magnitudes.", min(q$PctDetected), max(q$PctDetected)))
+    }
+  }, error = function(e) message("[figures] detected/inferred QC failed: ", e$message))
+
   # complete-ish matrix for PCA/heatmap: keep proteins seen in all samples; if too
   # few, mean-impute per protein (PCA/heatmap need no NAs).
   complete <- M[rowSums(is.na(M)) == 0, , drop = FALSE]

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
@@ -271,5 +271,68 @@ prov <- list(
 )
 writeLines(jsonlite_or_manual(prov), file.path(outdir, "de_provenance.json"))
 
+# ---- detected vs inferred QC ------------------------------------------------
+# DPC models missing precursors rather than leaving holes, so the protein matrix
+# is complete BY CONSTRUCTION. Counting non-missing cells therefore reports the
+# same number for every sample and hides real depth differences. The meaningful
+# split is detected (>=1 precursor actually observed in that run) vs inferred
+# (value supplied by the detection-probability model) — the same view DE-LIMP's
+# Data Completeness panel shows.
+qc_di <- NULL
+if (method == "dpc" && exists("dat") && exists("y_protein")) {
+  tryCatch({
+    prot <- as.character(dat$genes[["Protein.Group"]])
+    if (is.null(prot) || !length(prot)) prot <- rownames(dat$E)
+    detm <- rowsum((!is.na(dat$E)) * 1, group = prot, reorder = TRUE) > 0
+    ii   <- match(rownames(E), rownames(detm))
+    det  <- matrix(FALSE, nrow(E), ncol(E), dimnames = list(rownames(E), colnames(E)))
+    ok   <- !is.na(ii)
+    det[ok, ] <- as.matrix(detm)[ii[ok], , drop = FALSE]
+
+    qc_di <- data.frame(
+      Sample   = colnames(E),
+      Group    = if (exists("groups")) as.character(groups) else NA_character_,
+      Detected = colSums(det),
+      Inferred = nrow(E) - colSums(det),
+      Total    = nrow(E),
+      stringsAsFactors = FALSE
+    )
+    qc_di$PctDetected <- round(100 * qc_di$Detected / qc_di$Total, 1)
+    qc_di$PctInferred <- round(100 * qc_di$Inferred / qc_di$Total, 1)
+    qc_di <- qc_di[order(-qc_di$Detected), ]
+    utils::write.csv(qc_di, file.path(outdir, "QC_detected_vs_inferred.csv"), row.names = FALSE)
+    message(sprintf("[run_de] QC_detected_vs_inferred.csv: %.0f%%-%.0f%% detected across samples",
+                    min(qc_di$PctDetected), max(qc_di$PctDetected)))
+  }, error = function(e) message("[run_de] detected/inferred QC skipped: ", e$message))
+}
+
+# ---- DE-LIMP-loadable session ----------------------------------------------
+# Everything the DE-LIMP Shiny app needs is already in memory here. Writing it in
+# server_session.R's schema lets any result be dropped straight into the GUI at
+# https://delimp.stan-proteomics.org/ for interactive exploration.
+if (method == "dpc" && exists("dat") && exists("y_protein")) {
+  tryCatch({
+    session_data <- list(
+      raw_data     = dat,
+      metadata     = meta,
+      fit          = fit,
+      y_protein    = y_protein,
+      dpc_fit      = if (exists("dpcfit")) dpcfit else NULL,
+      design       = design,
+      qc_stats     = list(detected_vs_inferred = qc_di),
+      repro_log    = NULL,
+      contrast     = paste(forms, collapse = ","),
+      logfc_cutoff = logfc_thr,
+      q_cutoff     = adjp_thr,
+      saved_at     = Sys.time(),
+      app_version  = "DE-LIMP v2.5"
+    )
+    rds <- file.path(outdir, "DE-LIMP_session.rds")
+    saveRDS(session_data, rds)
+    message(sprintf("[run_de] DE-LIMP_session.rds (%.1f MB) — load at https://delimp.stan-proteomics.org/",
+                    file.size(rds) / 1e6))
+  }, error = function(e) message("[run_de] DE-LIMP session not written: ", e$message))
+}
+
 message("\n[run_de] done. Results + provenance (methods.txt, sessionInfo.txt, de_provenance.json) in ",
         normalizePath(outdir))

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/to_docx.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/to_docx.py
@@ -20,9 +20,16 @@ def via_pandoc(md_path, out_path):
     pandoc = shutil.which("pandoc")
     if not pandoc:
         return False
+    # Figures are referenced relatively (e.g. figures/pca.png). Without a resource
+    # path pandoc silently drops them, producing a text-only .docx. Resolve against
+    # the markdown's own directory and its figures/ subdirectory.
+    base = os.path.dirname(os.path.abspath(md_path)) or "."
+    rpath = os.pathsep.join([base, os.path.join(base, "figures")])
     try:
         subprocess.run([pandoc, md_path, "-o", out_path, "--from", "gfm",
-                        "--standalone"], check=True, capture_output=True, text=True)
+                        "--standalone", "--toc", "--toc-depth=2",
+                        "--number-sections", f"--resource-path={rpath}"],
+                       check=True, capture_output=True, text=True)
         return os.path.exists(out_path)
     except subprocess.CalledProcessError as e:
         sys.stderr.write(f"[to_docx] pandoc failed ({e.stderr.strip()[:200]}); using fallback\n")


### PR DESCRIPTION
Implements the three follow-ups flagged in #16, all requested directly.

**`DE-LIMP_session.rds`** — everything the Shiny app needs is already in memory at the end of `run_de.R`. Written in `server_session.R`'s schema so results drop straight into https://delimp.stan-proteomics.org/.

**Detected vs inferred QC** — a DPC matrix is complete by construction, so the old `qc_protein_counts.png` drew ten identical bars and hid a 3,110-vs-4,226 protein depth difference. The honest split is detected (>=1 precursor observed in that run) vs inferred (from the detection model). Reproduces DE-LIMP's Data Completeness panel exactly — verified against the GUI on a 10-file mouse cohort (4558/227 … 2703/2082).

**Figures in the .docx** — relative image paths never resolved because pandoc had no `--resource-path`, so every Word export was silently text-only. Fixed, plus a numbered TOC. A real report went from 25 KB to 491 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4E3rNmy5noGLyiJL9RWv5