### PR TITLE
fix(skill): compare_searches.py must read report.tsv; add parallel diaTracer (v1.0.19)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/compare_searches.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/compare_searches.py
@@ -36,14 +36,28 @@ def read_report(path, q_cut):
     comparable across tools -- the global one is the defensible cross-tool cutoff --
     so prefer Global.Q.Value / Lib.PG.Q.Value and fall back only when absent.
     """
-    try:
-        import pyarrow.parquet as pq
-    except ImportError:
-        sys.exit("pyarrow is required. It ships with the skill's conda env (setup.sh).")
     if not os.path.exists(path):
         sys.exit(f"No such report: {path}")
-    tbl = pq.read_table(path)
-    cols = {c.lower(): c for c in tbl.column_names}
+
+    # The FragPipe/diaTracer route emits report.TSV, not parquet — FragPipe 24 bundles
+    # DIA-NN 1.8.2 beta 8, which has no parquet writer. Assuming parquet made this tool
+    # unable to read the very output it exists to compare against. Accept either.
+    is_tsv = path.lower().endswith((".tsv", ".txt", ".csv"))
+    if is_tsv:
+        import csv as _csv
+        delim = "," if path.lower().endswith(".csv") else "\t"
+        with open(path, newline="") as fh:
+            rdr = _csv.DictReader(fh, delimiter=delim)
+            names = rdr.fieldnames or []
+            rows = list(rdr)
+        cols = {c.lower(): c for c in names}
+    else:
+        try:
+            import pyarrow.parquet as pq
+        except ImportError:
+            sys.exit("pyarrow is required for parquet reports. It ships with the skill's conda env (setup.sh).")
+        tbl = pq.read_table(path)
+        cols = {c.lower(): c for c in tbl.column_names}
 
     def col(*names):
         for n in names:
@@ -58,10 +72,16 @@ def read_report(path, q_cut):
     c_q = col("Global.PG.Q.Value", "Global.Q.Value", "Lib.PG.Q.Value", "Q.Value")
     q_basis = c_q or "(none — no q-value column, nothing filtered)"
 
-    runs = tbl.column(c_run).to_pylist()
-    pgs = tbl.column(c_pg).to_pylist()
-    ints = tbl.column(c_int).to_pylist()
-    qs = tbl.column(c_q).to_pylist() if c_q else [0.0] * len(runs)
+    if is_tsv:
+        runs = [r.get(c_run) for r in rows]
+        pgs = [r.get(c_pg) for r in rows]
+        ints = [r.get(c_int) for r in rows]
+        qs = [r.get(c_q) for r in rows] if c_q else [0.0] * len(rows)
+    else:
+        runs = tbl.column(c_run).to_pylist()
+        pgs = tbl.column(c_pg).to_pylist()
+        ints = tbl.column(c_int).to_pylist()
+        qs = tbl.column(c_q).to_pylist() if c_q else [0.0] * len(runs)
 
     data, dropped = defaultdict(dict), 0
     for run, pg, val, q in zip(runs, pgs, ints, qs):

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/diatracer_parallel.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/diatracer_parallel.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+diatracer_parallel.py -- run diaTracer conversion as a SLURM array, one task per file.
+
+WHY
+---
+FragPipe runs diaTracer serially inside its own job: ~20 min per .d (paper: 34 files,
+32 cores, 19.4 min each). A nine-file cohort is therefore ~3 hours of wall-clock before
+MSFragger even starts. But the conversion is per-file and completely independent, so on
+a cluster it should be an array: nine tasks at once finish in the time of the slowest
+single file.
+
+The pseudo-MS/MS mzML are reusable. Once they exist, diatracer_stage.py emits the reuse
+form of the manifest (mzML as DDA + the original .d as DIA-Quant), and the subsequent
+FragPipe run skips conversion entirely and goes straight to MSFragger.
+
+  stage symlinks -> THIS (array, ~1 file-time) -> re-stage -> FragPipe (no conversion)
+
+⚠ diaTracer's standalone main() parses every numeric option UNCONDITIONALLY and does
+NOT apply the defaults its own --help advertises. Omit one and it dies immediately with
+"NullPointerException: Cannot invoke String.trim() because in is null" inside
+Double.parseDouble. So every option below is passed explicitly, at the documented
+default. Do not "simplify" this by dropping them.
+
+Usage
+  python3 diatracer_parallel.py --stage <staging dir> --out <dir for scripts+logs> \\
+      [--jar <diatracer.jar>] [--threads 16] [--mem 96] [--time 6] \\
+      [--partition low] [--account publicgrp] [--max-simultaneous 9]
+  bash <out>/submit_diatracer.sh
+"""
+import argparse, glob, json, os, shutil, sys
+
+# documented defaults from `java -jar diatracer.jar --help` (diaTracer 2.2.1)
+DEFAULTS = {"-dI": "0.01", "-dR": "3", "-mC": "0.3",
+            "-mF": "1", "-mO": "0.1", "-r": "0", "-rM": "500"}
+
+HIVE_JAR = "/quobyte/proteomics-grp/fragpipe24/fragpipe-24.0/tools/diatracer-2.2.1.jar"
+
+
+def find_jar(explicit):
+    if explicit:
+        return explicit
+    if os.path.exists(HIVE_JAR):
+        return HIVE_JAR
+    env = os.environ.get("FRAGPIPE_TOOLS_FOLDER")
+    if env:
+        hits = sorted(glob.glob(os.path.join(env, "**", "diatracer*.jar"), recursive=True))
+        if hits:
+            return hits[-1]
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--stage", required=True, help="staging dir of .d symlinks (diatracer_stage.py)")
+    ap.add_argument("--out", required=True, help="where to write the sbatch + logs")
+    ap.add_argument("--jar")
+    ap.add_argument("--threads", type=int, default=16)
+    ap.add_argument("--mem", type=int, default=96, help="GB per task")
+    ap.add_argument("--time", type=int, default=6, help="hours per task")
+    ap.add_argument("--partition", default="low")
+    ap.add_argument("--account")
+    ap.add_argument("--max-simultaneous", type=int, default=0,
+                    help="cap concurrent tasks (0 = all at once)")
+    a = ap.parse_args()
+
+    stage = os.path.abspath(a.stage)
+    out = os.path.abspath(a.out)
+    os.makedirs(out, exist_ok=True)
+
+    dfiles = sorted(glob.glob(os.path.join(stage, "*.d")))
+    if not dfiles:
+        sys.exit(f"no .d entries in {stage} — run diatracer_stage.py first")
+
+    todo = [d for d in dfiles if not os.path.exists(d[:-2] + "_diatracer.mzML")]
+    n = len(dfiles)
+
+    jar = find_jar(a.jar)
+    if not jar:
+        sys.exit("diaTracer jar not found. Pass --jar, or set FRAGPIPE_TOOLS_FOLDER. "
+                 "It is licence-gated (MSFragger/IonQuant/diaTracer) and cannot be "
+                 "downloaded by script.")
+
+    if not todo:
+        print(json.dumps({"stage": stage, "n_files": n, "n_to_convert": 0,
+                          "note": "all pseudo-spectra already present — skip straight to FragPipe"},
+                         indent=2))
+        return
+
+    cap = f"%{a.max_simultaneous}" if a.max_simultaneous else ""
+    acct = f"#SBATCH --account={a.account}\n" if a.account else ""
+    opts = " ".join(f"{k} {v}" for k, v in DEFAULTS.items())
+
+    script = f"""#!/bin/bash -l
+#SBATCH --job-name=diatracer
+#SBATCH --array=0-{n - 1}{cap}
+#SBATCH --cpus-per-task={a.threads}
+#SBATCH --mem={a.mem}G
+#SBATCH --time={a.time}:00:00
+#SBATCH --partition={a.partition}
+{acct}#SBATCH --requeue
+#SBATCH -o {out}/diatracer_%A_%a.log
+#SBATCH -e {out}/diatracer_%A_%a.log
+set -uo pipefail
+
+mapfile -t DFILES < <(find "{stage}" -maxdepth 1 -name '*.d' | sort)
+D="${{DFILES[$SLURM_ARRAY_TASK_ID]}}"
+[ -n "${{D:-}}" ] || {{ echo "no .d for task $SLURM_ARRAY_TASK_ID"; exit 1; }}
+OUT="${{D%.d}}_diatracer.mzML"
+
+# reusable: never redo a conversion that already succeeded
+if [ -s "$OUT" ]; then echo "SKIP (already converted): $OUT"; exit 0; fi
+
+echo "=== task $SLURM_ARRAY_TASK_ID  host $(hostname)  $(date -u +%FT%TZ) ==="
+echo "input : $D"
+
+# every numeric option passed explicitly — diaTracer does NOT apply its own defaults
+java -Xmx{max(a.mem - 6, 8)}G -jar "{jar}" -d "$D" -w "{stage}" \\
+  -t "${{SLURM_CPUS_PER_TASK:-{a.threads}}}" {opts}
+rc=$?
+
+echo "=== finished $(date -u +%FT%TZ) exit=$rc ==="
+if [ -s "$OUT" ]; then ls -la "$OUT"; else echo "WARNING: expected output missing"; fi
+exit $rc
+"""
+    sp = os.path.join(out, "diatracer_array.sbatch")
+    with open(sp, "w") as fh:
+        fh.write(script)
+    os.chmod(sp, 0o755)
+
+    sub = os.path.join(out, "submit_diatracer.sh")
+    with open(sub, "w") as fh:
+        fh.write(f"""#!/bin/bash
+set -euo pipefail
+jid=$(sbatch --parsable "{sp}")
+echo "diatracer array = $jid"
+echo "watch: python3 checkpoint.py progress --session <session>"
+""")
+    os.chmod(sub, 0o755)
+
+    print(json.dumps({
+        "stage": stage, "out": out, "jar": jar,
+        "n_files": n, "n_to_convert": len(todo),
+        "n_already_converted": n - len(todo),
+        "sbatch": sp, "submit": f"bash {sub}",
+        "expected_outputs": [d[:-2] + "_diatracer.mzML" for d in dfiles],
+        "note": ("One SLURM task per file instead of FragPipe's serial loop: wall-clock "
+                 "becomes the slowest single file, not the sum. Re-stage afterwards so "
+                 "the manifest takes the reuse form and FragPipe skips conversion."),
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/resolve_organism.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/resolve_organism.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+resolve_organism.py -- turn what the user SAYS into the FASTA you actually search.
+
+THE GAP THIS FILLS
+------------------
+Organism cannot be detected from a raw file, so the skill asks for it. But asking is
+only half the job: the search needs a UniProt *proteome accession* (UP000000589), not
+the word "mouse". Until now that accession only ever came hardcoded out of a workflow
+bundle, so an organism with no bundle -- or an organism-agnostic bundle -- had nowhere
+to get it, and the run either stopped or silently searched the wrong species. Searching
+mouse data against a human FASTA does not error; it just quietly loses most of the
+proteome, which is the worst possible failure mode.
+
+Accepts a common name, a Latin name, a taxid, or a UP accession, and returns the
+proteome to search. Built-in table for the organisms a core facility actually sees;
+UniProt REST lookup for everything else.
+
+Usage
+  python3 resolve_organism.py --organism "mouse"
+  python3 resolve_organism.py --organism 10090
+  python3 resolve_organism.py --organism "Mus musculus" --json
+  python3 resolve_organism.py --list
+"""
+import argparse, json, re, sys, urllib.parse, urllib.request
+
+# taxid -> (canonical name, reference proteome, common aliases)
+TABLE = {
+    9606:  ("Homo sapiens",             "UP000005640", ["human", "hsapiens", "h. sapiens", "hs"]),
+    10090: ("Mus musculus",             "UP000000589", ["mouse", "mice", "murine", "mmusculus", "mm"]),
+    10116: ("Rattus norvegicus",        "UP000002494", ["rat", "rnorvegicus"]),
+    559292:("Saccharomyces cerevisiae", "UP000002311", ["yeast", "s. cerevisiae", "scerevisiae", "budding yeast"]),
+    83333: ("Escherichia coli K-12",    "UP000000625", ["e. coli", "ecoli", "e coli"]),
+    7227:  ("Drosophila melanogaster",  "UP000000803", ["fly", "fruit fly", "drosophila"]),
+    7955:  ("Danio rerio",              "UP000000437", ["zebrafish", "danio"]),
+    3702:  ("Arabidopsis thaliana",     "UP000006548", ["arabidopsis", "thale cress"]),
+    6239:  ("Caenorhabditis elegans",   "UP000001940", ["c. elegans", "celegans", "worm", "nematode"]),
+    9913:  ("Bos taurus",               "UP000009136", ["cow", "bovine", "cattle"]),
+    9823:  ("Sus scrofa",               "UP000008227", ["pig", "porcine", "swine"]),
+    9031:  ("Gallus gallus",            "UP000000539", ["chicken", "chick"]),
+    9615:  ("Canis lupus familiaris",   "UP000002254", ["dog", "canine"]),
+    9541:  ("Macaca fascicularis",      "UP000233100", ["cynomolgus", "cyno", "macaque"]),
+    284812:("Schizosaccharomyces pombe","UP000002485", ["fission yeast", "s. pombe", "pombe"]),
+    5691:  ("Trypanosoma brucei",       "UP000008524", ["trypanosoma", "t. brucei"]),
+    1773:  ("Mycobacterium tuberculosis","UP000001584", ["mtb", "m. tuberculosis", "tb"]),
+    5833:  ("Plasmodium falciparum",    "UP000001450", ["plasmodium", "malaria", "p. falciparum"]),
+}
+
+# NOTE: no `fields=` here. The proteomes endpoint rejects fields=proteome_type
+# ("Invalid fields parameter value"), and the full record already carries what we need.
+UNIPROT_PROTEOME_SEARCH = (
+    "https://rest.uniprot.org/proteomes/search"
+    "?query=organism_id:{taxid}&format=json&size=25"
+)
+UNIPROT_TAXON_SEARCH = (
+    "https://rest.uniprot.org/taxonomy/search?query={q}&format=json&size=25"
+)
+
+
+def _get(url, timeout=30):
+    req = urllib.request.Request(url, headers={"User-Agent": "ucdavis-proteomics-pipeline"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.loads(r.read().decode())
+
+
+def from_table(text):
+    t = text.strip().lower()
+    if t.isdigit() and int(t) in TABLE:
+        tx = int(t)
+        name, up, _ = TABLE[tx]
+        return {"taxid": tx, "organism": name, "uniprot_proteome": up, "source": "builtin"}
+    for tx, (name, up, aliases) in TABLE.items():
+        if t == name.lower() or t in aliases:
+            return {"taxid": tx, "organism": name, "uniprot_proteome": up, "source": "builtin"}
+    return None
+
+
+def _pick_taxon(hits, query):
+    """Choose the right taxon. NEVER just take hits[0].
+
+    A search for "Mus musculus" returns "Mus musculus musculus x Mus musculus
+    molossinus" (taxid 3004188) ahead of plain Mus musculus (10090). Taking the first
+    hit therefore searches a hybrid subspecies proteome and silently loses most of the
+    identifications. Prefer an exact scientific-name match, then a plain species-rank
+    hit, and only then fall back to first."""
+    q = query.strip().lower()
+    exact = [h for h in hits if (h.get("scientificName") or "").strip().lower() == q]
+    if exact:
+        return exact[0]
+    common = [h for h in hits
+              if any((c or "").strip().lower() == q for c in (h.get("commonName"), h.get("mnemonic")))]
+    if common:
+        return common[0]
+    species = [h for h in hits if (h.get("rank") or "").lower() == "species"
+               and " x " not in (h.get("scientificName") or "").lower()]
+    if species:
+        # shortest name = least sub-specific
+        return sorted(species, key=lambda h: len(h.get("scientificName") or ""))[0]
+    return hits[0]
+
+
+def from_uniprot(text):
+    """Resolve anything not in the table by asking UniProt directly."""
+    t = text.strip()
+    taxid = int(t) if t.isdigit() else None
+    organism = None
+    ambiguous = None
+    if taxid is None:
+        try:
+            res = _get(UNIPROT_TAXON_SEARCH.format(q=urllib.parse.quote(t)))
+        except Exception as e:
+            return {"error": f"UniProt taxonomy lookup failed for {t!r}: {e}"}
+        hits = res.get("results") or []
+        if not hits:
+            return {"error": f"no UniProt taxonomy match for {t!r}"}
+        chosen = _pick_taxon(hits, t)
+        taxid = int(chosen["taxonId"])
+        organism = chosen.get("scientificName")
+        if len(hits) > 1 and int(hits[0]["taxonId"]) != taxid:
+            ambiguous = (f"UniProt's top taxonomy hit was {hits[0].get('scientificName')!r} "
+                         f"(taxid {hits[0]['taxonId']}); selected {organism!r} "
+                         f"(taxid {taxid}) as the better match for {t!r}. Confirm.")
+    try:
+        res = _get(UNIPROT_PROTEOME_SEARCH.format(taxid=taxid))
+    except Exception as e:
+        return {"error": f"UniProt proteome lookup failed for taxid {taxid}: {e}"}
+    hits = res.get("results") or []
+    if not hits:
+        return {"error": f"no proteome in UniProt for taxid {taxid}",
+                "taxid": taxid, "organism": organism}
+
+    def rank(h):
+        pt = (h.get("proteomeType") or "").lower()
+        if "reference" in pt and "representative" not in pt:
+            return 0
+        if "representative" in pt:
+            return 1
+        if "other" in pt:
+            return 3
+        return 2
+    hits.sort(key=rank)
+    h = hits[0]
+    out = {"taxid": taxid,
+           "organism": organism or (h.get("taxonomy") or {}).get("scientificName"),
+           "uniprot_proteome": h["id"],
+           "proteome_type": h.get("proteomeType"),
+           "source": "uniprot",
+           "n_candidates": len(hits),
+           "alternatives": [x["id"] for x in hits[1:4]]}
+    if ambiguous:
+        out["ambiguous_name"] = ambiguous
+    return out
+
+
+def resolve(text, offline=False):
+    """UniProt is the source of truth. The built-in table is only a fallback for when
+    the network is unavailable — reference proteomes get superseded (an organism's
+    current UP accession is not a constant), so a hardcoded value can silently go
+    stale. Anything served from the table is flagged so the caller can say so."""
+    t = text.strip()
+    # already an accession? take it at face value
+    if re.fullmatch(r"UP\d{9}", t.upper()):
+        return {"taxid": None, "organism": None, "uniprot_proteome": t.upper(),
+                "source": "given-verbatim"}
+
+    if not offline:
+        live = from_uniprot(t)
+        if "error" not in live:
+            cached = from_table(t)
+            if cached and cached["uniprot_proteome"] != live["uniprot_proteome"]:
+                live["note_offline_cache_differs"] = (
+                    f"offline fallback table says {cached['uniprot_proteome']}; "
+                    f"UniProt currently says {live['uniprot_proteome']}. Using UniProt.")
+            return live
+
+    cached = from_table(t)
+    if cached:
+        cached["source"] = "offline-fallback" if not offline else "offline-table"
+        cached["warning"] = ("Resolved from the built-in fallback table, not UniProt. "
+                             "Reference proteome accessions change over time — verify "
+                             "before relying on this for a published method.")
+        return cached
+    return {"error": f"could not resolve {t!r}: UniProt unreachable and no offline entry"}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--organism", help="common name, Latin name, taxid, or UPxxxxxxxxx")
+    ap.add_argument("--list", action="store_true", help="show the built-in table")
+    ap.add_argument("--offline", action="store_true",
+                    help="skip UniProt and use the built-in fallback table only")
+    a = ap.parse_args()
+
+    if a.list:
+        print(json.dumps([{"taxid": tx, "organism": n, "uniprot_proteome": up,
+                           "aliases": al} for tx, (n, up, al) in sorted(TABLE.items())], indent=2))
+        return
+    if not a.organism:
+        sys.exit("Need --organism (or --list). The organism cannot be detected from raw "
+                 "files — ASK the user, then resolve it here.")
+
+    out = resolve(a.organism, offline=a.offline)
+    out["query"] = a.organism
+    if "error" not in out:
+        out["confirm_with_user"] = (
+            f"Searching {out.get('organism') or 'this organism'} "
+            f"(taxid {out.get('taxid')}) against UniProt {out['uniprot_proteome']}. "
+            "Confirm before the search starts — a wrong proteome does not error, it "
+            "silently loses most of the identifications.")
+    print(json.dumps(out, indent=2))
+    if "error" in out:
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Found running the first real DIA-NN vs diaTracer bake-off on 9 mouse dia-PASEF files.

**`compare_searches.py` could not read diaTracer output.** It called `pq.read_table()` unconditionally, but the FragPipe route emits `report.tsv` — FragPipe 24 bundles DIA-NN 1.8.2 beta 8, which has no parquet writer, and the workflow's own notes state this explicitly. The one tool written to compare the two engines therefore crashed on one of them. Now accepts `.tsv/.txt/.csv` or parquet.

**New `diatracer_parallel.py`.** diaTracer conversion is per-file and independent, but FragPipe runs it serially (~20 min/file → ~3 h for nine). This emits a SLURM array instead: **measured 9 files in ~25 min**. Existing mzML are skipped, so re-searches are free.

It also encodes a trap worth not rediscovering: diaTracer's standalone `main()` parses every numeric option unconditionally and does **not** apply the defaults its own `--help` advertises. Omit one and it dies immediately with `NullPointerException` in `Double.parseDouble`.

**Not fixed here, needs a decision** — headless FragPipe requires a populated `~/.config/FragPipe` cache. Without it the Spectral Library Generation module is rejected regardless of `--config-tools-folder`, `--config-python` or `--config-diann`. Copying a configured user's cache fixed it instantly. Every student will hit this on a fresh account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4E3rNmy5noGLyiJL9RWv5