### PR TITLE
feat(skill): FragPipe/diaTracer runbook, headless bootstrap, comparison report (v1.0.20)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -644,6 +644,14 @@ python3 scripts/make_comparison_report.py --out <session>/output/comparison_repo
   --instrument "<detected instrument>" --title "<A> vs <B>"
 python3 scripts/to_docx.py --in <...>/COMPARISON_REPORT.md --out <...>/COMPARISON_REPORT.docx
 ```
+**Read `references/cross-tool-comparison.md` BEFORE interpreting the output** — it holds
+the design rules (both engines through the same DE pipeline; name every uncontrolled
+difference) and the interpretation patterns a bake-off keeps producing: more precursors
+with fewer proteins means protein *inference*, not sensitivity; a high intensity r with a
+much lower logFC r means direction is trustworthy and magnitude is not; and the subtler
+the contrast, the more the engine choice decides the answer. It also says to **load the
+`dataviz` skill and re-run its palette validator** before changing any chart.
+
 It emits an **interactive standalone HTML** (metric toggles, hover tooltips, a 3x3
 concordance matrix, sortable tables, theme-aware, no CDN) plus a markdown skeleton in
 the section order DE-LIMP's Run Comparator prompt defines — `docs/AI_PROMPTS.md` §1:

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -346,7 +346,7 @@ python3 scripts/run_search.py --tools ~/.proteomics-pipeline/tools/tools.json \
   - FragPipe 24.0 bundles **DIA-NN 1.8.2_beta_8**, older than the 2.x the `diann_*`
     workflows pin. Expect different numbers from that alone; say so rather than
     attributing every difference to the spectrum-centric approach.
-  - Budget roughly **20 min per file for the diaTracer conversion alone** (paper: 34 files,
+  - **Four things block this route on a fresh account — read `references/fragpipe-diatracer.md`\n    BEFORE running it.** (1) the three engines are licence-gated and the tools folder must be the\n    one that also contains `speclib/`; (2) MSFragger needs a **target+decoy** FASTA, which DIA-NN\n    does not; (3) headless FragPipe rejects the spectral-library module until\n    `fragpipe-config.bin-python` exists in `~/.config/FragPipe/.../fragpipe-ui.cache` — no CLI flag\n    substitutes, run `scripts/fragpipe_bootstrap.py`; (4) diaTracer's standalone `main()` ignores its\n    own documented defaults and needs all seven numeric options passed.\n  - **On a cluster, parallelise the conversion automatically** with `scripts/diatracer_parallel.py`\n    — one SLURM task per file instead of FragPipe's serial loop. Measured 9 files in ~25 min vs ~3 h.\n    Re-stage afterwards so the manifest takes the reuse form and FragPipe skips conversion.\n  - Budget roughly **20 min per file for the diaTracer conversion alone** (paper: 34 files,
     32 cores, ~19.4 min each), before MSFragger and DIA-NN. The mzML are **reusable**, so a
     re-search with different parameters skips it. Needs Java 11+, MSFragger 4.4+,
     IonQuant 1.11.18+, diaTracer 2.2.1+. The three gated jars are **not** in the FragPipe
@@ -628,6 +628,37 @@ It writes `COMPARISON.md` + CSVs: protein-universe overlap, the 3×3 Up/Down/NS
 concordance per shared contrast, direction concordance on co-significant proteins,
 and logFC correlation. (`session.py finalize` already wrote `DIFFERENCES.md` —
 what *settings* changed; the Comparator shows how the *results* changed.)
+
+### 11c. Cross-tool comparison — report it, don't just compute it
+
+Comparing two search engines on the same raw files is a distinct deliverable from a DE
+re-analysis. `compare_searches.py` compares the SEARCHES (what each found, in how many
+runs, how reproducibly); `compare_analyses.R` compares the finished DE TABLES (which
+proteins actually change). Run both, then build the report:
+```
+python3 scripts/make_comparison_report.py --out <session>/output/comparison_report \
+  --search-comparison <dir from compare_searches.py> \
+  --de-comparison     <dir from compare_analyses.R> \
+  --qc "EngineA:<sessionA>/output/tables/QC_detected_vs_inferred.csv" \
+  --qc "EngineB:<sessionB>/output/tables/QC_detected_vs_inferred.csv" \
+  --instrument "<detected instrument>" --title "<A> vs <B>"
+python3 scripts/to_docx.py --in <...>/COMPARISON_REPORT.md --out <...>/COMPARISON_REPORT.docx
+```
+It emits an **interactive standalone HTML** (metric toggles, hover tooltips, a 3x3
+concordance matrix, sortable tables, theme-aware, no CDN) plus a markdown skeleton in
+the section order DE-LIMP's Run Comparator prompt defines — `docs/AI_PROMPTS.md` §1:
+Factual Observations, Sources of Disagreement, Case for A, Case for B, Settings Audit,
+Concordant Proteins, Synthesis, Follow-ups. **The generator writes every number; you
+write the judgement** — fill each `TODO(model)` block from the data and never invent a
+figure. Follow the prompt's guidelines: neither tool is inherently superior, every claim
+carries a number or a citation, speculation is labelled as such.
+
+**To compare engines fairly, run BOTH through the same DE method.** Push each engine's
+report through `run_de.R` with identical `--method`, contrasts and thresholds, so the
+search is the only variable. `run_de.R --format tsv` reads a FragPipe `report.tsv`
+directly. Also state any engine-VERSION gap out loud — FragPipe 24 bundles DIA-NN
+1.8.2 beta 8, two majors behind what the `diann_*` workflows pin, and that alone moves
+the numbers.
 
 ### 12. Finalize the session + report to the user
 ```

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -346,7 +346,17 @@ python3 scripts/run_search.py --tools ~/.proteomics-pipeline/tools/tools.json \
   - FragPipe 24.0 bundles **DIA-NN 1.8.2_beta_8**, older than the 2.x the `diann_*`
     workflows pin. Expect different numbers from that alone; say so rather than
     attributing every difference to the spectrum-centric approach.
-  - **Four things block this route on a fresh account — read `references/fragpipe-diatracer.md`\n    BEFORE running it.** (1) the three engines are licence-gated and the tools folder must be the\n    one that also contains `speclib/`; (2) MSFragger needs a **target+decoy** FASTA, which DIA-NN\n    does not; (3) headless FragPipe rejects the spectral-library module until\n    `fragpipe-config.bin-python` exists in `~/.config/FragPipe/.../fragpipe-ui.cache` — no CLI flag\n    substitutes, run `scripts/fragpipe_bootstrap.py`; (4) diaTracer's standalone `main()` ignores its\n    own documented defaults and needs all seven numeric options passed.\n  - **On a cluster, parallelise the conversion automatically** with `scripts/diatracer_parallel.py`\n    — one SLURM task per file instead of FragPipe's serial loop. Measured 9 files in ~25 min vs ~3 h.\n    Re-stage afterwards so the manifest takes the reuse form and FragPipe skips conversion.\n  - Budget roughly **20 min per file for the diaTracer conversion alone** (paper: 34 files,
+  - **Four things block this route on a fresh account — read `references/fragpipe-diatracer.md`
+    BEFORE running it.** (1) the three engines are licence-gated and the tools folder must be the
+    one that also contains `speclib/`; (2) MSFragger needs a **target+decoy** FASTA, which DIA-NN
+    does not; (3) headless FragPipe rejects the spectral-library module until
+    `fragpipe-config.bin-python` exists in `~/.config/FragPipe/.../fragpipe-ui.cache` — no CLI flag
+    substitutes, run `scripts/fragpipe_bootstrap.py`; (4) diaTracer's standalone `main()` ignores its
+    own documented defaults and needs all seven numeric options passed.
+  - **On a cluster, parallelise the conversion automatically** with `scripts/diatracer_parallel.py`
+    — one SLURM task per file instead of FragPipe's serial loop. Measured 9 files in ~25 min vs ~3 h.
+    Re-stage afterwards so the manifest takes the reuse form and FragPipe skips conversion.
+  - Budget roughly **20 min per file for the diaTracer conversion alone** (paper: 34 files,
     32 cores, ~19.4 min each), before MSFragger and DIA-NN. The mzML are **reusable**, so a
     re-search with different parameters skips it. Needs Java 11+, MSFragger 4.4+,
     IonQuant 1.11.18+, diaTracer 2.2.1+. The three gated jars are **not** in the FragPipe

--- a/skill/ucdavis-proteomics-core-pipeline/references/cross-tool-comparison.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/cross-tool-comparison.md
@@ -1,0 +1,126 @@
+# Comparing two search engines — the method, not just the script
+
+`make_comparison_report.py` regenerates the artifact. This file records **how to reach a
+defensible answer**, and the interpretation patterns that a bake-off keeps producing.
+Written after the first real DIA-NN vs FragPipe/diaTracer comparison (9 mouse dia-PASEF
+files); every pattern below was actually observed in that data.
+
+## Get the design right before computing anything
+
+**Run both engines through the SAME downstream pipeline.** Identical `run_de.R --method`,
+identical contrasts, identical thresholds. Otherwise you are comparing search × DE
+method and cannot attribute the difference. `run_de.R --format tsv` reads a FragPipe
+`report.tsv` directly, and a `conditions.csv` written for the DIA-NN route works
+unchanged because the `Run` column carries the original `.d` basenames.
+
+**Name every uncontrolled difference out loud, in the report, not just in your head.**
+The big one for this pair: FragPipe 24 bundles **DIA-NN 1.8.2 beta 8** while the
+`diann_*` workflows pin **2.x**. Both routes end in DIA-NN, so part of any gap is two
+major versions of quant engine, not the approach under test. A head-to-head that omits
+this silently attributes version lag to the method. Control it with `--config-diann`
+pointing at an external 2.x, or state it.
+
+**Compare at both levels; they answer different questions.**
+
+| Tool | Question it answers |
+|---|---|
+| `compare_searches.py` | What did each engine *find*, in how many runs, how reproducibly |
+| `compare_analyses.R` | Which proteins actually come out *changed* |
+| `QC_detected_vs_inferred.csv` (both sessions) | How much of each matrix was *measured* vs modelled |
+
+A search-level win does not imply a DE-level win. In the reference case DIA-NN found 20%
+more protein groups yet **lost** the subtle contrast on DE count.
+
+## Interpretation patterns that recur
+
+### More precursors, fewer proteins → protein inference, not sensitivity
+diaTracer identified up to **25% more precursors** than DIA-NN on the weakest samples
+while returning **fewer protein groups in every run**. That combination is not "detected
+less" — it is a parsimony difference (ProteinProphet collapsing shared peptides vs
+DIA-NN's own grouping). Always check precursor counts alongside protein counts before
+calling one engine less sensitive. Reporting only the protein number inverts the story.
+
+### logFC correlation vs intensity correlation → how far to trust magnitude
+Intensity agreement on shared proteins was r = **0.879**; fold-change agreement was only
+**0.637–0.718**. Ratios amplify disagreement because the errors do not cancel when you
+divide. When intensity r is high and logFC r is much lower, the honest statement is:
+**direction is trustworthy, magnitude is engine-dependent.** Report both correlations —
+quoting only the intensity one overstates agreement.
+
+### Effect size determines how much the engine matters
+On a large contrast (Urea vs Beads) 708 of 1,866 DE calls overlapped. On a subtle one
+(S-Trap vs Beads) only **91 of 382** did — two-thirds of that DE list depended on which
+engine ran. **The weaker the effect you are chasing, the more the search engine
+determines your answer.** Say this explicitly when the study's contrast is subtle; it is
+the difference between "engine choice is a detail" and "engine choice is the result".
+
+### Read the 3×3 matrix by cell type
+- **Diagonal** (Up/Up, Down/Down, NS/NS) — agreement.
+- **NS ↔ significant** off-diagonals — *detection* differences. Almost always where the
+  disagreement lives, and the benign kind.
+- **Up ↔ Down corners** — genuine direction disagreement. Should be near-empty; 9 of 708
+  in the reference case. A populated corner is a red flag, not a curiosity.
+
+### Completeness advantage tends to track sample quality
+diaTracer's detected fraction was 5–7 points higher on all three urea (worst) runs and
+*lower* on the strongest S-Trap runs. An empirical library built from the data helps most
+where signal is scarce. Break the QC panel down by sample quality rather than reporting a
+single mean — the mean hides the pattern that explains the mechanism.
+
+### Protein-group identifiers are not perfectly comparable across tools
+Different parsimony rules mean a protein can appear "unique to engine X" purely because
+it was merged into a differently-named group. Some fraction of every unique list is
+grouping, not detection. **Warn about this before anyone reads biology into a unique
+set**, and check per-protein claims at peptide level first.
+
+## Building the report
+
+Follow the structure DE-LIMP's Run Comparator prompt defines
+(`docs/AI_PROMPTS.md` §1) — `make_comparison_report.py` emits it as a skeleton:
+
+1 Factual Observations · 2 Sources of Disagreement · 3 Case for A · 4 Case for B ·
+5 Settings Audit · 6 Concordant Proteins · 7 Synthesis · 8 Recommended Follow-ups
+
+Its guidelines are load-bearing, not decoration:
+
+- **Neither tool is inherently superior.** Sections 3 and 4 exist so you argue *both*
+  sides properly before section 7 weighs them. Write 3 and 4 before you know your verdict.
+- **Every claim carries a number from the data or a literature citation.**
+- **Label speculation** — "one possible explanation is…", never stated as fact.
+- **If the evidence does not clearly favour one tool, say so.** Do not force a
+  recommendation. The reference case concluded *complementary, not ranked*, and that was
+  the correct answer, not a hedge.
+- Section 8 wants **one follow-up probing each pipeline** — not two aimed at the same tool.
+
+**The generator writes the numbers; you write the judgement.** Fill each `TODO(model)`
+block from the data. Never invent a figure to complete a sentence.
+
+## Charts: load the `dataviz` skill first
+
+The HTML template's palette and mark choices are not taste — they came from the dataviz
+method, and a future chart must re-derive them the same way:
+
+- **Run the validator, don't eyeball it.**
+  `node dataviz/scripts/validate_palette.js "<hex,hex>" --mode light` and again
+  `--mode dark`. The two-series pair shipped in `make_comparison_report.py`
+  (`#2a78d6` / `#eb6834` light, `#3987e5` / `#d95926` dark) passes all six checks in both
+  modes. Changing a colour obliges re-running it.
+- **Form follows the data's job.** Grouped bars for magnitude across categories;
+  **dumbbell** for two paired values per sample (it shows the *gap*, which is the point,
+  and needs one row per sample rather than two); a **sequential single-hue ramp** for
+  counts in the 3×3 matrix, with agreement cells on the accent hue and direction-flip
+  cells on the warning hue so the eye lands on the cell that matters.
+- **Hover by default.** An HTML chart is interactive; every mark gets a tooltip naming
+  the run, the value, and what the cell *means* ("both agree", "OPPOSITE DIRECTION").
+- **Theme-aware under both scopes** — the `prefers-color-scheme` media query and the
+  `data-theme` attribute, so a viewer's toggle wins either way. Redraw the SVGs on toggle;
+  CSS variables alone will not repaint canvas-computed geometry.
+- **Colour is never the only encoding** — legend always present for two series, direct
+  value labels beside the marks.
+- Self-contained: no CDN, no external fonts, inline SVG. It has to open from a file path
+  on a cluster with no browser network access.
+
+## Deliver both formats
+
+HTML for exploration, `.docx` for circulation — `to_docx.py` handles the conversion and
+resolves relative figure paths, so images actually embed rather than silently vanishing.

--- a/skill/ucdavis-proteomics-core-pipeline/references/fragpipe-diatracer.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/fragpipe-diatracer.md
@@ -1,0 +1,176 @@
+# Running FragPipe + diaTracer — what actually blocks you
+
+Everything here was found by running the route end-to-end on nine mouse dia-PASEF files
+(timsTOF HT, 100 SPD) as a fresh cluster account. Each item cost a failed job, so none
+of it is theoretical. **Nothing below is HIVE-specific except where a path is given as
+an example** — a laptop or a generic Linux box hits the same four gates.
+
+## The four gates, in the order you hit them
+
+### 1. The three engines are licence-gated and cannot be scripted
+
+MSFragger, IonQuant and diaTracer come from a web form plus a licence key (one shared
+academic licence; commercial via fragmatics.com). `acquire_tools.sh` can fetch FragPipe
+itself but never these. Point FragPipe at wherever you unpacked them.
+
+**The tools folder must be the one that also contains `speclib/`.** A directory holding
+only the three jars is not enough — FragPipe looks for `speclib/gen_con_spec_lib.py`
+alongside them. On a stock install that is `<fragpipe>/tools`, which already contains all
+three jars plus `speclib/`, `Philosopher/` and `diann/`. Handing it a curated
+"licensed jars only" folder fails.
+
+> The DIA-NN that FragPipe bundles is explicitly *"available for both academic and
+> commercial use within FragPipe"* — DIA-NN is **not** the restriction. Never tell a
+> commercial user this route is closed to them; they must licence the three gated tools.
+
+### 2. MSFragger needs a target+decoy FASTA — DIA-NN does not
+
+DIA-NN generates decoys internally. FragPipe does not, and fails immediately:
+
+```
+ERROR - No decoys found in the FASTA file.
+```
+
+Build one with the Philosopher that ships with FragPipe, using the decoy tag the
+workflow expects (`database.decoy-tag=rev_` in the diaPASEF preset):
+
+```bash
+PH=<fragpipe>/tools/Philosopher/philosopher-v5.1.3-RC9
+cd <somewhere writable>
+cp search.fasta target.fasta
+"$PH" workspace --init
+"$PH" database --custom ./target.fasta --prefix rev_
+# -> <date>-decoys-target.fasta.fas   (targets + decoys)
+```
+
+Point `database.db-path` at the `.fas`, not the original FASTA. A 55,245-sequence
+proteome becomes 110,490 entries.
+
+### 3. Headless FragPipe needs a per-user config cache — THE BIG ONE
+
+On any account that has never opened the GUI:
+
+```
+ERROR - Spectral Library Generation module was not configured correctly.
+        Please make sure that Python and FragPipe-SpecLib have been installed.
+```
+
+**This cannot be fixed with command-line flags.** It survives a correct
+`--config-tools-folder`, a correct `--config-diann`, a python with `easypqp` first on
+`PATH`, and `--config-python` pointed at either the venv or its binary. Five separate
+invocations, five identical failures.
+
+The state FragPipe actually reads is:
+
+```
+~/.config/FragPipe/fragpipe/<version>/fragpipe-ui.cache
+    fragpipe-config.bin-python=/path/to/python     <-- the key that matters
+    fragpipe-config.bin-diann=/path/to/diann
+```
+
+Write it without a GUI:
+
+```bash
+python3 scripts/fragpipe_bootstrap.py \
+    --python <interpreter that can import easypqp> \
+    --diann  <fragpipe>/tools/diann/1.8.2_beta_8/linux/diann-1.8.1.8
+python3 scripts/fragpipe_bootstrap.py --check     # verify, writes nothing
+```
+
+`fragpipe_bootstrap.py` verifies the interpreter can actually `import easypqp` before
+writing, because a python that can't fails later and less legibly. If you need to build
+that interpreter: `python3 -m venv pqp && pqp/bin/pip install easypqp`.
+
+**Every user on a fresh account hits this** — for a class, it has to be part of setup,
+not troubleshooting.
+
+`--config-python` is also mis-documented: its help says *"the Python directory"*, but
+FragPipe execs the path directly, so a directory gives
+`Cannot run program ...: error 13 (Permission denied)`. Pass a binary, or better, set
+the cache and omit the flag — the verified working invocation does not use it at all.
+
+### 4. diaTracer standalone does not apply its own defaults
+
+Running the jar directly (which is what parallelising requires) with only `-d`, `-w`
+and `-t` dies instantly:
+
+```
+Exception in thread "main" java.lang.NullPointerException:
+    Cannot invoke "String.trim()" because "in" is null
+        at java.base/java.lang.Double.parseDouble
+        at diatracer.diaTracerMainClass.main
+```
+
+`main()` parses **every** numeric option unconditionally and ignores the defaults its
+own `--help` advertises. All seven must be passed:
+
+```
+-dI 0.01   -dR 3   -mC 0.3   -mF 1   -mO 0.1   -r 0   -rM 500
+```
+
+`diatracer_parallel.py` encodes these; don't "simplify" them away.
+
+## Parallelising the conversion
+
+FragPipe runs diaTracer serially inside its own job — ~20 min per file, so ~3 hours for
+nine. The conversion is per-file and independent, so on a cluster it should be an array:
+
+```bash
+python3 scripts/diatracer_stage.py --raw *.d --stage ./stage \
+    --manifest ./fragpipe.fp-manifest --conditions conditions.csv
+python3 scripts/diatracer_parallel.py --stage ./stage --out ./dt \
+    --partition low --account <acct> --threads 16 --mem 96
+bash ./dt/submit_diatracer.sh
+# then RE-STAGE: the manifest becomes the reuse form
+python3 scripts/diatracer_stage.py --raw *.d --stage ./stage \
+    --manifest ./fragpipe.fp-manifest --conditions conditions.csv
+```
+
+**Measured: nine files in ~25 min instead of ~3 h.** The mzML are reusable, so
+re-staging emits the two-row reuse form (mzML as `DDA` + the original `.d` as
+`DIA-Quant`) and FragPipe skips conversion entirely, going straight to MSFragger.
+
+No cluster? Run the conversion serially and warn the user about the wall-clock; the
+mzML still only need building once.
+
+## Output contract
+
+FragPipe 24 bundles **DIA-NN 1.8.2 beta 8**, which has **no parquet writer**. The output
+is `<workdir>/dia-quant-output/report.tsv` — there is no `report.parquet` unless someone
+configured DIA-NN 2.x. `adapt_fragpipe` handles either, and `compare_searches.py` reads
+both. `run_de.R --format tsv` consumes the TSV directly, and the `Run` column matches
+the original `.d` basenames, so a `conditions.csv` written for the DIA-NN route works
+unchanged.
+
+`combined_protein.tsv` also appears (IonQuant over the pseudo-spectra). **Do not use it
+as the quant of record** — it is not equivalent to the DIA-NN numbers and the paper
+never uses it.
+
+## When comparing against the DIA-NN route, say this out loud
+
+FragPipe's bundled DIA-NN 1.8.2 beta 8 is **two major versions behind** the 2.x the
+`diann_*` workflows pin. Some of any difference is version lag, not the spectrum-centric
+approach. To control for it, pass an external DIA-NN 2.x via `--config-diann`. Reporting
+a head-to-head without noting this attributes the version gap to the method.
+
+## The verified working invocation
+
+```bash
+export PATH=<venv>/bin:$PATH          # python that can import easypqp
+"$FP" --headless \
+  --workflow  workflow_with_db.workflow \    # database.db-path -> the .fas decoy DB
+  --manifest  fragpipe.fp-manifest \         # reuse form after conversion
+  --workdir   out \
+  --ram 220 --threads 32 \
+  --config-tools-folder <fragpipe>/tools \   # must contain speclib/
+  --config-diann <fragpipe>/tools/diann/1.8.2_beta_8/linux/diann-1.8.1.8
+```
+
+Chain: diaTracer → MSFragger → MSBooster → Percolator → ProteinProphet → EasyPQP →
+DIA-NN. On nine files with conversion already done: **63.8 minutes**, exit 0.
+
+Never trust SLURM `State` alone — verify `dia-quant-output/report.tsv` exists. A
+segfault masked by a trailing `echo` has reported `COMPLETED` with no output.
+
+**Cite:** K. Li et al., *diaTracer enables spectrum-centric analysis of diaPASEF
+proteomics data*, Nat Commun 16, 95 (2025).

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/fragpipe_bootstrap.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/fragpipe_bootstrap.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+fragpipe_bootstrap.py -- make headless FragPipe actually run on a fresh account.
+
+THE PROBLEM
+-----------
+Headless FragPipe refuses the Spectral Library Generation module on any account that
+has never opened the GUI:
+
+    ERROR - Spectral Library Generation module was not configured correctly.
+            Please make sure that Python and FragPipe-SpecLib have been installed.
+
+This is NOT fixable from the command line. It persists with a correct
+--config-tools-folder, a correct --config-diann, python with easypqp on PATH, and
+--config-python pointed at either the venv or its python binary. (--config-python is
+also mis-documented: its help says "the Python directory" but FragPipe execs the path
+directly, so handing it a directory gives `Cannot run program ...: error 13`.)
+
+The state FragPipe actually reads is a per-user cache:
+
+    ~/.config/FragPipe/fragpipe/<version>/fragpipe-ui.cache
+        fragpipe-config.bin-python=/path/to/python      <-- the key that matters
+        fragpipe-config.bin-diann=/path/to/diann-binary
+
+Copying a configured user's cache fixes it instantly; this script writes the same
+two keys without needing a GUI, a display, or another user's home directory.
+
+Every student on a fresh cluster account hits this, so it is not an edge case.
+
+Usage
+  python3 fragpipe_bootstrap.py --python <python-with-easypqp> \\
+      [--diann <diann binary>] [--fragpipe-version 24.0] [--check]
+
+  # UC Davis HIVE (paths already installed):
+  python3 fragpipe_bootstrap.py \\
+      --python /quobyte/proteomics-grp/fragpipe24/easypqp_venv/bin/python \\
+      --diann  /quobyte/proteomics-grp/fragpipe24/fragpipe-24.0/tools/diann/1.8.2_beta_8/linux/diann-1.8.1.8
+
+Then run FragPipe with --config-tools-folder <fragpipe>/tools (the folder holding
+MSFragger, IonQuant, diatracer AND speclib/ — not a jars-only directory).
+"""
+import argparse, os, subprocess, sys
+
+KEY_PY = "fragpipe-config.bin-python"
+KEY_DIANN = "fragpipe-config.bin-diann"
+
+
+def cache_path(version):
+    return os.path.join(os.path.expanduser("~"), ".config", "FragPipe",
+                        "fragpipe", version, "fragpipe-ui.cache")
+
+
+def verify_python(py):
+    """A python that cannot import easypqp will fail later, less legibly."""
+    if not os.path.isfile(py):
+        return f"not a file: {py} (pass the python BINARY, not the venv directory)"
+    if not os.access(py, os.X_OK):
+        return f"not executable: {py}"
+    try:
+        r = subprocess.run([py, "-c", "import easypqp"], capture_output=True, text=True, timeout=90)
+    except Exception as e:
+        return f"could not run {py}: {e}"
+    if r.returncode != 0:
+        return (f"{py} cannot import easypqp. Install it into that interpreter:\n"
+                f"    {py} -m pip install easypqp")
+    return None
+
+
+def read_cache(p):
+    out = {}
+    if os.path.exists(p):
+        for line in open(p):
+            if "=" in line and not line.lstrip().startswith("#"):
+                k, _, v = line.partition("=")
+                out[k.strip()] = v.rstrip("\n")
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--python", help="python interpreter that can import easypqp")
+    ap.add_argument("--diann", help="DIA-NN binary FragPipe should use for quantification")
+    ap.add_argument("--fragpipe-version", default="24.0")
+    ap.add_argument("--check", action="store_true", help="report current state, write nothing")
+    a = ap.parse_args()
+
+    p = cache_path(a.fragpipe_version)
+    cur = read_cache(p)
+
+    if a.check or not (a.python or a.diann):
+        import json
+        print(json.dumps({
+            "cache": p,
+            "exists": os.path.exists(p),
+            KEY_PY: cur.get(KEY_PY),
+            KEY_DIANN: cur.get(KEY_DIANN),
+            "speclib_ready": bool(cur.get(KEY_PY)),
+            "hint": ("Pass --python <interpreter with easypqp> to write it. Without "
+                     f"{KEY_PY} set, headless FragPipe rejects the Spectral Library "
+                     "Generation module no matter what CLI flags you pass."),
+        }, indent=2))
+        return
+
+    if a.python:
+        err = verify_python(a.python)
+        if err:
+            sys.exit(f"[fragpipe_bootstrap] {err}")
+        cur[KEY_PY] = os.path.abspath(a.python)
+    if a.diann:
+        if not os.path.isfile(a.diann):
+            sys.exit(f"[fragpipe_bootstrap] no such DIA-NN binary: {a.diann}")
+        cur[KEY_DIANN] = os.path.abspath(a.diann)
+
+    os.makedirs(os.path.dirname(p), exist_ok=True)
+    with open(p, "w") as fh:
+        fh.write(f"# FragPipe v{a.fragpipe_version} ui cache\n")
+        fh.write("# written by fragpipe_bootstrap.py — headless speclib configuration\n")
+        for k in sorted(cur):
+            fh.write(f"{k}={cur[k]}\n")
+
+    import json
+    print(json.dumps({
+        "wrote": p,
+        KEY_PY: cur.get(KEY_PY),
+        KEY_DIANN: cur.get(KEY_DIANN),
+        "next": ("FragPipe should now accept the speclib module headlessly. Run it with "
+                 "--config-tools-folder <fragpipe>/tools (the folder that holds MSFragger, "
+                 "IonQuant, diatracer AND speclib/)."),
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/make_comparison_report.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/make_comparison_report.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""
+make_comparison_report.py -- build the cross-tool comparison report, interactive
+HTML + markdown, from the outputs the comparison scripts already produce.
+
+WHY
+---
+compare_searches.py and compare_analyses.R emit correct numbers in CSVs. Nobody reads
+CSVs. This assembles them into the report structure DE-LIMP's Run Comparator prompt
+defines (docs/AI_PROMPTS.md section 1) so a cross-tool bake-off lands as a document a
+collaborator can act on:
+
+  1 Factual Observations   2 Sources of Disagreement   3 Case for Run A
+  4 Case for Run B         5 Settings Audit            6 Concordant Proteins
+  7 Synthesis              8 Recommended Follow-ups
+
+It writes the FACTUAL half — every number, table and chart — and leaves the
+interpretive sections as explicit TODO blocks for the model to fill from the data.
+That split is deliberate: the numbers must not be invented, and the judgement must not
+be templated.
+
+The HTML is standalone (no CDN, no fonts, inline SVG), theme-aware, and interactive:
+metric toggles, hover tooltips, sortable tables, a 3x3 concordance matrix.
+
+Usage
+  python3 make_comparison_report.py --out <dir> \\
+      --search-comparison <dir from compare_searches.py> \\
+      [--de-comparison <dir from compare_analyses.R>] \\
+      [--qc "LabelA:<sessionA>/output/tables/QC_detected_vs_inferred.csv"] \\
+      [--qc "LabelB:<sessionB>/output/tables/QC_detected_vs_inferred.csv"] \\
+      [--instrument "timsTOF HT"] [--title "..."]
+
+Then: python3 to_docx.py --in <out>/COMPARISON_REPORT.md --out <out>/COMPARISON_REPORT.docx
+"""
+import argparse, csv, html, json, os, sys
+
+PALETTE = {  # validated with dataviz/scripts/validate_palette.js, light + dark
+    "a_light": "#2a78d6", "b_light": "#eb6834",
+    "a_dark": "#3987e5", "b_dark": "#d95926",
+}
+
+
+def read_csv(p):
+    if not p or not os.path.exists(p):
+        return []
+    with open(p, newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def num(x, d=0.0):
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return d
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--search-comparison", required=True,
+                    help="directory written by compare_searches.py")
+    ap.add_argument("--de-comparison", help="directory written by compare_analyses.R")
+    ap.add_argument("--qc", action="append", default=[],
+                    help='"Label:path/to/QC_detected_vs_inferred.csv" (repeatable)')
+    ap.add_argument("--instrument", default="")
+    ap.add_argument("--title", default="Cross-tool search comparison")
+    a = ap.parse_args()
+    os.makedirs(a.out, exist_ok=True)
+
+    searches = read_csv(os.path.join(a.search_comparison, "search_summary.csv"))
+    if not searches:
+        sys.exit(f"no search_summary.csv in {a.search_comparison} — run compare_searches.py first")
+    conc = read_csv(os.path.join(a.de_comparison, "concordance_summary.csv")) if a.de_comparison else []
+    universe = read_csv(os.path.join(a.de_comparison, "protein_universe.csv")) if a.de_comparison else []
+
+    qc = {}
+    for spec in a.qc:
+        lab, _, path = spec.partition(":")
+        rows = read_csv(path)
+        if rows:
+            qc[lab] = rows
+
+    # 3x3 matrices, one per shared contrast
+    mats = {}
+    if a.de_comparison:
+        for fn in sorted(os.listdir(a.de_comparison)):
+            if fn.startswith("concordance_") and fn.endswith(".csv") and "summary" not in fn:
+                rows = read_csv(os.path.join(a.de_comparison, fn))
+                if rows:
+                    ct = fn.replace("concordance_", "").replace(".csv", "").split("__")[-1]
+                    mats[ct] = [[int(num(r.get(k, 0))) for k in ("Up", "Down", "NS")] for r in rows]
+
+    labels = [s["search"] for s in searches]
+    A = labels[0]
+    B = labels[1] if len(labels) > 1 else None
+
+    data = {
+        "title": a.title, "instrument": a.instrument,
+        "searches": searches, "concordance": conc, "universe": universe,
+        "qc": qc, "matrices": mats, "labels": labels,
+    }
+
+    # ---------------------------------------------------------------- markdown
+    md = [f"# {a.title}", ""]
+    if a.instrument:
+        md += [f"**Instrument:** {a.instrument}", ""]
+    md += ["> Both pipelines are established and peer-reviewed; neither is inherently superior.",
+           "> Evaluate on the data.", ""]
+
+    md += ["## 1. Factual observations", "",
+           "| Search | Runs | Protein groups | Per-run min/med/max | In every run | Median CV |",
+           "|---|---:|---:|---|---:|---:|"]
+    for s in searches:
+        md.append(f"| {s['search']} | {s['runs']} | {s['protein_groups']} | "
+                  f"{s['per_run_min']} / {s['per_run_median']} / {s['per_run_max']} | "
+                  f"{s['complete_in_all_runs']} ({s['completeness_pct']}%) | {s['median_cv_pct']}% |")
+    md.append("")
+    md.append("Depth alone does not decide which search is better — read protein groups, "
+              "how many survive in *every* run, and the CV together.")
+    md.append("")
+
+    if conc:
+        md += ["### Differential expression — same DE pipeline, search as the only variable", "",
+               "| Contrast | " + " | ".join(f"{c} sig" for c in (A, B)) +
+               " | Co-significant | Direction concordance | logFC r |",
+               "|---|---:|---:|---:|---:|---:|"]
+        for c in conc:
+            md.append(f"| {c['contrast']} | {c['sig_A']} | {c['sig_B']} | {c['sig_both']} | "
+                      f"{100*num(c['direction_concordance']):.1f}% | {num(c['logFC_correlation']):.3f} |")
+        md += ["", "<!-- TODO(model): does one engine give more DE proteins? State whether the "
+                   "answer is consistent across contrasts or flips, and quantify. Compare the "
+                   "logFC correlation against the search-level intensity correlation — ratios "
+                   "amplify disagreement, so a high intensity r with a lower logFC r means "
+                   "direction is trustworthy and magnitude is engine-dependent. -->", ""]
+    for ct, m in mats.items():
+        md += [f"#### 3x3 concordance — {ct}", "",
+               f"| {A} \\ {B} | Up | Down | NS |", "|---|---:|---:|---:|"]
+        for lab, row in zip(("Up", "Down", "NS"), m):
+            md.append(f"| **{lab}** | " + " | ".join(f"{v:,}" for v in row) + " |")
+        md.append("")
+
+    if qc:
+        md += ["### QC panels", "",
+               "| Run | " + " | ".join(f"{k} % detected" for k in qc) + " |",
+               "|---|" + "---:|" * len(qc)]
+        keys = list(qc)
+        runs = {r["Sample"]: r for r in qc[keys[0]]}
+        for samp in runs:
+            cells = []
+            for k in keys:
+                row = next((r for r in qc[k] if r["Sample"] == samp), None)
+                cells.append(f"{num(row['PctDetected']):.1f}" if row else "—")
+            md.append(f"| {samp} | " + " | ".join(cells) + " |")
+        md += ["", "<!-- TODO(model): note where each engine's detected fraction is higher and "
+                   "whether the advantage tracks sample quality. -->", ""]
+
+    for n, head, todo in [
+        (2, "Sources of disagreement",
+         "For each source: what the difference is, how many proteins it plausibly affects "
+         "(systematic vs protein-specific), and the expected direction. Ground claims in the "
+         "literature. Name any engine-VERSION difference explicitly — it confounds everything."),
+        (3, f"Case for {A}",
+         f"Argue the strongest case for trusting {A} for THIS experiment, citing numbers above."),
+        (4, f"Case for {B or 'Run B'}",
+         f"Argue the strongest case for trusting {B or 'Run B'} for THIS experiment, citing numbers above."),
+        (5, "Settings audit",
+         "One row per differing setting: could it explain an observed discrepancy? Flag anything "
+         "that looks misconfigured for this experiment type. Be specific about which discrepancy."),
+        (6, "Concordant proteins",
+         "Characterise the shared significant set — pathways, compartments, known markers. Then "
+         "warn that protein-GROUP identifiers differ between tools, so some 'unique' proteins are "
+         "grouping artefacts, not detection differences."),
+        (7, "Synthesis",
+         "Weigh sections 3-4. If one pipeline is clearly more appropriate for this design, say why. "
+         "If the evidence does not clearly favour one, SAY SO — do not force a recommendation."),
+        (8, "Recommended follow-ups",
+         "Two concrete follow-ups, one probing each pipeline (not both aimed at the same tool). "
+         "Name specific proteins, settings or validations."),
+    ]:
+        md += [f"## {n}. {head}", "", f"<!-- TODO(model): {todo} -->", ""]
+
+    md_path = os.path.join(a.out, "COMPARISON_REPORT.md")
+    open(md_path, "w").write("\n".join(md) + "\n")
+
+    # ---------------------------------------------------------------- html
+    html_path = os.path.join(a.out, "COMPARISON_REPORT.html")
+    open(html_path, "w").write(build_html(data))
+
+    print(json.dumps({
+        "markdown": md_path, "html": html_path,
+        "searches": labels, "contrasts": [c["contrast"] for c in conc],
+        "qc_panels": list(qc),
+        "next": ["Fill every TODO(model) block in the markdown from the data — do not invent numbers.",
+                 f"python3 to_docx.py --in {md_path} --out {os.path.join(a.out,'COMPARISON_REPORT.docx')}"],
+    }, indent=2))
+
+
+def build_html(d):
+    esc = html.escape
+    j = json.dumps
+    return f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{esc(d['title'])}</title>
+<style>
+:root{{color-scheme:light;--s0:#f4f3ef;--s1:#fcfcfb;--s2:#eeece6;--line:#dcd9d0;--lineS:#c4c0b4;
+ --t1:#0b0b0b;--t2:#52514e;--t3:#7d7b74;--a:{PALETTE['a_light']};--b:{PALETTE['b_light']};--warn:#eda100;--good:#1baf7a}}
+@media (prefers-color-scheme:dark){{:root:where(:not([data-theme="light"])){{color-scheme:dark;
+ --s0:#121211;--s1:#1a1a19;--s2:#232322;--line:#33322f;--lineS:#4a4945;
+ --t1:#fff;--t2:#c3c2b7;--t3:#928f85;--a:{PALETTE['a_dark']};--b:{PALETTE['b_dark']};--warn:#c98500;--good:#199e70}}}}
+:root[data-theme="dark"]{{color-scheme:dark;--s0:#121211;--s1:#1a1a19;--s2:#232322;--line:#33322f;--lineS:#4a4945;
+ --t1:#fff;--t2:#c3c2b7;--t3:#928f85;--a:{PALETTE['a_dark']};--b:{PALETTE['b_dark']};--warn:#c98500;--good:#199e70}}
+*{{box-sizing:border-box}}body{{margin:0;background:var(--s0);color:var(--t1);line-height:1.6;
+ font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}}
+.wrap{{max-width:1080px;margin:0 auto;padding:40px 22px 80px}}
+header{{border-bottom:2px solid var(--t1);padding-bottom:18px;margin-bottom:24px}}
+h1{{font-size:1.8rem;margin:0 0 6px;letter-spacing:-.015em}}h2{{font-size:1.2rem;margin:40px 0 10px}}
+.sub{{color:var(--t2);margin:0}}
+.cards{{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:14px;margin:20px 0}}
+.card{{background:var(--s1);border:1px solid var(--line);border-radius:12px;padding:16px 18px}}
+.lab{{font-size:.73rem;text-transform:uppercase;letter-spacing:.07em;color:var(--t3);font-weight:700}}
+.n{{font-size:1.85rem;font-weight:700;margin:4px 0 2px;font-variant-numeric:tabular-nums}}
+.note{{font-size:.83rem;color:var(--t2)}}
+.sw{{display:inline-block;width:10px;height:10px;border-radius:3px;margin-right:6px}}
+.pa{{background:var(--a)}}.pb{{background:var(--b)}}
+.panel{{background:var(--s1);border:1px solid var(--line);border-radius:12px;padding:18px 20px;margin:16px 0}}
+.ctl{{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin-bottom:12px}}
+button.seg{{background:var(--s2);border:1px solid var(--lineS);color:var(--t2);padding:6px 13px;
+ border-radius:999px;font-size:.85rem;cursor:pointer;font-family:inherit}}
+button.seg[aria-pressed="true"]{{background:var(--t1);color:var(--s1);border-color:var(--t1)}}
+.leg{{display:flex;gap:15px;font-size:.84rem;color:var(--t2);margin-left:auto}}
+svg{{display:block;width:100%;height:auto;overflow:visible}}.grid line{{stroke:var(--line)}}
+.bar:hover{{opacity:.78;cursor:pointer}}.dot{{stroke:var(--s1);stroke-width:2}}
+.tip{{position:fixed;pointer-events:none;opacity:0;transition:opacity .1s;background:var(--t1);
+ color:var(--s1);padding:8px 11px;border-radius:8px;font-size:.8rem;z-index:50;max-width:260px}}
+table{{border-collapse:collapse;width:100%;font-size:.9rem;margin:.6rem 0}}
+th,td{{border-bottom:1px solid var(--line);padding:8px 10px;text-align:left}}
+th{{color:var(--t2);font-size:.77rem;text-transform:uppercase;letter-spacing:.05em;cursor:pointer}}
+td.num,th.num{{text-align:right;font-variant-numeric:tabular-nums}}
+.tw{{overflow-x:auto}}
+.todo{{background:var(--s2);border-left:3px solid var(--warn);border-radius:8px;padding:12px 15px;
+ margin:14px 0;font-size:.9rem;color:var(--t2)}}
+footer{{margin-top:48px;padding-top:16px;border-top:1px solid var(--line);color:var(--t3);font-size:.83rem}}
+.tb{{position:fixed;top:14px;right:14px;z-index:60;background:var(--s1);border:1px solid var(--lineS);
+ color:var(--t2);border-radius:999px;padding:6px 13px;font-size:.8rem;cursor:pointer}}
+</style></head><body>
+<button class="tb" id="tb">◐ theme</button>
+<div class="wrap">
+<header><h1>{esc(d['title'])}</h1>
+<p class="sub">{esc(d['instrument'])}</p></header>
+
+<div class="todo"><strong>Both pipelines are established and peer-reviewed; neither is inherently
+superior.</strong> Sections 2–8 of the markdown carry <code>TODO(model)</code> blocks to be filled
+from the data below. The numbers here are generated, not written.</div>
+
+<div class="cards" id="cards"></div>
+
+<h2>1. Factual observations</h2>
+<div class="panel">
+  <div class="ctl" id="mctl"></div>
+  <svg id="bars" viewBox="0 0 900 400" role="img" aria-label="Per-search identification summary"></svg>
+</div>
+
+<div class="panel" id="concpanel" hidden>
+  <div class="ctl" id="cctl"><strong style="font-size:.92rem">3&times;3 DE concordance</strong></div>
+  <svg id="conc" viewBox="0 0 900 290" role="img" aria-label="Concordance matrix"></svg>
+  <p class="note" id="cnote"></p>
+</div>
+
+<div class="panel" id="qcpanel" hidden>
+  <div class="ctl"><strong style="font-size:.92rem">Detected vs DPC-inferred, per sample</strong>
+    <div class="leg" id="qcleg"></div></div>
+  <svg id="qc" viewBox="0 0 900 340" role="img" aria-label="Percent detected per sample"></svg>
+</div>
+
+<div class="tw"><table id="tbl"><thead></thead><tbody></tbody></table></div>
+
+<footer>Generated by <code>make_comparison_report.py</code> ·
+structure follows DE-LIMP's Run Comparator (<code>docs/AI_PROMPTS.md</code> §1) ·
+palette validated with the dataviz six-checks validator</footer>
+</div>
+<div class="tip" id="tip"></div>
+<script>
+const D = {j(d)};
+const NS="http://www.w3.org/2000/svg", tip=document.getElementById("tip");
+const fmt=n=>Number(n).toLocaleString();
+const el=(t,a={{}})=>{{const e=document.createElementNS(NS,t);for(const k in a)e.setAttribute(k,a[k]);return e}};
+function T(h,ev){{tip.innerHTML=h;tip.style.opacity=1;const r=tip.getBoundingClientRect();
+ let x=ev.clientX+14,y=ev.clientY-10;
+ if(x+r.width>innerWidth-10)x=ev.clientX-r.width-14;
+ if(y+r.height>innerHeight-10)y=innerHeight-r.height-10;
+ tip.style.left=x+"px";tip.style.top=y+"px"}}
+const H=()=>tip.style.opacity=0;
+const COL=i=>i===0?"var(--a)":"var(--b)";
+
+/* cards */
+(function(){{
+  const c=document.getElementById("cards");
+  D.searches.forEach((s,i)=>{{
+    c.insertAdjacentHTML("beforeend",
+     `<div class="card"><div class="lab"><span class="sw ${{i===0?'pa':'pb'}}"></span>${{s.search}}</div>
+      <div class="n">${{fmt(s.protein_groups)}}</div>
+      <div class="note">protein groups · ${{s.median_cv_pct}}% median CV</div></div>`);
+  }});
+  D.concordance.forEach(k=>{{
+    c.insertAdjacentHTML("beforeend",
+     `<div class="card"><div class="lab">${{k.contrast}} · significant</div>
+      <div class="n">${{fmt(k.sig_A)}} <span style="font-size:1rem;color:var(--t3)">vs ${{fmt(k.sig_B)}}</span></div>
+      <div class="note">${{fmt(k.sig_both)}} co-significant · r ${{Number(k.logFC_correlation).toFixed(3)}}</div></div>`);
+  }});
+}})();
+
+/* metric bars */
+const METRICS=[["protein_groups","Protein groups"],["complete_in_all_runs","In every run"],
+               ["median_cv_pct","Median CV %"]];
+let mi=0;
+(function(){{const w=document.getElementById("mctl");
+  METRICS.forEach(([k,l],i)=>{{const b=document.createElement("button");
+    b.className="seg";b.textContent=l;b.setAttribute("aria-pressed",i===0);
+    b.onclick=()=>{{mi=i;[...w.querySelectorAll("button")].forEach((o,jj)=>o.setAttribute("aria-pressed",jj===i));bars()}};
+    w.appendChild(b)}});
+  const lg=document.createElement("div");lg.className="leg";
+  lg.innerHTML=D.searches.map((s,i)=>`<span><span class="sw ${{i===0?'pa':'pb'}}"></span>${{s.search}}</span>`).join("");
+  w.appendChild(lg)}})();
+function bars(){{
+  const svg=document.getElementById("bars");svg.innerHTML="";
+  const [key,label]=METRICS[mi];
+  const W=900,L=210,R=70,Tp=20,B=44,ih=D.searches.length*72;
+  const vals=D.searches.map(s=>Number(s[key])||0), mx=Math.max(...vals)*1.12;
+  svg.setAttribute("viewBox",`0 0 ${{W}} ${{Tp+ih+B}}`);
+  const x=v=>L+(v/mx)*(W-L-R);
+  for(let i=0;i<=4;i++){{const gx=x(mx*i/4);
+    svg.appendChild(el("line",{{x1:gx,x2:gx,y1:Tp,y2:Tp+ih,class:"grid","stroke-width":1}}));
+    const t=el("text",{{x:gx,y:Tp+ih+18,"text-anchor":"middle",fill:"var(--t3)","font-size":"11"}});
+    t.textContent=(mx*i/4).toFixed(mx<100?1:0);svg.appendChild(t)}}
+  D.searches.forEach((s,i)=>{{
+    const cy=Tp+72*i+36, v=Number(s[key])||0;
+    const lb=el("text",{{x:L-14,y:cy+4,"text-anchor":"end","font-size":"12",fill:"var(--t2)"}});
+    lb.textContent=s.search;svg.appendChild(lb);
+    const r=el("rect",{{x:L,y:cy-13,width:Math.max(1,x(v)-L),height:26,rx:4,fill:COL(i),class:"bar"}});
+    r.addEventListener("mousemove",e=>T(`<b>${{s.search}}</b><br>${{label}}: <b>${{fmt(v)}}</b><br>`+
+      `runs ${{s.runs}} · per-run ${{s.per_run_min}}–${{s.per_run_max}}`,e));
+    r.addEventListener("mouseleave",H);svg.appendChild(r);
+    const vt=el("text",{{x:x(v)+10,y:cy+4,"font-size":"12",fill:"var(--t2)"}});
+    vt.textContent=fmt(v);svg.appendChild(vt)}});
+  const at=el("text",{{x:(L+W-R)/2,y:Tp+ih+38,"text-anchor":"middle",fill:"var(--t2)","font-size":"11"}});
+  at.textContent=label;svg.appendChild(at)}}
+
+/* 3x3 concordance */
+const CT=Object.keys(D.matrices||{{}});let ck=CT[0];
+if(CT.length){{
+  document.getElementById("concpanel").hidden=false;
+  const w=document.getElementById("cctl");
+  CT.forEach((k,i)=>{{const b=document.createElement("button");b.className="seg";b.textContent=k;
+    b.setAttribute("aria-pressed",i===0);
+    b.onclick=()=>{{ck=k;[...w.querySelectorAll("button")].forEach(o=>o.setAttribute("aria-pressed",o.textContent===k));conc()}};
+    w.appendChild(b)}});
+}}
+function conc(){{
+  if(!CT.length)return;
+  const svg=document.getElementById("conc");svg.innerHTML="";
+  const m=D.matrices[ck],labs=["Up","Down","NS"],L=200,Tp=44,cw=118,ch=62;
+  const mx=Math.max(...m.flat());
+  labs.forEach((l,jj)=>{{const t=el("text",{{x:L+cw*jj+cw/2,y:Tp-14,"text-anchor":"middle",
+    "font-size":"12",fill:"var(--t2)","font-weight":"600"}});
+    t.textContent=(D.labels[1]||"B")+" "+l;svg.appendChild(t)}});
+  m.forEach((row,i)=>{{
+    const t=el("text",{{x:L-14,y:Tp+ch*i+ch/2+4,"text-anchor":"end","font-size":"12",
+      fill:"var(--t2)","font-weight":"600"}});
+    t.textContent=(D.labels[0]||"A")+" "+labs[i];svg.appendChild(t);
+    row.forEach((v,jj)=>{{
+      const agree=i===jj, flip=(i===0&&jj===1)||(i===1&&jj===0);
+      const f=Math.pow(v/mx,0.45);
+      const fill = flip ? `color-mix(in oklab, var(--warn) ${{Math.max(18,f*100)}}%, var(--s1))`
+        : agree ? `color-mix(in oklab, var(--a) ${{Math.max(10,f*88)}}%, var(--s1))`
+        : `color-mix(in oklab, var(--t3) ${{Math.max(7,f*42)}}%, var(--s1))`;
+      const r=el("rect",{{x:L+cw*jj+1,y:Tp+ch*i+1,width:cw-3,height:ch-3,rx:6,fill:fill,
+        stroke:"var(--line)"}});
+      r.style.cursor="pointer";
+      const mean=agree?"both agree":(flip?"OPPOSITE DIRECTION":(i===2?"B only":"A only"));
+      r.addEventListener("mousemove",e=>T(`<b>${{fmt(v)}}</b> protein groups<br>${{mean}}`,e));
+      r.addEventListener("mouseleave",H);svg.appendChild(r);
+      const tx=el("text",{{x:L+cw*jj+cw/2,y:Tp+ch*i+ch/2+5,"text-anchor":"middle","font-size":"14",
+        "font-weight":(agree||flip)?"700":"500",fill:f>0.62?"var(--s1)":"var(--t1)"}});
+      tx.textContent=fmt(v);svg.appendChild(tx)}})}});
+  const k=(D.concordance||[]).find(c=>ck.includes(c.contrast)||c.contrast.includes(ck));
+  document.getElementById("cnote").textContent = k
+    ? `${{k.contrast}} — direction concordance ${{(100*Number(k.direction_concordance)).toFixed(1)}}%, logFC r ${{Number(k.logFC_correlation).toFixed(3)}}. Off-diagonal NS cells are detection differences; the Up/Down corners are genuine direction disagreements.`
+    : "";
+}}
+
+/* QC dumbbell */
+const QK=Object.keys(D.qc||{{}});
+function qcplot(){{
+  if(QK.length<1)return;
+  document.getElementById("qcpanel").hidden=false;
+  document.getElementById("qcleg").innerHTML=
+    QK.map((k,i)=>`<span><span class="sw ${{i===0?'pa':'pb'}}"></span>${{k}}</span>`).join("");
+  const rows=D.qc[QK[0]].map(r=>r.Sample);
+  const svg=document.getElementById("qc");svg.innerHTML="";
+  const W=900,L=210,R=60,Tp=16,B=44,ih=Math.max(120,rows.length*32);
+  svg.setAttribute("viewBox",`0 0 ${{W}} ${{Tp+ih+B}}`);
+  const lo=Math.min(50,...QK.flatMap(k=>D.qc[k].map(r=>+r.PctDetected)))-4, hi=100;
+  const x=v=>L+((v-lo)/(hi-lo))*(W-L-R), band=ih/rows.length;
+  for(let v=Math.ceil(lo/10)*10;v<=100;v+=10){{const gx=x(v);
+    svg.appendChild(el("line",{{x1:gx,x2:gx,y1:Tp,y2:Tp+ih,class:"grid","stroke-width":1}}));
+    const t=el("text",{{x:gx,y:Tp+ih+18,"text-anchor":"middle",fill:"var(--t3)","font-size":"11"}});
+    t.textContent=v+"%";svg.appendChild(t)}}
+  rows.forEach((samp,i)=>{{
+    const cy=Tp+band*i+band/2;
+    const short=samp.replace(/^.*?DIA_/,"");
+    const lb=el("text",{{x:L-12,y:cy+4,"text-anchor":"end","font-size":"11",fill:"var(--t2)"}});
+    lb.textContent=short.length>26?short.slice(0,25)+"…":short;svg.appendChild(lb);
+    const vs=QK.map(k=>{{const r=D.qc[k].find(r=>r.Sample===samp);return r?+r.PctDetected:null}});
+    const ok=vs.filter(v=>v!==null);
+    if(ok.length>1) svg.appendChild(el("line",{{x1:x(Math.min(...ok)),x2:x(Math.max(...ok)),
+      y1:cy,y2:cy,stroke:"var(--lineS)","stroke-width":2}}));
+    vs.forEach((v,k)=>{{if(v===null)return;
+      const c=el("circle",{{cx:x(v),cy:cy,r:6,fill:COL(k),class:"dot"}});
+      c.addEventListener("mousemove",e=>T(`<b>${{short}}</b><br>${{QK[k]}}: <b>${{v.toFixed(1)}}%</b> detected`+
+        `<br>${{(100-v).toFixed(1)}}% inferred by DPC`,e));
+      c.addEventListener("mouseleave",H);svg.appendChild(c)}})}});
+  const at=el("text",{{x:(L+W-R)/2,y:Tp+ih+38,"text-anchor":"middle",fill:"var(--t2)","font-size":"11"}});
+  at.textContent="% of protein matrix actually measured (not DPC-inferred)";svg.appendChild(at)}}
+
+/* sortable table */
+let sk="search",sa=true;
+function tbl(){{
+  const cols=Object.keys(D.searches[0]);
+  const th=document.querySelector("#tbl thead");
+  th.innerHTML="<tr>"+cols.map(c=>`<th class="${{isNaN(D.searches[0][c])?'':'num'}}" data-k="${{c}}">${{c.replace(/_/g," ")}}</th>`).join("")+"</tr>";
+  th.querySelectorAll("th").forEach(h=>h.onclick=()=>{{const k=h.dataset.k;
+    if(sk===k)sa=!sa;else{{sk=k;sa=true}}tbl()}});
+  const rows=[...D.searches].sort((p,q)=>{{const A=p[sk],Bv=q[sk];
+    const v=(!isNaN(A)&&!isNaN(Bv))?A-Bv:String(A).localeCompare(String(Bv));return sa?v:-v}});
+  document.querySelector("#tbl tbody").innerHTML=rows.map(r=>"<tr>"+
+    cols.map(c=>`<td class="${{isNaN(r[c])?'':'num'}}">${{r[c]}}</td>`).join("")+"</tr>").join("");
+}}
+
+document.getElementById("tb").onclick=()=>{{
+  const cur=document.documentElement.getAttribute("data-theme");
+  const nx=cur==="dark"?"light":(cur==="light"?"dark":
+    (matchMedia("(prefers-color-scheme: dark)").matches?"light":"dark"));
+  document.documentElement.setAttribute("data-theme",nx);
+  bars();conc();qcplot()}};
+
+bars();conc();qcplot();tbl();
+</script></body></html>
+"""
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Everything here came out of the first real DIA-NN vs diaTracer bake-off — 9 mouse dia-PASEF files on a **fresh cluster account**, which is what a student will be. Each item cost a failed job, so none of it is theoretical. **Written for people without HIVE**: every path in the docs is an example, not a requirement.

## `references/fragpipe-diatracer.md` — the four gates

1. **The engines are licence-gated, and the tools folder must be the one containing `speclib/`.** A curated "licensed jars only" directory fails — FragPipe wants `speclib/gen_con_spec_lib.py` beside the jars.
2. **MSFragger needs a target+decoy FASTA** (`No decoys found in the FASTA file`). DIA-NN generates decoys internally; FragPipe does not. Philosopher recipe included, matching `database.decoy-tag=rev_`.
3. **Headless FragPipe rejects the spectral-library module on any account that has never opened the GUI — and no CLI flag fixes it.** It survived a correct `--config-tools-folder`, a correct `--config-diann`, easypqp first on `PATH`, and `--config-python` at both the venv and its binary. Five invocations, five identical failures. The state it actually reads is `~/.config/FragPipe/fragpipe/<ver>/fragpipe-ui.cache` → `fragpipe-config.bin-python`. (`--config-python` is also mis-documented: help says "directory", but FragPipe execs the path, so a directory gives `error 13`.)
4. **diaTracer's standalone `main()` ignores its own documented defaults** — omit any numeric option and it dies instantly with `NullPointerException` in `Double.parseDouble`.

## `scripts/fragpipe_bootstrap.py`

Writes that cache without a GUI or a display. Verifies the interpreter can actually `import easypqp` before writing, because one that can't fails later and less legibly. `--check` reports current state without touching anything. **Every student on a fresh account hits gate 3** — this makes it setup rather than triage.

## `scripts/make_comparison_report.py`

The comparison scripts emit correct numbers in CSVs; nobody reads CSVs. This builds a **standalone interactive HTML** — metric toggles, hover tooltips, a 3×3 concordance matrix, sortable tables, theme-aware, no CDN — plus a markdown skeleton in the section order your Run Comparator prompt defines (`docs/AI_PROMPTS.md` §1).

The split is deliberate: **the generator writes every number, and leaves `TODO(model)` blocks for the judgement.** Numbers must not be invented; judgement must not be templated. It also carries the prompt's guidelines forward — neither tool inherently superior, every claim tied to a number or citation, speculation labelled.

Palette validated with the dataviz six-checks validator, light and dark.

## `SKILL.md`

New **step 11c**: run `compare_searches.py` *and* `compare_analyses.R`, then build the report. Two things it insists on — push **both** engines through the same `run_de.R` so the search is the only variable (`--format tsv` reads FragPipe output directly), and **state any engine-version gap out loud**, because FragPipe 24 bundles DIA-NN 1.8.2 beta 8, two majors behind what the `diann_*` workflows pin. Plus the four gates and the auto-parallel instruction in the engine section.

## Verified

`fragpipe_bootstrap.py --check` and `make_comparison_report.py` both run clean against the real 9-file bake-off. The full FragPipe chain (diaTracer → MSFragger → MSBooster → Percolator → ProteinProphet → EasyPQP → DIA-NN) completed in 63.8 min, exit 0, once gate 3 was cleared.

**Not merging this myself** — leaving it for review as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4E3rNmy5noGLyiJL9RWv5