### PR TITLE
fix(tests): source helpers_site.R in the test harness (1 of 6 CI failures)

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -10,6 +10,11 @@ if (!exists("%||%")) `%||%` <- function(x, y) if (is.null(x)) y else x
 # Load helpers.R (cal_z_score, detect_organism_db)
 source(file.path(project_root, "R", "helpers.R"))
 
+# Load helpers_site.R (delimp_site) — helpers_search.R calls it from
+# translate_storage_path() and activity_log_path(), so it must be loaded FIRST or
+# every test touching those paths dies with "could not find function delimp_site".
+source(file.path(project_root, "R", "helpers_site.R"))
+
 # Load helpers_search.R (build_diann_flags, parse_sbatch_output, etc.)
 source(file.path(project_root, "R", "helpers_search.R"))
 


### PR DESCRIPTION
CI on `main` is red, and has been since before PR #23/#26 — I verified the failure set is byte-identical on `main` and on those branches, so neither introduced it. This fixes the one failure that has an unambiguous fix.

## Fixed here

`test-search_history.R:4` — `Error: could not find function "delimp_site"`.

`helpers_search.R` calls `delimp_site()` from `translate_storage_path()` and `activity_log_path()`, but `tests/testthat/setup.R` never sourced `R/helpers_site.R`. Any test touching those paths died at load. One `source()` line.

Verified locally: `search_history_path()` now returns `~/.delimp_activity_log.csv`.

## NOT fixed here — needs your call

The other five failures are all `test-helpers_proteogenomics.R` (lines 93, 95, 96, 98, 108) and are a genuine code-vs-test disagreement, not a harness gap:

The test calls `classify_proteins(fake_genes)` with **no `fasta_path`**, supplying `source=` / `ORF_type=` / `parent_gene=` in a `Protein.Group.Description` column and expecting them to be parsed. But `classify_proteins()` never reads that column — it classifies by **accession structure**, and only picks up those tags from `parse_fasta_source_tags(fasta_path)`. Production always passes one (`server_data.R:21` → `values$proteog_active_fasta`), so on that evidence the *test* is under-specified, not the code.

But fixing the test that way still leaves row 4 failing, and that one looks like a real bug:

- Accession `sp|MSTRG.10075.2.p1|Trim25_MM39TEST` → `.classify_single_accession()` returns `NOVEL_GENE` (matches the `MSTRG.*.pN` pattern).
- The FASTA header says `source=NOVEL_ISOFORM parent_gene=ENSMUSG00000005951` — a novel isoform *of a known gene*.
- `classify_proteins()` only upgrades to `NOVEL_ISOFORM` when the accession-based class is exactly `REF` (`helpers_proteogenomics.R:196`), so `NOVEL_GENE` never upgrades.

A StringTie-assembled novel isoform of a known gene gets an `MSTRG` transcript ID, so its accession *always* looks like `NOVEL_GENE` while the FASTA correctly labels it `NOVEL_ISOFORM`. If that reading is right, novel-isoform proteins are being reported as novel genes — which would inflate the novel-gene count in proteogenomics output.

I stopped short of changing it: that's a scientific classification rule, and whether the FASTA tag should override the accession heuristic in general is your call, not something to infer from a test. Happy to implement whichever way you want — my suggestion would be to let the explicit FASTA `source=` win over the structural guess (the code already treats the FASTA as authoritative "refinement"), and update the test to pass a `fasta_path` like production does.