### PR TITLE
fix(skill): drop the fold-change cutoff; label the fold change on the volcano (v1.0.13)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.10",
+  "version": "1.0.12",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.10",
+      "version": "1.0.12",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.10",
+  "version": "1.0.12",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -361,6 +361,17 @@ Produces publication-quality volcano (per contrast), PCA, heatmap of top protein
 p-value distributions, and a per-sample protein-count QC plot, plus `figures.json`
 (captions). These get embedded in the report.
 
+**Significance is `adj.P.Val` alone — there is no fold-change cutoff anywhere in this
+pipeline.** `--logfc` only positions a labelled reference line on the volcano. Never
+re-impose it when you count, rank, or describe significant proteins, and never justify a
+result by "it's ≥2-fold". The moderated t-test tested H0: log2FC = 0, so that is the only
+claim the FDR covers; filtering the list on the observed fold change afterwards would
+report a stronger claim than the error rate supports, because an observed fold change is
+a point estimate with no uncertainty attached. (Testing a fold-change threshold properly
+needs `limma::treat()`'s interval null — McCarthy & Smyth 2009 — not a post-hoc cut.) You
+may report how many significant proteins also exceed the reference line, as a description
+of effect size.
+
 ### 8c. Audit the results for common mistakes (surface every issue)
 ```
 python3 scripts/audit_results.py --out AUDIT.md --conditions ./conditions.csv \

--- a/skill/ucdavis-proteomics-core-pipeline/references/audit.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/audit.md
@@ -36,6 +36,7 @@ matter most. It complements DE-LIMP's architectural rules (no fabricated values;
 pipeline self-describes) and its "Error handling & UX audit" review.
 
 ## Tuning
-`--adjp` / `--logfc` should match the DE thresholds; `--min-proteins` and
+`--adjp` should match the DE significance cutoff and `--logfc` the volcano's reference
+line (it is counted descriptively, never used to call significance); `--min-proteins` and
 `--max-missing` are soft thresholds — adjust for very small samples or enriched
 fractions (e.g. a phospho or secretome experiment legitimately quantifies fewer).

--- a/skill/ucdavis-proteomics-core-pipeline/references/de-analysis.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/de-analysis.md
@@ -14,6 +14,18 @@ Rscript scripts/run_de.R --input report.parquet --metadata conditions.csv \
 match the `Run` / column names in the report. Default contrasts = every group vs
 the first factor level.
 
+**`--logfc` is a reference line, not a filter.** Significance is `adj.P.Val < --adjp`
+(BH) and nothing else. `--logfc` is drawn and labelled on the volcano so a reader can see
+effect size, and it is reported descriptively ("N of the significant proteins are also
+≥2-fold"), but it never removes a protein from the significant set. This keeps the
+reported claim identical to the hypothesis `eBayes`/`topTable` actually tested
+(H0: log2FC = 0). A post-hoc `|logFC|` cut would assert "changed by at least Nx" while
+the FDR only covers "changed at all" — and because the observed fold change is a point
+estimate, proteins whose true effect is below the line pass it routinely. If a genuine
+fold-change threshold is ever wanted, use `limma::treat()` + `topTreat()`, whose interval
+null tests it properly; note that `treat` is far more stringent than the same cut applied
+post hoc, so limma recommends a *small* threshold there (fc 1.1–1.5, not 2).
+
 ## `--method dpc` (limpa DPC-Quant + limma) — DE-LIMP default, use with DIA-NN
 ```r
 dat <- limpa::readDIANN("report.parquet", format="parquet", q.cutoffs=0.01)

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/analysis_prompt.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/analysis_prompt.py
@@ -97,7 +97,14 @@ def main():
         w(f"- Missing values: {missing_policy}")
     if citation:
         w(f"- Citation: {citation}")
-    w(f"- Significance thresholds used: adj.P.Val < {adjp} and |logFC| ≥ {lfc} (ID FDR q ≤ {q_cut}).")
+    w(f"- Significance rule: adj.P.Val < {adjp} (Benjamini-Hochberg) — the adjusted p-value "
+      f"ALONE (ID FDR q ≤ {q_cut}). **No fold-change filter is applied.** |log2FC| = {lfc} "
+      f"({2**float(lfc):.3g}-fold) is drawn on the volcano as a reference line only.")
+    w("- Do not re-impose a fold-change cutoff when you count or describe significant "
+      "proteins, and never call a result significant \"because it is ≥2-fold\". The test "
+      "was of H0: fold change = 0, so that is the claim the error rate covers. You may say "
+      "how many significant proteins also exceed the reference line — as a description of "
+      "effect size, not as a second significance criterion.")
     w("- The exact, self-describing methods text is in `tables/methods.txt` — do not "
       "contradict it or invent a different pipeline.")
     w("")
@@ -116,7 +123,7 @@ def main():
         w(f"- `{a.gsea}` — Gene Set Enrichment results.")
     w("")
     w("Compute everything you cite directly from these files: significant proteins per "
-      f"contrast (apply adj.P.Val < {adjp} and |logFC| ≥ {lfc}), up/down splits, the "
+      f"contrast (apply adj.P.Val < {adjp} only), up/down splits, the "
       "top up/down proteins by fold change, proteins significant in ≥2 contrasts, and — "
       "from the expression matrix + conditions — the most stable proteins (lowest CV "
       "across replicates). Use gene names where available. **Never fabricate a value, "

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/audit_results.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/audit_results.py
@@ -171,7 +171,7 @@ def audit_de(findings, de_dir, adjp, logfc):
     for f in sorted(glob.glob(os.path.join(de_dir, "DE_*.csv"))):
         rows = read_csv(f)
         ct = os.path.basename(f)
-        n = sig = 0
+        n = sig = beyond = 0
         for r in rows:
             try:
                 a = float(r.get("adj.P.Val", "nan")); l = float(r.get("logFC", "nan"))
@@ -180,21 +180,27 @@ def audit_de(findings, de_dir, adjp, logfc):
             if a != a:  # nan
                 continue
             n += 1
-            if a < adjp and abs(l) >= logfc:
+            # Significance is the adjusted p-value alone -- the same rule run_de.R and the
+            # figures use. |logFC| is only counted descriptively, for the report.
+            if a < adjp:
                 sig += 1
+                if abs(l) >= logfc:
+                    beyond += 1
         if n == 0:
             continue
         frac = sig / n
         if sig == 0:
             add(findings, "de_signal", "WARN",
-                f"{ct}: 0 proteins significant (adj.P<{adjp}, |logFC|≥{logfc}). The experiment may be "
+                f"{ct}: 0 proteins significant (adj.P<{adjp}). The experiment may be "
                 "underpowered, the effect small, or the groups mislabeled.")
         elif frac > 0.5:
             add(findings, "de_signal", "WARN",
                 f"{ct}: {sig}/{n} ({frac*100:.0f}%) proteins significant — implausibly high. This usually "
                 "means a batch effect, a normalization problem, or confounded/mislabeled groups, not real biology.")
         else:
-            add(findings, "de_signal", "PASS", f"{ct}: {sig}/{n} proteins significant ({frac*100:.0f}%).")
+            add(findings, "de_signal", "PASS",
+                f"{ct}: {sig}/{n} proteins significant at adj.P<{adjp} ({frac*100:.0f}%); "
+                f"{beyond} of those are also ≥{2**logfc:.3g}-fold.")
 
 
 def main():

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/make_figures.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/make_figures.R
@@ -21,7 +21,9 @@ de_dir   <- getone("--de-dir", "output/tables")
 cond_path<- getone("--conditions")
 outdir   <- getone("--outdir", "output/figures")
 adjp_thr <- as.numeric(getone("--adjp", "0.05"))
-logfc_thr<- as.numeric(getone("--logfc", "1"))
+# Reference line only -- drawn and labelled on the volcano, never used to call
+# significance. See the note in run_de.R: significance is the BH adjusted p-value alone.
+logfc_ref<- as.numeric(getone("--logfc", "1"))
 top_n    <- as.integer(getone("--top", "50"))
 dir.create(outdir, showWarnings = FALSE, recursive = TRUE)
 
@@ -38,7 +40,10 @@ add_fig <- function(file, type, caption) figs[[length(figs) + 1]] <<- list(file 
 THEME <- theme_bw(base_size = 13) + theme(panel.grid.minor = element_blank(),
                                           plot.title = element_text(face = "bold"))
 gene_label <- function(df) {
-  g <- if ("Genes" %in% names(df)) df$Genes else NA
+  # Must be one value PER ROW: a bare NA makes ifelse() return a single element, and the
+  # caller's rownames(H) <- ... then dies with "dimnames [1] not equal to array extent".
+  # run_de.R omits Genes whenever the report carries no annotation, so this is reachable.
+  g <- if ("Genes" %in% names(df)) df$Genes else rep(NA_character_, nrow(df))
   ifelse(is.na(g) | g == "", df$Protein.Group, g)
 }
 
@@ -51,7 +56,7 @@ for (f in de_files) {
   tryCatch({
     d <- utils::read.csv(f, stringsAsFactors = FALSE, check.names = FALSE)
     d <- d[is.finite(d$logFC) & is.finite(d$adj.P.Val), ]
-    d$sig <- ifelse(d$adj.P.Val < adjp_thr & abs(d$logFC) >= logfc_thr,
+    d$sig <- ifelse(d$adj.P.Val < adjp_thr,
                     ifelse(d$logFC > 0, "Up", "Down"), "NS")
     d$lab <- gene_label(d)
     nlogp <- -log10(pmax(d$adj.P.Val, .Machine$double.xmin))
@@ -60,17 +65,27 @@ for (f in de_files) {
     p <- ggplot(d, aes(logFC, nlogp, color = sig)) +
       geom_point(alpha = 0.6, size = 1.4) +
       scale_color_manual(values = c(Up = "#d6604d", Down = "#4393c3", NS = "grey75"), name = NULL) +
-      geom_vline(xintercept = c(-logfc_thr, logfc_thr), linetype = "dashed", color = "grey50") +
+      geom_vline(xintercept = c(-logfc_ref, logfc_ref), linetype = "dashed", color = "grey50") +
       geom_hline(yintercept = -log10(adjp_thr), linetype = "dashed", color = "grey50") +
+      # Sit the labels at the FOOT of each line, tucked inward (hjust 0 = extend right of
+      # the left line, 1 = extend left of the right line). Anchoring them at the top
+      # collided with the repelled point labels and clipped at the panel edge.
+      annotate("text", x = c(-logfc_ref, logfc_ref), y = min(nlogp, na.rm = TRUE),
+               label = sprintf("%.3g-fold", 2^logfc_ref), hjust = c(-0.12, 1.12),
+               vjust = -0.6, size = 2.9, color = "grey40") +
       labs(title = paste0("Volcano — ", ct),
-           subtitle = sprintf("%d up, %d down (adj.P<%.2g, |logFC|>=%.2g)",
-                              sum(d$sig == "Up"), sum(d$sig == "Down"), adjp_thr, logfc_thr),
+           subtitle = sprintf("%d up, %d down at adj.P < %.2g; dashed lines mark %.3g-fold (reference, not a cutoff)",
+                              sum(d$sig == "Up"), sum(d$sig == "Down"), adjp_thr, 2^logfc_ref),
            x = "log2 fold change", y = "-log10 adjusted p-value") + THEME
     if (has_repel && nrow(top)) p <- p + ggrepel::geom_text_repel(
       data = top, aes(label = lab), size = 3, max.overlaps = 20, show.legend = FALSE)
     fn <- file.path(outdir, sprintf("volcano_%s.png", make.names(ct)))
     ggsave(fn, p, width = 7, height = 6, dpi = 200)
-    add_fig(fn, "volcano", sprintf("Volcano plot for %s: log2 fold change vs significance; coloured points pass adj.P<%.2g and |logFC|>=%.2g.", ct, adjp_thr, logfc_thr))
+    add_fig(fn, "volcano", sprintf(paste("Volcano plot for %s: log2 fold change vs significance.",
+      "Coloured points are significant at adj.P < %.2g (Benjamini-Hochberg); no fold-change",
+      "filter is applied. Vertical dashed lines mark %.3g-fold for reference only, so a",
+      "coloured point inside them is a confidently measured small change, not an error."),
+      ct, adjp_thr, 2^logfc_ref))
 
     if ("P.Value" %in% names(d)) {
       pp <- ggplot(d, aes(P.Value)) +
@@ -142,17 +157,26 @@ if (file.exists(em_path)) {
 
   # ---- heatmap of top differential proteins ----
   tryCatch({
-    sig_ids <- character(0)
+    # Rank by strength of evidence (smallest adjusted p across contrasts). Selecting by
+    # matrix row order instead would make "top differential proteins" an arbitrary slice
+    # of the significant set -- which matters more now that no fold-change filter thins it.
+    best_p <- numeric(0)
     for (f in de_files) {
       d <- utils::read.csv(f, stringsAsFactors = FALSE, check.names = FALSE)
       d <- d[is.finite(d$adj.P.Val) & is.finite(d$logFC), ]
-      s <- d$Protein.Group[d$adj.P.Val < adjp_thr & abs(d$logFC) >= logfc_thr]
-      sig_ids <- union(sig_ids, s)
+      d <- d[d$adj.P.Val < adjp_thr, , drop = FALSE]
+      if (!nrow(d)) next
+      v <- stats::setNames(d$adj.P.Val, d$Protein.Group)
+      shared <- intersect(names(v), names(best_p))
+      if (length(shared)) best_p[shared] <- pmin(best_p[shared], v[shared])
+      new <- setdiff(names(v), names(best_p))
+      if (length(new)) best_p <- c(best_p, v[new])
     }
-    pick <- intersect(sig_ids, rownames(Mi))
+    sig_ids <- names(sort(best_p))              # most significant first
+    pick <- intersect(sig_ids, rownames(Mi))    # intersect() preserves sig_ids' order
     if (length(pick) < 5) {  # fall back to most-variable proteins
       v <- apply(Mi, 1, var); pick <- names(sort(v, decreasing = TRUE))[seq_len(min(top_n, nrow(Mi)))]
-    } else pick <- head(pick[order(match(pick, rownames(Mi)))], top_n)
+    } else pick <- head(pick, top_n)
     H <- Mi[pick, , drop = FALSE]
     lab <- gene_label(em[match(rownames(H), em$Protein.Group), , drop = FALSE])
     lab <- ifelse(is.na(lab), rownames(H), lab)

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/provenance.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/provenance.py
@@ -349,7 +349,8 @@ This bundle contains everything needed to reproduce the analysis.
 - id: `{wf_id}`
 - registry: {REGISTRY_LINE(reg)}
 - engine: {(wfman or {}).get('engine')}
-- DE: method=`{a.de_method}`, contrasts=`{a.contrasts}`, q≤{a.q_cutoff}, |logFC|≥{a.logfc}, adj.P<{a.adjp}
+- DE: method=`{a.de_method}`, contrasts=`{a.contrasts}`, q≤{a.q_cutoff}, adj.P<{a.adjp}
+  (significance is the BH adjusted p-value alone; |logFC|={a.logfc} is a volcano reference line, not a filter)
 - query: acquisition=`{a.acquisition}`, organism_taxid=`{a.organism_taxid}`, instrument=`{a.instrument}`
 
 ## How to reproduce

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
@@ -57,7 +57,14 @@ q_cutoff  <- as.numeric(getarg("--q-cutoff", "0.01"))
 eq_cutoff <- as.numeric(getarg("--eq-cutoff", "0"))
 pgq_cutoff<- as.numeric(getarg("--pgq-cutoff", "0"))
 outdir    <- getarg("--outdir", "de_results")
-logfc_thr <- as.numeric(getarg("--logfc", "1.0"))
+# --logfc is a REFERENCE LINE ONLY -- it is drawn and labelled on the volcano and never
+# filters anything. Significance is the BH-adjusted p-value alone, which is the exact
+# hypothesis eBayes/topTable tested (true logFC != 0). Filtering that list on the
+# observed |logFC| afterwards would report a stronger claim ("changed by at least Nx")
+# than the error rate covers, since the observed fold change is a point estimate carrying
+# no uncertainty. Testing a fold-change threshold properly needs limma::treat()'s interval
+# null, not a post-hoc cut (McCarthy & Smyth 2009).
+logfc_ref <- as.numeric(getarg("--logfc", "1.0"))
 adjp_thr  <- as.numeric(getarg("--adjp", "0.05"))
 
 if (is.null(input) || is.null(meta_path))
@@ -200,10 +207,11 @@ for (cn in forms) {
   tt <- tt[order(tt$adj.P.Val), ]
   fn <- file.path(outdir, sprintf("DE_%s_%s.csv", method, make.names(cn)))
   utils::write.csv(tt, fn, row.names = FALSE)
-  sig <- subset(tt, !is.na(adj.P.Val) & adj.P.Val < adjp_thr & abs(logFC) >= logfc_thr)
+  sig <- subset(tt, !is.na(adj.P.Val) & adj.P.Val < adjp_thr)
   all_sig[[cn]] <- nrow(sig)
-  message(sprintf("[run_de] %-20s  %d proteins, %d significant (adj.P<%.2g, |logFC|>=%.2g) -> %s",
-                  cn, nrow(tt), nrow(sig), adjp_thr, logfc_thr, basename(fn)))
+  n_beyond <- sum(abs(sig$logFC) >= logfc_ref, na.rm = TRUE)   # descriptive, not a filter
+  message(sprintf("[run_de] %-20s  %d proteins, %d significant (adj.P<%.2g); %d of those with |logFC|>=%.2g -> %s",
+                  cn, nrow(tt), nrow(sig), adjp_thr, n_beyond, logfc_ref, basename(fn)))
 }
 
 # ---- methods + reproducibility provenance -----------------------------------
@@ -219,7 +227,10 @@ methods_txt <- c(
                           sprintf("Normalization : DPC-CN (applied within dpcCN before dpcQuant)"),
   sprintf("Design        : ~ 0 + %s", paste(formula_parts, collapse = " + ")),
   sprintf("Contrasts     : %s", paste(forms, collapse = ", ")),
-  sprintf("Thresholds    : adj.P.Val < %.3g and |logFC| >= %.3g", adjp_thr, logfc_thr),
+  sprintf("Significance  : adj.P.Val < %.3g (Benjamini-Hochberg), moderated t-test of", adjp_thr),
+  "                H0: log2 fold change = 0. No fold-change filter is applied --",
+  sprintf("                |log2FC| = %.3g is drawn on the volcano for reference only, so", logfc_ref),
+  "                the reported error rate matches the hypothesis actually tested.",
   "",
   sprintf("Citation      : %s", descriptor$citation)
 )
@@ -260,7 +271,8 @@ prov <- list(
   rollup_method = descriptor$rollup_method, de_engine = descriptor$de_engine,
   missing_policy = descriptor$missing_policy, citation = descriptor$citation,
   method = method, q_cutoff = q_cutoff, eq_cutoff = eq_cutoff, pgq_cutoff = pgq_cutoff,
-  logfc = logfc_thr, adjp = adjp_thr,
+  logfc = logfc_ref, logfc_role = "reference_line_only", adjp = adjp_thr,
+  significance_rule = "adj.P.Val < adjp (BH); no fold-change filter",
   design = paste0("~ 0 + ", paste(formula_parts, collapse = " + ")),
   contrasts = forms, n_samples = nrow(meta), groups = as.list(table(groups)),
   significant_per_contrast = all_sig,


### PR DESCRIPTION
Resolves the FDR issue flagged as a follow-up in #16.

## The problem

`run_de.R` tested `H0: log2FC = 0` via `eBayes`/`topTable`, then filtered the result on `abs(logFC) >= 1`. Those are two different questions. The BH-adjusted p-value guarantees that ~5% of the listed proteins have a true fold change of zero; the list handed to the customer claims something stronger — *changed, and by at least 2-fold* — which nothing tested.

It fails in the permissive direction. An observed fold change is a point estimate carrying no uncertainty, so a low-variance protein with a true effect of 1.3-fold and an observed 2.05-fold passes the filter and is never counted as an error. On the mouse cohort in #16 the post-hoc cut returned **1,372** proteins where `treat(lfc = 1)` returned **241**.

## The fix

Per Brett's call: remove the cutoff rather than adopt `treat()`. Significance is the BH-adjusted p-value alone, so the reported claim and the controlled error rate are the same statement. The fold change becomes a **labelled reference line on the volcano** and a descriptive count ("N of the significant proteins are also ≥2-fold"), never a filter.

This also sidesteps a trap in the `treat()` route: its interval null is considerably more rigorous than the same threshold applied post hoc, so limma recommends a *small* threshold there (fc 1.1–1.5, not 2). Moving `logfc = 1.0` straight into `treat(lfc = 1)` would have been far stricter than what the pipeline reports today.

`--logfc` is retained as the reference line and updated in lockstep everywhere so nothing re-imposes it: `run_de.R` (significance, methods text, provenance), `make_figures.R` (volcano colouring and labelled lines, heatmap selection), `audit_results.py`, `analysis_prompt.py`, `provenance.py`, `SKILL.md`, `de-analysis.md`, `audit.md`.

## Two bugs found while testing this path

- **`gene_label()` killed the heatmap on unannotated data.** With no `Genes` column it set `g <- NA` (length 1), so `ifelse()` returned one value instead of one per row and `rownames(H) <- ...` died with `dimnames [1] not equal to array extent`. `run_de.R` omits `Genes` whenever the report carries no annotation, so any such dataset silently lost its heatmap. Reproduced against the pre-change code — not caused by this work.
- **The heatmap's "top differential proteins" were arbitrary.** Selection was by matrix row order, not by evidence. Now ranked by smallest adjusted p across contrasts, which matters more now that no fold-change filter thins the pool.

## Verification

Ran end to end on synthetic data deliberately containing significant-but-small-effect proteins — the population the old filter discarded. The volcano renders with both reference lines labelled and unclipped (label placement was corrected after inspecting the render), the heatmap renders at all now (5 figures, previously 4), and the audit reports `24/2000 proteins significant at adj.P<0.05 (1%); 14 of those are also ≥2-fold`.

## Merge order

Takes **v1.0.12** because #15 is open at v1.0.11. **Merge #15 first.** If merged in the other order, #15 must be re-bumped to 1.0.13 so main's version never goes backwards — the same collision that #14 and #16 hit silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Msrj7b5cPXYz9Sn1FtJidB