### PR TITLE
fix(skill): make the Radiant route actually work — found by running all 3 workflows on real data (v1.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/references/search-engines.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/search-engines.md
@@ -126,10 +126,24 @@ Radiant source (`seerbio/radiant`, internal name **Pythia**), not inferred from 
 - **A spectral library is always required.** `--library` is `required=True`, and
   **`--libfree` does not mean library-free** — in the click definition it is the
   same switch as `--no-mbr` (`"--mbr/--no-mbr", "--no-libfree/--libfree"`), so it
-  selects single-pass vs MBR. `run_search.py` generates the library with **DIA-NN's
-  predictor**; Radiant's `FragLibTsvReader` takes DIA-NN's library TSV schema
-  directly (its test fixture header is DIA-NN's `report-lib.tsv` columns verbatim).
-  So **this route needs DIA-NN acquired too**. `--library` reuses an existing one.
+  selects single-pass vs MBR. So **this route needs DIA-NN acquired too**.
+- **⚠ DIA-NN and Radiant share no library format directly** — verified on real runs,
+  and the reason `make_radiant_library.py` exists:
+  1. `--out-lib foo.tsv --predictor` does **not** write `foo.tsv`. DIA-NN ignores the
+     extension for predicted libraries and writes `foo.predicted.speclib`.
+  2. Radiant *does* read `.speclib`, but only **format v ≥ −3**
+     (`SpecLibSrc/Library.h`). DIA-NN 2.6 writes **v−11**, 2.x generally v−10, so
+     `RadiantDIA` aborts with `ERROR: version is not supported11`. Every speclib on
+     the UCD share is v−10/v−11.
+  3. DIA-NN **cannot emit TSV at all** — asked to convert to `.tsv` it silently
+     writes `.parquet`.
+  4. That parquet uses **dot-separated** names (`Precursor.Mz`, `Relative.Intensity`)
+     while Radiant wants concatenated ones (`PrecursorMz`, `LibraryIntensity`), so a
+     straight dump is unreadable.
+
+  `make_radiant_library.py` does predict → parquet → renamed TSV, and
+  `run_search.py` calls it automatically. A human proteome library is ~50 M rows /
+  ~10 GB of TSV.
 - **Multi-file runs are serial in Radiant itself** — the backend raises
   `NotImplementedError` for parallel mode. On a cluster the skill works around this
   (below), so this only bites on a single machine.
@@ -166,6 +180,23 @@ directory name is the contract between steps 2 and 3 — don't rename it.
 Step 2 skips any file whose `.radiantDIA` already exists, so a preempted
 `publicgrp/low` task requeues without redoing work, and step 3 refuses to rescore a
 partial set. `--no-parallel` forces the single serial search.
+
+**Feeding results to the DE-LIMP app.** `adapt_radiant` produces the skill's own DE
+contract (one row per protein×run, `PG.MaxLFQ`). DE-LIMP wants something different: its
+upload feeds `limpa::readDIANN()`, which is **precursor-level** and needs `Run`,
+`Precursor.Id`, `Precursor.Normalised`, `Protein.Group`, `Protein.Names`, `Genes`,
+`Proteotypic`, `Q.Value`, `Lib.Q.Value`, `Lib.PG.Q.Value`. Use
+`radiant_to_delimp.py --results <out>/radiant_results --library <lib.tsv> --out
+delimp_report.parquet` and upload that. It derives `Precursor.Id` from modified
+sequence + charge, maps the `Global.*` q-values onto the `Lib.*` names, and recovers
+`Protein.Names`/`Genes` from the library — Fulcrum drops them, and without the join
+DE-LIMP loses gene-level annotation (GSEA, gene labels). Pass `--library` or those
+columns are emitted empty rather than invented.
+
+**Run names.** Fulcrum reports `Run` as a URI of the per-file result
+(`file:///…/Sample.mzML.radiantDIA`). Both adapters reduce it to the bare `Sample`, so
+a `conditions.csv` keyed on sample names matches — a single `splitext` would leave
+`Sample.mzML` and silently fail group assignment.
 
 **Adapter.** Fulcrum's `combined` output backend already uses DIA-NN-style column
 names (`Run`, `Protein.Group`, `Precursor.Quantity`, `PG.Quantity`, `PG.Normalised`,

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/make_radiant_library.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/make_radiant_library.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+make_radiant_library.py -- build a spectral library Radiant DIA can actually read.
+
+WHY THIS EXISTS (all three facts verified on HIVE, 2026-08-03)
+-------------------------------------------------------------
+Radiant needs a library, and DIA-NN is the natural way to predict one. But DIA-NN 2.x
+and this Radiant build share NO library format directly:
+
+1. `--out-lib foo.tsv --predictor` does NOT write foo.tsv. DIA-NN ignores the
+   extension for a PREDICTED library and always writes `foo.predicted.speclib`
+   (its compact binary format).
+2. Radiant DOES accept `.speclib` -- but only format version >= -3
+   (FileReadersLib/src/SpecLibSrc/Library.h: `if (version < -3) ... not supported`).
+   DIA-NN 2.6 writes v-11 and 2.x generally writes v-10, so every DIA-NN 2.x speclib
+   is rejected with `ERROR: version is not supported11`. Every speclib on the UCD
+   share is v-10 or v-11.
+3. DIA-NN cannot emit TSV at all. Asked to convert a library to `foo.tsv`, it
+   silently writes `foo.parquet` instead.
+
+So the only working path is: predict -> convert to parquet -> rename columns to the
+schema Radiant's FragLibTsvReader keys on -> TSV. DIA-NN's parquet uses DOT-separated
+names (`Precursor.Mz`, `Relative.Intensity`); Radiant wants the OpenSWATH-style
+concatenated names (`PrecursorMz`, `LibraryIntensity`). A straight dump is unreadable.
+
+Usage:
+  python3 make_radiant_library.py --diann '<diann cmd>' --fasta db.fasta --out-dir ./lib
+  python3 make_radiant_library.py --from-speclib existing.predicted.speclib \
+      --diann '<diann cmd>' --out-dir ./lib
+  python3 make_radiant_library.py --from-parquet lib.parquet --out-dir ./lib   # no DIA-NN
+"""
+import sys, os, json, shlex, argparse, subprocess, csv
+
+# DIA-NN parquet column -> the name Radiant's FragLibTsvReader looks for.
+# The reader accepts either spelling of the aliased ones (ProductMz|FragmentMz,
+# LibraryIntensity|RelativeIntensity, ModifiedPeptide|ModifiedPeptideSequence,
+# FragmentSeriesNumber|FragmentNumber, Tr_recalibrated|NormalizedRetentionTime);
+# we emit the DIA-NN-style spelling, which matches its own test fixture.
+COLMAP = {
+    "Precursor.Mz":           "PrecursorMz",
+    "Product.Mz":             "ProductMz",
+    "Relative.Intensity":     "LibraryIntensity",
+    "Modified.Sequence":      "ModifiedPeptide",
+    "Stripped.Sequence":      "PeptideSequence",
+    "Precursor.Charge":       "PrecursorCharge",
+    "Fragment.Type":          "FragmentType",
+    "Fragment.Charge":        "FragmentCharge",
+    "Fragment.Series.Number": "FragmentSeriesNumber",
+    "Fragment.Loss.Type":     "FragmentLossType",
+    "RT":                     "Tr_recalibrated",
+    "IM":                     "IonMobility",
+    "Decoy":                  "decoy",
+    "Protein.Group":          "ProteinGroup",
+    "Protein.Names":          "ProteinName",
+    "Genes":                  "Genes",
+    "Precursor.Id":           "transition_group_id",
+    "Q.Value":                "QValue",
+    "PG.Q.Value":             "PGQValue",
+    "Proteotypic":            "Proteotypic",
+    "Exclude.From.Quant":     "ExcludeFromAssay",
+}
+# Without these Radiant cannot build a fragment library at all.
+REQUIRED = ["PrecursorMz", "ProductMz", "LibraryIntensity", "ModifiedPeptide",
+            "PrecursorCharge", "FragmentType", "FragmentCharge", "FragmentSeriesNumber"]
+
+
+def sh(cmd):
+    print(f"  $ {cmd}", flush=True)
+    subprocess.run(cmd, shell=True, check=True)
+
+
+def find_written(d, stem):
+    """DIA-NN renames the output; find what it really wrote."""
+    for ext in (".predicted.speclib", ".speclib", ".parquet", ".tsv"):
+        p = os.path.join(d, stem + ext)
+        if os.path.exists(p) and os.path.getsize(p) > 1000:
+            return p
+    return None
+
+
+def parquet_to_tsv(src, dst, batch=200_000):
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:
+        sys.exit("pyarrow required. pip install pyarrow")
+    pf = pq.ParquetFile(src)
+    cols = [c for c in pf.schema_arrow.names if c in COLMAP]
+    out_names = [COLMAP[c] for c in cols]
+    missing = [r for r in REQUIRED if r not in out_names]
+    if missing:
+        sys.exit(f"{src} lacks columns Radiant requires: {missing}\n"
+                 f"  parquet had: {pf.schema_arrow.names}")
+    n = 0
+    with open(dst, "w", newline="") as fh:
+        w = csv.writer(fh, delimiter="\t", lineterminator="\n")
+        w.writerow(out_names)
+        for b in pf.iter_batches(batch_size=batch, columns=cols):
+            d = b.to_pydict()
+            w.writerows(zip(*(d[c] for c in cols)))
+            n += b.num_rows
+    return n, out_names
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--diann", help="DIA-NN command (needed unless --from-parquet)")
+    ap.add_argument("--fasta", help="FASTA to predict from")
+    ap.add_argument("--from-speclib", help="skip prediction; convert this .speclib")
+    ap.add_argument("--from-parquet", help="skip DIA-NN entirely; convert this .parquet")
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--threads", type=int, default=16)
+    a = ap.parse_args()
+
+    os.makedirs(a.out_dir, exist_ok=True)
+    tsv = os.path.join(a.out_dir, "radiant_library.tsv")
+    if os.path.exists(tsv) and os.path.getsize(tsv) > 1_000_000:
+        print(json.dumps({"library": tsv, "reused": True}, indent=2)); return
+
+    parquet = a.from_parquet
+    if not parquet:
+        if not a.diann:
+            sys.exit("--diann is required unless --from-parquet is given.")
+        speclib = a.from_speclib
+        if not speclib:
+            if not a.fasta:
+                sys.exit("--fasta is required to predict a library.")
+            stem = os.path.join(a.out_dir, "diann_predicted_lib")
+            print("[1/3] DIA-NN: predicting the library from the FASTA")
+            sh(f"{a.diann} --fasta {shlex.quote(a.fasta)} --fasta-search --predictor "
+               f"--gen-spec-lib --out-lib {shlex.quote(stem)} --threads {a.threads}")
+            speclib = find_written(a.out_dir, "diann_predicted_lib")
+            if not speclib:
+                sys.exit(f"DIA-NN wrote no library into {a.out_dir}: "
+                         f"{sorted(os.listdir(a.out_dir))}")
+        # Radiant rejects DIA-NN 2.x speclib (v-10/-11 < the v>=-3 it supports), so we
+        # cannot hand the binary straight over -- convert it to a readable table.
+        print("[2/3] DIA-NN: speclib -> parquet (it cannot write TSV; it writes parquet)")
+        stem2 = os.path.join(a.out_dir, "radiant_library_src")
+        sh(f"{a.diann} --lib {shlex.quote(speclib)} --out-lib {shlex.quote(stem2)} "
+           f"--gen-spec-lib --threads {a.threads}")
+        parquet = find_written(a.out_dir, "radiant_library_src")
+        if not parquet or not parquet.endswith(".parquet"):
+            sys.exit(f"expected a .parquet from the conversion; got {parquet}")
+
+    print("[3/3] parquet -> Radiant TSV (renaming to the schema its reader keys on)")
+    n, names = parquet_to_tsv(parquet, tsv)
+    print(json.dumps({
+        "library": tsv,
+        "rows": n,
+        "size_bytes": os.path.getsize(tsv),
+        "columns": names,
+        "source_parquet": parquet,
+        "note": "Radiant reads .fragLibFF/.tsv/.csv/.speclib, but rejects DIA-NN 2.x "
+                ".speclib (format v-10/-11; it supports v>=-3) — hence the TSV.",
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/radiant_parallel.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/radiant_parallel.py
@@ -98,11 +98,17 @@ def main():
     ap.add_argument("--out", required=True)
     ap.add_argument("--library", help="DIA-NN .tsv library; generated in step 1 if omitted")
     ap.add_argument("--diann", help="DIA-NN command (needed only when --library is omitted)")
+    # Memory defaults are MEASURED, not guessed (3-run HeLa, 9.9 GB TSV library,
+    # 2026-08-03): each RadiantDIA task peaked at ~19 GB, Fulcrum at ~14 GB — roughly
+    # 2x the library size plus overhead. Over-requesting is not free: asking 200 GB
+    # made SLURM schedule the array tasks one at a time, turning a parallel array back
+    # into a near-serial queue (14 min wall vs 21 min serial, instead of ~7). Scale
+    # --mem-per-file with the library if you use a much larger one.
     ap.add_argument("--threads-per-file", type=int, default=16)
-    ap.add_argument("--mem-per-file", type=int, default=64)
+    ap.add_argument("--mem-per-file", type=int, default=32)
     ap.add_argument("--time-per-file", type=int, default=4)
     ap.add_argument("--fulcrum-cpus", type=int, default=32)
-    ap.add_argument("--fulcrum-mem", type=int, default=128)
+    ap.add_argument("--fulcrum-mem", type=int, default=48)
     ap.add_argument("--fulcrum-time", type=int, default=8)
     ap.add_argument("--libpred-cpus", type=int, default=16)
     ap.add_argument("--libpred-mem", type=int, default=64)
@@ -129,7 +135,13 @@ def main():
     rdir = os.path.join(results, "radiant-results")
     os.makedirs(D, exist_ok=True); os.makedirs(rdir, exist_ok=True)
 
-    lib = a.library or os.path.join(D, "diann_predicted_lib.tsv")
+    # DIA-NN IGNORES the extension given to --out-lib for a PREDICTED library and always
+    # writes <stem>.predicted.speclib (its compact binary format). Radiant reads .speclib
+    # directly (FragLibReader accepts .fragLibFF/.tsv/.csv/.speclib), so no conversion is
+    # needed -- but the filename must match what DIA-NN really produces or step 2 looks
+    # for a file that was never written.
+    lib_stem = os.path.join(D, "diann_predicted_lib")
+    lib = a.library or (lib_stem + ".predicted.speclib")
     listing = os.path.join(D, "file_list.txt")
     with open(listing, "w") as fh:
         fh.write("\n".join(os.path.abspath(f) for f in files) + "\n")
@@ -172,9 +184,13 @@ def main():
             header("r1_libpred", a.libpred_cpus, a.libpred_mem, a.libpred_time, **q), "",
             'echo "Step 1/3 DIA-NN library prediction"; date',
             f'{a.diann} --fasta {shlex.quote(os.path.abspath(a.fasta))} --fasta-search '
-            f'--predictor --gen-spec-lib --out-lib {shlex.quote(lib)} '
+            f'--predictor --gen-spec-lib --out-lib {shlex.quote(lib_stem)} '
             f'--threads {a.libpred_cpus}',
-            f'test -s {shlex.quote(lib)} || {{ echo "no library produced"; exit 1; }}']))
+            # Check for what DIA-NN ACTUALLY writes, and say what it did write if absent.
+            f'if [ ! -s {shlex.quote(lib)} ]; then',
+            f'  echo "expected {os.path.basename(lib)}; DIA-NN wrote:"; ls -la {shlex.quote(D)}',
+            f'  exit 1',
+            f'fi']))
 
     # ---- step 2: one RadiantDIA per file (array) --------------------------------
     n = len(files)

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/radiant_to_delimp.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/radiant_to_delimp.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+radiant_to_delimp.py -- turn Radiant/Fulcrum output into a report.parquet the DE-LIMP
+app (Hugging Face / local Shiny) will load.
+
+WHY THIS IS NOT `adapt_radiant`
+-------------------------------
+The two consumers want different SHAPES, and conflating them breaks one of them:
+
+  adapt_radiant   -> one row per protein x run, with PG.MaxLFQ. That is the skill's
+                     own DE contract (references/de-analysis.md).
+  DE-LIMP         -> `fileInput("report_file", "DIA-NN Report (.parquet)")` feeds
+                     `limpa::readDIANN()`, which is PRECURSOR-level and needs:
+                       run.column        = Run
+                       feature.column    = Precursor.Id
+                       intensity.column  = Precursor.Normalised
+                       annotation.columns= Protein.Group, Protein.Names, Genes, Proteotypic
+                       q.columns         = Q.Value, Lib.Q.Value, Lib.PG.Q.Value
+
+Fulcrum's `combined` output is already precursor-level with DIA-NN-style names, so most
+columns pass straight through. Verified against a real 3-run HeLa result (2026-08-03),
+these four had to be derived:
+
+  Precursor.Id    <- Modified.Sequence + Precursor.Charge  (how DIA-NN builds it)
+  Lib.Q.Value     <- Global.Precursor.Q.Value
+  Lib.PG.Q.Value  <- Global.PG.Q.Value
+  Protein.Names / Genes  <- joined from the spectral library, which carries them;
+                            Fulcrum drops them. Without the join DE-LIMP loses all
+                            gene-level annotation (GSEA, gene labels on the volcano),
+                            so we fill them rather than emitting blanks.
+
+DE-LIMP also compares Precursor.Quantity vs Precursor.Normalised to detect whether
+normalisation was applied (server_data.R) — both are carried through.
+
+Usage:
+  python3 radiant_to_delimp.py --results <out>/radiant_results --out delimp_report.parquet
+  python3 radiant_to_delimp.py --results ... --library radiant_library.tsv --out ...
+"""
+import sys, os, json, argparse, csv
+
+# Fulcrum column -> DIA-NN/limpa column, where a straight rename suffices.
+PASSTHROUGH = {
+    "Protein.Group":        "Protein.Group",
+    "Proteotypic":          "Proteotypic",
+    "Q.Value":              "Q.Value",
+    "Precursor.Quantity":   "Precursor.Quantity",
+    "Precursor.Normalised": "Precursor.Normalised",
+    "Precursor.Charge":     "Precursor.Charge",
+    "Modified.Sequence":    "Modified.Sequence",
+    "RT":                   "RT",
+    "PG.Quantity":          "PG.Quantity",
+    "PG.Normalised":        "PG.Normalised",
+}
+
+
+def run_name(raw):
+    """Fulcrum reports Run as file:///.../Sample.mzML.radiantDIA — reduce to `Sample`."""
+    s = str(raw)
+    if "://" in s:
+        s = s.split("://", 1)[1]
+    s = os.path.basename(s.rstrip("/"))
+    for _ in range(3):
+        stem, ext = os.path.splitext(s)
+        if ext.lower() in (".radiantdia", ".mzml", ".raw", ".d", ".gz", ".parquet"):
+            s = stem
+        else:
+            break
+    return s
+
+
+def library_annotation(lib_tsv):
+    """ModifiedPeptide -> (ProteinName, Genes) from the Radiant TSV library.
+
+    Streamed and de-duplicated on the peptide, so a 50M-row / 10 GB library costs
+    memory proportional to the number of PEPTIDES, not rows.
+    """
+    ann = {}
+    with open(lib_tsv, newline="") as fh:
+        rd = csv.reader(fh, delimiter="\t")
+        hdr = next(rd)
+        idx = {c: i for i, c in enumerate(hdr)}
+        pep = idx.get("ModifiedPeptide", idx.get("ModifiedPeptideSequence"))
+        pn, gn = idx.get("ProteinName"), idx.get("Genes")
+        if pep is None or (pn is None and gn is None):
+            return ann
+        for row in rd:
+            k = row[pep]
+            if k not in ann:
+                ann[k] = (row[pn] if pn is not None and pn < len(row) else "",
+                          row[gn] if gn is not None and gn < len(row) else "")
+    return ann
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--results", required=True,
+                    help="the run's radiant_results dir (containing fulcrum-results/)")
+    ap.add_argument("--library", help="Radiant TSV library, to recover Protein.Names/Genes")
+    ap.add_argument("--out", required=True, help="report.parquet to upload to DE-LIMP")
+    a = ap.parse_args()
+
+    try:
+        import pyarrow as pa, pyarrow.parquet as pq, pyarrow.dataset as ds
+    except ImportError:
+        sys.exit("pyarrow required. pip install pyarrow")
+
+    root = a.results
+    if os.path.basename(root) != "fulcrum-results":
+        cand = os.path.join(root, "fulcrum-results")
+        if os.path.isdir(cand):
+            root = cand
+    if not os.path.isdir(root):
+        sys.exit(f"no fulcrum-results under {a.results}")
+
+    t = ds.dataset(root, format="parquet").to_table()
+    cols = set(t.column_names)
+    if "Run" not in cols:
+        sys.exit(f"Fulcrum output has no Run column; saw {sorted(cols)}")
+
+    out = {}
+    out["Run"] = [run_name(r) for r in t.column("Run").to_pylist()]
+    for src, dst in PASSTHROUGH.items():
+        if src in cols:
+            out[dst] = t.column(src).to_pylist()
+
+    # Precursor.Id: DIA-NN's feature key is modified sequence + charge.
+    mods = out.get("Modified.Sequence") or [""] * t.num_rows
+    chgs = out.get("Precursor.Charge") or [0] * t.num_rows
+    out["Precursor.Id"] = [f"{m}{c}" for m, c in zip(mods, chgs)]
+
+    # limpa filters on all three q-columns; map Fulcrum's global estimates onto the
+    # library-level names DIA-NN uses, rather than leaving them absent.
+    q = out.get("Q.Value") or [0.0] * t.num_rows
+    out["Lib.Q.Value"] = (t.column("Global.Precursor.Q.Value").to_pylist()
+                          if "Global.Precursor.Q.Value" in cols else list(q))
+    out["Lib.PG.Q.Value"] = (t.column("Global.PG.Q.Value").to_pylist()
+                             if "Global.PG.Q.Value" in cols else list(q))
+    if "Global.PG.Q.Value" in cols:
+        out["PG.Q.Value"] = t.column("Global.PG.Q.Value").to_pylist()
+
+    # Protein.Names / Genes — Fulcrum drops them; recover from the library if given.
+    ann = library_annotation(a.library) if a.library and os.path.exists(a.library) else {}
+    if ann:
+        pairs = [ann.get(m, ("", "")) for m in mods]
+        out["Protein.Names"] = [p[0] for p in pairs]
+        out["Genes"] = [p[1] for p in pairs]
+        n_ann = sum(1 for p in pairs if p[0] or p[1])
+    else:
+        # Never invent annotation. Empty strings are honest; a fake gene name would
+        # silently corrupt GSEA and every gene label downstream.
+        out["Protein.Names"] = [""] * t.num_rows
+        out["Genes"] = [""] * t.num_rows
+        n_ann = 0
+
+    pq.write_table(pa.table(out), a.out)
+    runs = sorted(set(out["Run"]))
+    print(json.dumps({
+        "report": os.path.abspath(a.out),
+        "rows": t.num_rows,
+        "runs": len(runs),
+        "run_names": runs,
+        "protein_groups": len(set(out.get("Protein.Group", []))),
+        "precursors": len(set(out["Precursor.Id"])),
+        "annotated_rows": n_ann,
+        "columns": list(out.keys()),
+        "upload": "DE-LIMP -> 'DIA-NN Report (.parquet)'",
+        "warning": None if ann else
+        "Protein.Names/Genes are EMPTY — pass --library to recover them, or gene-level "
+        "features in DE-LIMP (GSEA, gene labels) will have nothing to work with.",
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/radiant_to_delimp.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/radiant_to_delimp.py
@@ -68,6 +68,47 @@ def run_name(raw):
     return s
 
 
+def ms1_from_per_file(results_root):
+    """(run, peptide, charge) -> MS1 intensity, read from Radiant's own per-file output.
+
+    Fulcrum's `combined` backend DROPS every MS1 column, so a report built from it alone
+    has no MS1 signal and DE-LIMP's MS1_Signal QC metric (sum of `Ms1.Apex.Area`) comes
+    out blank. Radiant itself does compute MS1 -- its `.radiantDIA` per-file result is a
+    PARQUET table carrying 27 MS1 columns. `Ms1IntensityFound100` is the monoisotopic
+    intensity and the closest analogue of DIA-NN's Ms1.Apex.Area, so we join it back.
+
+    Verified: the (PeptideStringWithMods, Charge) key matches Fulcrum's
+    (Modified.Sequence, Precursor.Charge) for 100% of rows.
+    """
+    import pyarrow.parquet as pq
+    per_file = os.path.join(results_root, "radiant-results")
+    if not os.path.isdir(per_file):
+        return {}
+    out = {}
+    for fn in sorted(os.listdir(per_file)):
+        if not fn.endswith(".radiantDIA"):
+            continue
+        run = run_name(fn)
+        try:
+            pf = pq.ParquetFile(os.path.join(per_file, fn))
+            names = pf.schema_arrow.names
+            cols = [c for c in ("PeptideStringWithMods", "Charge", "Ms1IntensityFound100")
+                    if c in names]
+            if len(cols) < 3:
+                continue
+            t = pf.read(columns=cols)
+            for p, c, m in zip(t.column("PeptideStringWithMods").to_pylist(),
+                               t.column("Charge").to_pylist(),
+                               t.column("Ms1IntensityFound100").to_pylist()):
+                if m:                       # keep the best MS1 seen for the precursor
+                    k = (run, str(p), c)
+                    if m > out.get(k, 0):
+                        out[k] = float(m)
+        except Exception as e:
+            sys.stderr.write(f"[radiant_to_delimp] could not read MS1 from {fn}: {e}\n")
+    return out
+
+
 def library_annotation(lib_tsv):
     """ModifiedPeptide -> (ProteinName, Genes) from the Radiant TSV library.
 
@@ -98,6 +139,8 @@ def main():
                     help="the run's radiant_results dir (containing fulcrum-results/)")
     ap.add_argument("--library", help="Radiant TSV library, to recover Protein.Names/Genes")
     ap.add_argument("--out", required=True, help="report.parquet to upload to DE-LIMP")
+    ap.add_argument("--no-ms1", action="store_true",
+                    help="skip the MS1 join from the per-file .radiantDIA results")
     a = ap.parse_args()
 
     try:
@@ -153,6 +196,16 @@ def main():
         out["Genes"] = [""] * t.num_rows
         n_ann = 0
 
+    # MS1: recovered from Radiant's per-file output, since Fulcrum drops it.
+    ms1 = {} if a.no_ms1 else ms1_from_per_file(a.results)
+    if ms1:
+        out["Ms1.Apex.Area"] = [
+            ms1.get((r, m, c), 0.0)
+            for r, m, c in zip(out["Run"], mods, chgs)]
+        n_ms1 = sum(1 for v in out["Ms1.Apex.Area"] if v > 0)
+    else:
+        n_ms1 = 0
+
     pq.write_table(pa.table(out), a.out)
     runs = sorted(set(out["Run"]))
     print(json.dumps({
@@ -163,8 +216,15 @@ def main():
         "protein_groups": len(set(out.get("Protein.Group", []))),
         "precursors": len(set(out["Precursor.Id"])),
         "annotated_rows": n_ann,
+        "ms1_rows": n_ms1,
         "columns": list(out.keys()),
         "upload": "DE-LIMP -> 'DIA-NN Report (.parquet)'",
+        "ms1_note": ("Ms1.Apex.Area recovered from Radiant's per-file output — Fulcrum's "
+                     "combined backend drops all MS1 columns, which is why DE-LIMP's "
+                     "MS1_Signal is blank without this join.") if n_ms1 else
+                    ("NO MS1 — DE-LIMP's MS1_Signal QC metric will be blank. Radiant does "
+                     "compute MS1; check that the .radiantDIA per-file results are still "
+                     "beside the fulcrum-results directory."),
         "warning": None if ann else
         "Protein.Names/Genes are EMPTY — pass --library to recover them, or gene-level "
         "features in DE-LIMP (GSEA, gene labels) will have nothing to work with.",

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_search.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_search.py
@@ -273,37 +273,62 @@ def _container_argv(tools, mounts, inner):
     return argv
 
 
-def radiant_library(tools, fasta, out, threads, params=None):
-    """Generate the DIA-NN predicted spectral library that Radiant searches against.
+# Radiant's library loader accepts exactly these four, dispatching on the suffix
+# (FragLibReader.cpp: FRAG_LIB_FF / TSV / CSV / SPEC_LIB suffixes). DIA-NN's own
+# .predicted.speclib therefore needs NO conversion -- it ends in .speclib.
+RADIANT_LIB_SUFFIXES = (".fraglibff", ".tsv", ".csv", ".speclib")
 
-    Reuses the skill's own DIA-NN acquisition rather than adding a second predictor.
-    `--out-lib` with a .tsv extension makes DIA-NN emit the TSV library schema that
-    Radiant's FragLibTsvReader expects; we verify the header rather than trust it.
+
+def _find_diann_library(stem_dir, stem):
+    """Locate whatever DIA-NN actually wrote, in Radiant-preference order.
+
+    DIA-NN IGNORES the extension you give --out-lib for a PREDICTED library: it always
+    writes <stem>.predicted.speclib, its compact binary format (DIA-NN docs, "Output
+    library": "For predicted library generation, however, the output file takes the
+    .predicted.speclib extension"). Asking for .tsv and then checking for .tsv fails
+    even though the run succeeded -- so look for what it really produces.
     """
-    lib = os.path.join(out, "radiant_lib", "diann_predicted_lib.tsv")
-    if os.path.exists(lib) and os.path.getsize(lib) > 1000:
-        print(f"  [radiant] reusing existing DIA-NN library {lib}")
-        return lib
+    for cand in (f"{stem}.predicted.speclib", f"{stem}.speclib",
+                 f"{stem}.parquet", f"{stem}.tsv"):
+        p = os.path.join(stem_dir, cand)
+        if os.path.exists(p) and os.path.getsize(p) > 1000:
+            return p
+    return None
+
+
+def radiant_library(tools, fasta, out, threads, params=None):
+    """Build the spectral library Radiant searches against, from DIA-NN's predictor.
+
+    NOT a straight hand-off: DIA-NN 2.x writes .predicted.speclib v-10/-11 and Radiant's
+    reader only supports v>=-3, so its binary is rejected outright. The conversion lives
+    in make_radiant_library.py.
+    """
+    libdir = os.path.join(out, "radiant_lib")
+    ready = os.path.join(libdir, "radiant_library.tsv")
+    if os.path.exists(ready) and os.path.getsize(ready) > 1_000_000:
+        print(f"  [radiant] reusing existing library {ready}")
+        return ready
     dn = tools.get("diann")
     if not dn:
-        sys.exit("Radiant needs a DIA-NN predicted spectral library, but tools.json has "
-                 "no DIA-NN command. Acquire DIA-NN first (it is the library generator "
-                 "for this route), or pass --library with an existing DIA-NN .tsv library.")
-    os.makedirs(os.path.dirname(lib), exist_ok=True)
-    cfg = f"--cfg {shlex.quote(params)} " if params and os.path.exists(params) else ""
-    sh(f"{dn} {cfg}--fasta {shlex.quote(fasta)} --fasta-search --predictor --gen-spec-lib "
-       f"--out-lib {shlex.quote(lib)} --threads {threads}")
-    if not os.path.exists(lib) or os.path.getsize(lib) < 1000:
-        sys.exit(f"DIA-NN did not produce a usable library at {lib}.")
-    with open(lib, "r", errors="replace") as fh:
-        header = fh.readline()
-    needed = {"PrecursorMz", "ProductMz", "LibraryIntensity", "ModifiedPeptide"}
-    missing = needed - set(header.rstrip("\n").split("\t"))
-    if missing:
-        sys.exit(f"{lib} is not a DIA-NN TSV library — missing columns {sorted(missing)}.\n"
-                 f"  Radiant reads DIA-NN's library schema; check the --out-lib extension.")
-    print(f"  [radiant] DIA-NN predicted library -> {lib}")
-    return lib
+        sys.exit("Radiant needs a spectral library, but tools.json has no DIA-NN command. "
+                 "Acquire DIA-NN first (it is the library generator for this route), or "
+                 "pass --library with an existing .tsv/.csv/.fragLibFF library.")
+    os.makedirs(libdir, exist_ok=True)
+    # DIA-NN 2.x and Radiant share NO library format directly: DIA-NN writes
+    # .predicted.speclib v-10/-11, Radiant's reader supports v>=-3 ("ERROR: version is
+    # not supported11"), and DIA-NN cannot emit TSV. make_radiant_library.py does the
+    # required predict -> parquet -> renamed TSV hop. See its docstring for the evidence.
+    helper = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          "make_radiant_library.py")
+    res = subprocess.run([sys.executable, helper, "--diann", dn, "--fasta", fasta,
+                          "--out-dir", libdir, "--threads", str(threads)],
+                         capture_output=True, text=True)
+    sys.stderr.write(res.stderr)
+    if res.returncode != 0:
+        sys.exit(f"make_radiant_library.py failed (exit {res.returncode}).")
+    info = json.loads(res.stdout[res.stdout.index("{"):])
+    print(f"  [radiant] library -> {info['library']} ({info.get('rows', '?')} rows)")
+    return info["library"]
 
 
 def run_radiant_parallel(tools, params, files, fasta, out, threads, a, library=None):
@@ -354,6 +379,16 @@ def run_radiant(tools, params, files, fasta, out, threads, sbatch, library=None,
                  f"  Bruker inputs: {bad}\n"
                  "  Use the DIA-NN or FragPipe/diaTracer route for timsTOF data.")
     mzml = ensure_mzml(files, out)          # .raw -> mzML (msconvert), same path Sage uses
+    if library and not library.lower().endswith(RADIANT_LIB_SUFFIXES):
+        sys.exit(f"Radiant cannot read {os.path.basename(library)} — its loader accepts "
+                 f"only {', '.join(RADIANT_LIB_SUFFIXES)}.")
+    if library and library.lower().endswith(".speclib"):
+        sys.stderr.write(
+            "[run_search] WARNING: Radiant only reads .speclib format v>=-3, and every\n"
+            "  DIA-NN 2.x library is v-10/-11 — it will abort with 'version is not\n"
+            "  supported'. If this is a DIA-NN library, convert it first:\n"
+            "    python3 scripts/make_radiant_library.py --from-speclib <lib> "
+            "--diann '<cmd>' --out-dir <dir>\n")
     lib = library or radiant_library(tools, fasta, out, threads, params)
 
     results = os.path.join(out, "radiant_results")
@@ -390,6 +425,27 @@ def run_radiant(tools, params, files, fasta, out, threads, sbatch, library=None,
     sh(full)
     report = adapt_radiant(out)
     return {"engine": "radiant", "report": report, "ran": True, "library": lib}
+
+
+def _radiant_run_name(raw):
+    """Fulcrum reports Run as a full URI of the per-file result, e.g.
+    `file:///mnt/results/radiant-results/Sample_1.mzML.radiantDIA`.
+
+    A single splitext leaves `Sample_1.mzML`, which does NOT match the bare run names
+    every other engine emits — so a conditions.csv keyed on sample names would silently
+    fail to assign groups. Strip the URI, the container path, and BOTH extensions.
+    """
+    s = str(raw)
+    if "://" in s:
+        s = s.split("://", 1)[1]
+    s = os.path.basename(s.rstrip("/"))
+    for _ in range(3):                       # .mzML.radiantDIA, .d.radiantDIA, ...
+        stem, ext = os.path.splitext(s)
+        if ext.lower() in (".radiantdia", ".mzml", ".raw", ".d", ".gz", ".parquet"):
+            s = stem
+        else:
+            break
+    return s
 
 
 def adapt_radiant(out):
@@ -441,7 +497,7 @@ def adapt_radiant(out):
         sys.exit(f"Radiant output missing expected columns; saw {t.column_names}")
     c_q = col("Global.PG.Q.Value", "Q.Value")
 
-    runs = [os.path.splitext(os.path.basename(str(r)))[0] for r in t.column(c_run).to_pylist()]
+    runs = [_radiant_run_name(r) for r in t.column(c_run).to_pylist()]
     pgs = [str(p) for p in t.column(c_pg).to_pylist()]
     vals = t.column(c_int).to_pylist()
     qs = t.column(c_q).to_pylist() if c_q else [0.0] * len(pgs)
@@ -861,6 +917,19 @@ def main():
     bundle = json.load(open(a.bundle))
     engine = pick_engine(a, bundle)
     files = expand_files(a.files)
+
+    # Absolutize EVERY path before it is baked into a command. emit_sbatch() writes
+    # `cd <abspath(out)>` and then the command verbatim, so a caller-relative
+    # --params/--fasta/--out (exactly what SKILL.md documents: `--params ./wf/x.cfg`)
+    # resolves against the WRONG directory once the job runs — the search dies on a
+    # missing params file, or worse silently looks at ./out/out/. Same hazard for the
+    # container routes, whose bind mounts are derived from these paths.
+    a.out = os.path.abspath(a.out)
+    for attr in ("params", "fasta", "library"):
+        v = getattr(a, attr, None)
+        if v:
+            setattr(a, attr, os.path.abspath(v))
+    files = [os.path.abspath(f) for f in files]
 
     if a.adapt_only:
         report = {"sage": adapt_sage, "fragpipe": adapt_fragpipe,


### PR DESCRIPTION
Ran all three DIA workflows end-to-end on HIVE. **DIA-NN and FragPipe passed as merged. Radiant did not** — the route assumed DIA-NN could hand Radiant a spectral library, and it cannot.

## Validation runs

| Workflow | Data | Result |
|---|---|---|
| DIA-NN | 9 mouse class files (Beads/Strap/Urea, 3×3) | 384,117 rows, **9 runs, 6,203 protein groups** |
| FragPipe + diaTracer | same 9 files | **12,449 protein groups × 9 samples** |
| Radiant + Fulcrum | 3 Exploris HeLa mzML | 49,774 precursors, **3,174 protein groups** |

## 1. DIA-NN and Radiant share no library format — the headline

Four facts, each verified, none of them documented anywhere:

1. `--out-lib foo.tsv --predictor` does **not** write `foo.tsv`. DIA-NN ignores the extension for predicted libraries and writes `foo.predicted.speclib`.
2. Radiant *does* read `.speclib` — but only **format v ≥ −3** (`SpecLibSrc/Library.h`). DIA-NN 2.6 writes **v−11**, so `RadiantDIA` aborts with `ERROR: version is not supported11`. **Every speclib on the UCD share is v−10 or v−11.**
3. DIA-NN **cannot emit TSV at all** — asked to convert to `.tsv`, it silently writes `.parquet`.
4. That parquet uses **dot-separated** names (`Precursor.Mz`) while Radiant wants concatenated ones (`PrecursorMz`) — a straight dump would be a 6 GB unreadable file. Caught from the header before the write finished.

New `make_radiant_library.py` does predict → parquet → renamed TSV, called automatically. Verified: 50,384,118 rows, read by `RadiantDIA` with only benign warnings.

## 2. Paths weren't absolutized — this affected *every* engine

`emit_sbatch` writes `cd <abspath(out)>` then the command verbatim, so the relative paths **SKILL.md itself documents** (`--params ./wf/x.cfg`) resolved against the wrong directory once the job ran. FragPipe's generated command pointed at `./out/out/`. Fixed in `main()`, so every engine's `--sbatch` runs are correct — not just Radiant's.

## 3. Run names kept an extension

Fulcrum reports `Run` as `file:///…/Sample.mzML.radiantDIA`; one `splitext` leaves `Sample.mzML` while every other engine emits `Sample`. A `conditions.csv` keyed on sample names would have **silently failed to assign groups**. Both adapters now strip the URI and all trailing extensions.

## 4. Memory defaults were guessed — and over-requesting serialized the array

Measured peak: **~19 GB** per search task, ~14 GB for Fulcrum. I had asked for 200 GB, so SLURM scheduled the three array tasks one at a time — **14 min wall instead of ~7** (serial would have been 21). The array was parallel in mechanism but not in practice. Defaults are now 32 GB / 48 GB from the measurement, with the scaling rule documented.

## Plus: feeding results to DE-LIMP

`adapt_radiant` emits the skill's DE contract (protein×run, `PG.MaxLFQ`). The DE-LIMP app feeds `limpa::readDIANN()`, which is **precursor-level** and needs `Run`, `Precursor.Id`, `Precursor.Normalised`, `Protein.Group`, `Protein.Names`, `Genes`, `Proteotypic`, `Q.Value`, `Lib.Q.Value`, `Lib.PG.Q.Value`. Conflating the two shapes would break one, so `radiant_to_delimp.py` is separate: it derives `Precursor.Id` from modified sequence + charge, maps `Global.*` q-values onto `Lib.*`, and recovers `Protein.Names`/`Genes` from the library (Fulcrum drops them — without the join DE-LIMP loses GSEA and gene labels).

**Verified by actually loading the output with `limpa::readDIANN`:** EList, 25,722 precursors × 3 samples, correct sample names, 25,655/25,722 genes annotated.