### PR TITLE
feat(skill): live progress + stage narration while a search runs (v1.0.14)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -328,10 +328,24 @@ python3 scripts/run_search.py --tools ~/.proteomics-pipeline/tools/tools.json \
 unmonitored.** Poll with `watch_run.sh` in a loop until it finishes:
 ```
 # local: python3 scripts/run_search.py ... run_in_background, then loop:
-bash scripts/watch_run.sh --log <search log>
+bash scripts/watch_run.sh --log <search log> --out <search out dir> --poll <n>
 # SLURM on HIVE:
-bash scripts/watch_run.sh --slurm <jobid> --log <job log> --hive   # (HIVE_USER/HIVE_KEY set)
+bash scripts/watch_run.sh --slurm <jobid> --log <job log> --out <out> --poll <n> --hive
 ```
+**Always pass `--out` and increment `--poll` each time.** `--out` is what turns "still
+running" into real progress: the chain drops a `.quant` per finished file, so the watcher
+reports the actual step and file count rather than guessing. `--poll` rotates the note.
+
+**Report progress to the user on every poll — a search is hours long and silence reads as
+a hang.** Give them one short line from `progress.summary` plus `doing`, and pass along
+`note` (with `note_source`) so there's something to read while waiting. For example:
+
+> Step 2 of 5 — searching each file against the predicted library. 34 of 66 files done
+> (52%). *While you wait: decoy sequences exist to be wrong on purpose. How often a search
+> prefers a decoy is what calibrates the false discovery rate. (Elias & Gygi 2007)*
+
+Keep it to a couple of lines; don't dump the JSON. Never present the note as a finding
+about **their** data — it is general background, and it must not be mistaken for a result.
 It returns `{state, done, failed, stalled, error_class, fix}`. While `done` is false,
 keep polling (sleep ~60s between polls; for long SLURM jobs use a scheduled wake-up).
 Pass `--log` so it can also catch **stalls** — a job stuck in `RUNNING` with its log

--- a/skill/ucdavis-proteomics-core-pipeline/references/watcher.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/watcher.md
@@ -88,3 +88,32 @@ any auto-fix you applied to the user.
 - **A job's SLURM State=COMPLETED does NOT mean the tool succeeded.** If the sbatch's last
   line is `echo ...` (exit 0), FragPipe/DIA-NN can crash yet the job shows COMPLETED. Verify
   the expected OUTPUT file exists (`report.parquet`, `combined_peptide.tsv`), not just the state.
+
+## Progress reporting (`--out`, `--poll`)
+
+`--out <search out dir>` makes the watcher report **real** progress instead of "still
+running". It counts what the 5-step chain leaves on disk — one `.quant` per finished file —
+and infers the stage from which artefacts exist:
+
+| Present in `--out` | Reported stage |
+|---|---|
+| nothing yet | step 1/5, library prediction |
+| `step1.predicted.speclib` | step 2/5, first pass — progress = `quant_step2/*.quant` ÷ `file_list.txt` |
+| all first-pass `.quant` present | step 3/5, empirical assembly |
+| `empirical.parquet` | step 4/5, final pass — progress = `quant_step4/*.quant` |
+| `report.parquet` | step 5/5, done |
+
+Emptiness counts as absent (`test -s`), so a zero-byte or truncated output is not mistaken
+for a finished step. All checks run through the same `run()` helper, so they work over SSH
+on HIVE exactly as locally. Without `--out` the watcher behaves as before.
+
+`--poll <n>` is a counter you increment each poll. It rotates the stage explanation's
+companion note (`pipeline_notes.py`) so a multi-hour search does not repeat itself; notes
+relevant to the current stage come first, then the rest of the list.
+
+**Relay `progress.summary` + `doing` to the user every poll**, and pass `note` along with
+its `note_source`. Silence during a multi-hour search reads as a hang. The note is general
+background — never present it as a finding about the user's data.
+
+Every fact in `pipeline_notes.py` carries a `source`. If you add one and cannot attribute
+it, do not add it.

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/pipeline_notes.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/pipeline_notes.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+pipeline_notes.py  --  What the pipeline is doing right now, in plain language, plus a
+rotating proteomics note to read while a multi-hour search grinds away.
+
+watch_run.sh calls this each poll and folds the result into its JSON, so the orchestrator
+can tell the user something true and specific instead of "still running" for four hours.
+
+Every FACT below carries a `source`. Nothing here is invented: if a claim could not be
+attributed it did not go in. Prefer qualitative statements over numbers -- a number the
+user cannot check is worse than no number (DE-LIMP architectural rule #2).
+
+Usage:
+  python3 pipeline_notes.py --stage step2 --index 7
+  python3 pipeline_notes.py --stage de --index 0 --no-fact
+"""
+import argparse, json
+
+# --- what is happening, and why it takes as long as it does -------------------
+# Keys match the stages watch_run.sh infers from the output directory.
+STAGES = {
+    "step1": ("Predicting a spectral library from your FASTA",
+              "A deep-learning model predicts the retention time, ion mobility and fragment "
+              "pattern of every peptide your proteins could produce. One job, no raw data "
+              "read yet -- this is why nothing looks like it is touching your files."),
+    "step2": ("First pass: searching each file against the predicted library",
+              "Each raw file is searched independently as its own cluster task, which is "
+              "where the parallel chain earns its time back. Each finished file leaves a "
+              ".quant behind, so progress here is real files completed, not an estimate."),
+    "step3": ("Building an empirical library from what was actually seen",
+              "The first-pass results are pooled into a library measured from your own data "
+              "rather than predicted. This replaces match-between-runs, and it is why the "
+              "second pass identifies more than the first."),
+    "step4": ("Final pass: re-searching every file against the empirical library",
+              "The same per-file fan-out as the first pass, now against the better library. "
+              "Files that failed the first pass are skipped rather than blocking the run."),
+    "step5": ("Assembling the cross-run report",
+              "Per-file results are combined into one protein-group matrix, with quantities "
+              "made comparable across runs. This produces report.parquet, the file the "
+              "statistics step reads."),
+    "single": ("Searching your files",
+               "One job is working through the raw data: extracting fragment traces, matching "
+               "them to peptides, and scoring each match against decoys to control the false "
+               "discovery rate."),
+    "de": ("Differential expression",
+           "Protein abundances are modelled per group and moderated across proteins, so a "
+           "protein measured in few replicates borrows variance information from the rest."),
+}
+
+# --- notes. Each: (text, source, stages it suits best or None for any) --------
+FACTS = [
+    ("Trypsin cuts after lysine and arginine, but not when proline follows. Nearly every "
+     "search you will ever run assumes those rules.",
+     "Keil, Specificity of Proteolysis (1992)", None),
+    ("DIA-NN is short for 'Data-Independent Acquisition by Neural Networks' — the neural "
+     "networks are what turn a FASTA into a usable spectral library without you measuring one.",
+     "Demichev et al. 2020, Nat Methods 17:41-44", ("step1", "step2")),
+    ("A predicted library is a hypothesis about your peptides; an empirical one is a "
+     "measurement of them. Searching twice — predicted, then empirical — is why the second "
+     "pass finds more.",
+     "Demichev et al. 2020, Nat Methods 17:41-44", ("step3", "step4")),
+    ("An Orbitrap has no magnet. Ions orbit a spindle-shaped central electrode, and their "
+     "oscillation frequency scales with the inverse square root of m/z — mass is measured as "
+     "a frequency, which is why the resolution is so high.",
+     "Makarov 2000, Anal Chem 72:1156-1162", None),
+    ("On a timsTOF, ions are held stationary against a flowing gas by an electric field, then "
+     "released in order of size and shape. That extra separation is the 'TIMS' in the name.",
+     "Meier et al. 2015, J Proteome Res 14:5378-5387", None),
+    ("Two peptides from the same protein can differ enormously in how well they ionize. That "
+     "is why label-free quantification compares a peptide to itself across runs, and never to "
+     "another peptide.",
+     "Cox et al. 2014, MaxLFQ, Mol Cell Proteomics 13:2513-2526", ("step5", "de")),
+    ("Shared peptides mean the protein you detected is sometimes ambiguous. Software reports "
+     "'protein groups' rather than proteins precisely because the evidence cannot always tell "
+     "family members apart — this is the protein inference problem.",
+     "Nesvizhskii & Aebersold 2005, Mol Cell Proteomics 4:1419-1440", ("step5", "de")),
+    ("Controlling the false discovery rate at 1% for peptides does not give you 1% at the "
+     "protein level. The error rates are separate, and protein-level FDR is the stricter one "
+     "to satisfy.",
+     "Nesvizhskii 2010, J Proteomics 73:2092-2123", ("step5", "de")),
+    ("Keratin is the classic contaminant — skin, hair and dust find their way into almost "
+     "every sample. It is only a problem when it is unevenly distributed across your groups.",
+     "cRAP contaminant database, thegpm.org/crap/", None),
+    ("The moderated t-test used here borrows variance information across all proteins, which "
+     "is what makes small-replicate experiments analysable at all.",
+     "Smyth 2004, Stat Appl Genet Mol Biol 3:Article3", ("de",)),
+    ("The Benjamini-Hochberg procedure does not tell you which discoveries are wrong. It "
+     "promises that, on average, only a set fraction of the ones you report will be.",
+     "Benjamini & Hochberg 1995, J R Stat Soc B 57:289-300", ("de",)),
+    ("Decoy sequences exist to be wrong on purpose. How often a search prefers a decoy over a "
+     "real peptide is what calibrates the false discovery rate.",
+     "Elias & Gygi 2007, Nat Methods 4:207-214", ("step2", "step4")),
+    ("Monoisotopic mass uses only the lightest isotope of each element; average mass uses the "
+     "natural mixture. Mixing them up shifts a peptide by about one dalton per 1000 — enough "
+     "to lose the identification entirely.",
+     "IUPAC isotopic composition conventions", None),
+    ("In data-independent acquisition the instrument stops choosing which peptides to "
+     "fragment and simply fragments everything in a window. Nothing is missed because it was "
+     "not selected — the difficulty moves from acquisition into the software.",
+     "Venable et al. 2004, Nat Methods 1:39-45", ("step2", "step4", "single")),
+    ("Thousands of human proteins still have little or no direct protein-level evidence, "
+     "despite their genes being known for decades. They are tracked as 'missing proteins'.",
+     "neXtProt protein-existence (PE) levels, nextprot.org", None),
+    ("Retention time is a strong second opinion. A peptide eluting far from where it should "
+     "is treated as suspicious even when its fragments match well.",
+     "Escher et al. 2012, Proteomics 12:1111-1121 (iRT)", ("step1", "step2")),
+    ("Cysteine is usually reduced and capped with iodoacetamide before digestion, which is "
+     "why searches carry a fixed +57 Da carbamidomethyl modification. Forgetting it costs "
+     "most of your cysteine-containing peptides.",
+     "Standard bottom-up sample preparation", None),
+    ("A protein's abundance in a cell can span roughly ten orders of magnitude. No single "
+     "mass-spec run sees all of it at once — depth is always a compromise with time.",
+     "Beck et al. 2011, Mol Syst Biol 7:549", None),
+]
+
+
+def pick(stage, index, prefer_stage=True):
+    """Deterministic rotation: same (stage, index) always yields the same note, and a
+    caller stepping index forward each poll walks the whole list without repeating.
+
+    Stage-relevant notes come first, then everything else -- rather than cycling only the
+    matching ones, which for a stage with four facts would repeat every four minutes at a
+    60-second poll. The full list is always reachable, so a long search keeps varying."""
+    matched = [f for f in FACTS if f[2] and stage in f[2]] if prefer_stage else []
+    pool = matched + [f for f in FACTS if f not in matched]
+    return pool[index % len(pool)]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--stage", default="single", help="step1..step5 | single | de")
+    ap.add_argument("--index", type=int, default=0, help="poll counter; rotates the note")
+    ap.add_argument("--no-fact", action="store_true")
+    a = ap.parse_args()
+
+    headline, why = STAGES.get(a.stage, STAGES["single"])
+    out = {"stage": a.stage, "doing": headline, "why": why}
+    if not a.no_fact:
+        text, source, _ = pick(a.stage, a.index)
+        out["note"] = text
+        out["note_source"] = source
+    print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
@@ -16,12 +16,14 @@
 #   while not done: watch_run.sh ...; sleep 60; done   # then act on failed/fix
 # =============================================================================
 set -uo pipefail
-MODE="local"; JOB=""; LOG=""; HIVE=false; STALL_MIN=15
+MODE="local"; JOB=""; LOG=""; HIVE=false; STALL_MIN=15; OUTDIR=""; POLL=0
 while [ $# -gt 0 ]; do case "$1" in
   --slurm)     MODE="slurm"; JOB="$2"; shift 2;;
   --log)       LOG="$2"; shift 2;;
   --hive)      HIVE=true; shift;;
   --stall-min) STALL_MIN="$2"; shift 2;;   # RUNNING + log frozen this long ⇒ stalled
+  --out)       OUTDIR="$2"; shift 2;;      # search output dir ⇒ real progress + narration
+  --poll)      POLL="$2"; shift 2;;        # poll counter; rotates the note
   *) shift;;
 esac; done
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -83,14 +85,60 @@ if [ -z "$err_class" ] && [ -n "$LOG" ] && printf '%s' "$state" | grep -qiE "RUN
   fi
 fi
 
+# ---- real progress ----------------------------------------------------------
+# Counted from what the 5-step chain actually leaves on disk, not guessed from the log:
+# every finished file drops a .quant, so "34 of 66" is a fact. Runs through run() so it
+# works over SSH on HIVE exactly as it does locally.
+stage="single"; n_total=0; n_done=0
+if [ -n "$OUTDIR" ]; then
+  q() { run "$*" 2>/dev/null | tr -dc 0-9; }
+  n_total="$(q "wc -l < $(printf %q "$OUTDIR/file_list.txt")")"
+  q2="$(q "ls -1 $(printf %q "$OUTDIR/quant_step2")/*.quant 2>/dev/null | wc -l")"
+  q4="$(q "ls -1 $(printf %q "$OUTDIR/quant_step4")/*.quant 2>/dev/null | wc -l")"
+  has() { [ "$(run "test -s $(printf %q "$1") && echo 1 || echo 0" 2>/dev/null | tr -dc 0-9)" = "1" ]; }
+  : "${n_total:=0}"; : "${q2:=0}"; : "${q4:=0}"
+  if [ "$n_total" -gt 0 ]; then                       # a 5-step chain lives here
+    if   has "$OUTDIR/report.parquet";     then stage="step5"; n_done="$n_total"
+    elif has "$OUTDIR/empirical.parquet";  then stage="step4"; n_done="$q4"
+    elif [ "$q2" -ge "$n_total" ];         then stage="step3"; n_done="$n_total"
+    elif has "$OUTDIR/step1.predicted.speclib"; then stage="step2"; n_done="$q2"
+    else stage="step1"; n_done=0
+    fi
+  fi
+fi
+
+# ---- narration: what this stage is doing, plus something to read while waiting
+notes="$(python3 "$HERE/pipeline_notes.py" --stage "$stage" --index "$POLL" 2>/dev/null)"
+
 STATE="$state" DONE="$done" FAILED="$failed" STALLED="$stalled" JOB="$JOB" MODE="$MODE" \
-ECLASS="$err_class" FIX="$fix" TAIL="$tail_txt" python3 - <<'PY'
+ECLASS="$err_class" FIX="$fix" TAIL="$tail_txt" \
+STAGE="$stage" NDONE="${n_done:-0}" NTOTAL="${n_total:-0}" NOTES="$notes" python3 - <<'PY'
 import os, json
-print(json.dumps({
+n_done, n_total = int(os.environ.get("NDONE") or 0), int(os.environ.get("NTOTAL") or 0)
+stage = os.environ.get("STAGE", "single")
+out = {
     "mode": os.environ["MODE"], "job": os.environ["JOB"], "state": os.environ["STATE"],
     "done": os.environ["DONE"] == "true", "failed": os.environ["FAILED"] == "true",
     "stalled": os.environ.get("STALLED") == "true",
     "error_class": os.environ["ECLASS"], "fix": os.environ["FIX"],
-    "log_tail": os.environ["TAIL"][-1500:],
-}, indent=2))
+}
+step_no = stage[4:] if stage.startswith("step") else None
+progress = {"stage": stage, "files_done": n_done, "files_total": n_total}
+if step_no:
+    progress["step"] = f"{step_no}/5"
+if n_total:
+    progress["percent"] = round(100.0 * n_done / n_total, 1)
+# One sentence the orchestrator can hand the user verbatim.
+where = f"step {step_no}/5" if step_no else "search"
+progress["summary"] = (f"{where}: {n_done}/{n_total} files done"
+                       + (f" ({progress['percent']:.0f}%)" if n_total else "")) \
+    if n_total else f"{where} running"
+out["progress"] = progress
+try:
+    out.update({k: v for k, v in json.loads(os.environ.get("NOTES") or "{}").items()
+                if k in ("doing", "why", "note", "note_source")})
+except Exception:
+    pass
+out["log_tail"] = os.environ["TAIL"][-1500:]
+print(json.dumps(out, indent=2))
 PY


### PR DESCRIPTION
A search runs for hours and reported nothing but `still running`. Silence was indistinguishable from a hang, and there was nothing to look at.

## Real progress, not a guess

`watch_run.sh --out <search dir>` counts what the 5-step chain actually leaves on disk — one `.quant` per finished file — and infers the stage from which artefacts exist:

| Present in `--out` | Reported |
|---|---|
| nothing yet | step 1/5, library prediction |
| `step1.predicted.speclib` | step 2/5, first pass — `quant_step2/*.quant` ÷ `file_list.txt` |
| all first-pass `.quant` | step 3/5, empirical assembly |
| `empirical.parquet` | step 4/5, final pass — `quant_step4/*.quant` |
| `report.parquet` | step 5/5, done |

So the user gets `Step 2 of 5 — 34 of 66 files done (52%)`, which is a fact rather than an estimate. Emptiness counts as absent (`test -s`), so a zero-byte or truncated output is never mistaken for a finished step. All checks run through the existing `run()` helper, so this works over SSH on HIVE exactly as it does locally.

**Backwards compatible:** without `--out` the watcher behaves exactly as before, and every JSON key it emitted previously is still emitted.

## Something to read while waiting

New `pipeline_notes.py` gives each stage a plain-language *what is happening and why it takes this long* — during library prediction, for instance, nothing appears to touch the raw files, and it's useful to know that's expected. Alongside it is a rotating proteomics note, advanced by `--poll <n>`.

Stage-relevant notes come first and then the rest of the list. Cycling only the stage-matched ones meant a four-fact stage repeated every four polls — about every four minutes at a 60-second interval, which is worse than saying nothing.

**On accuracy:** every note carries a `source`, and anything that couldn't be attributed didn't go in. Claims are kept qualitative rather than quoting numbers a user can't check — the same rule the rest of the skill follows for parameters. `SKILL.md` also forbids presenting a note as a finding about the user's own data, so general background can't be mistaken for a result.

## Verification

Simulated an in-flight chain and advanced it artefact by artefact: all five stages report the correct step and file count, the no-`--out` path is unchanged, and each stage now yields 18 distinct notes before repeating. Shell passes `bash -n`, Python compiles.

Follows #18; takes v1.0.14 from main's v1.0.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Msrj7b5cPXYz9Sn1FtJidB