### PR TITLE
feat(skill): coverage filter for MaxLFQ+QuantUMS, surface the filters, verify the citation (v1.6.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "UC Davis Proteomics Core skills for Claude — agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "UC Davis Proteomics Core pipeline — end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE — with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -639,11 +639,19 @@ Use `maxlfq` when **either**:
 1. **The user asks for it** — e.g. they want QuantUMS quality filtering (below), or
    to match a previous MaxLFQ-based analysis.
 2. **The input cannot support limpa.** `readDIANN()` needs PRECURSOR-level columns
-   (`Precursor.Id`, `Precursor.Normalised`). DIA-NN's own `report.parquet` has them.
-   The Sage / FragPipe / Radiant adapters collapse to one row per protein × run, so
-   limpa cannot run on their output — `run_de.R` checks this up front and says so.
-   (Radiant: `radiant_to_delimp.py` emits a precursor-level report that *does*
-   support `dpc` — point `--input` at that if you want limpa on Radiant results.)
+   (`Precursor.Id`, `Precursor.Normalised`). What matters is *which file you point at*,
+   not which engine ran:
+
+   | engine | file to use for `dpc` | verified |
+   |---|---|---|
+   | DIA-NN | `search_out/report.parquet` (native) | yes |
+   | FragPipe | `dia-quant-output/report.tsv` + `--format tsv` | yes — its DIA route bundles DIA-NN, so this **is** a DIA-NN report, `Lib.Q.Value`/`Lib.PG.Q.Value` included |
+   | Radiant | `radiant_to_delimp.py --out <x>.parquet` | yes |
+
+   What does **not** work is the *adapted* `report.parquet` from `adapt_sage` /
+   `adapt_fragpipe` / `adapt_radiant` — those deliberately collapse to one row per
+   protein × run to feed the maxlfq path. `run_de.R` checks up front and names the
+   precursor-level file to use instead.
 
 Writes `DE_<method>_<contrast>.csv` + `Expression_Matrix.csv` +
 `methods.txt` + `sessionInfo.txt` + `de_provenance.json` (exact R package versions).

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -589,6 +589,8 @@ unmonitored.** Poll with `watch_run.sh` in a loop until it finishes:
 bash scripts/watch_run.sh --log <search log> --out <search out dir> --poll <n>
 # SLURM on HIVE:
 bash scripts/watch_run.sh --slurm <jobid> --log <job log> --out <out> --poll <n> --hive
+# multi-step chains (diann_parallel / radiant_parallel): watch EVERY step, never just the last
+bash scripts/watch_run.sh --all <search out dir> --hive
 ```
 **Always pass `--out` and increment `--poll` each time.** `--out` is what turns "still
 running" into real progress: the chain drops a `.quant` per finished file, so the watcher

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -632,6 +632,28 @@ Rscript scripts/run_de.R --input ./search_out/report.parquet \
 Use the `de.method` from the bundle (`dpc` for DIA-NN/limpa, `maxlfq` for
 Sage/FragPipe). Writes `DE_<method>_<contrast>.csv` + `Expression_Matrix.csv` +
 `methods.txt` + `sessionInfo.txt` + `de_provenance.json` (exact R package versions).
+
+**QuantUMS quality filtering (`--method maxlfq`, DIA-NN input only).** DIA-NN's
+QuantUMS scores how well MS1 and MS2 agree for each measurement, and filtering on it
+trades depth for quantitative reliability:
+
+| flag | column | default | what it does |
+|---|---|---|---|
+| `--eq-cutoff` | `Empirical.Quality` | 0 (off) | drop precursors whose empirical quality is below this |
+| `--pgq-cutoff` | `PG.MaxLFQ.Quality` | 0 (off) | drop protein groups whose MaxLFQ quality is below this |
+| `--coverage-min` | — | 0.5 | require a protein in ≥ this fraction of samples before testing |
+
+Both QuantUMS cutoffs are **off by default** — they discard real measurements, so
+they are the user's call, not a silent default. Offer them when quantitative
+precision matters more than depth (small fold-changes, few replicates), say roughly
+how many proteins each costs, and record the choice: the counts land in
+`filters_applied` and flow into `methods.txt`. They need DIA-NN input — the columns
+don't exist in Sage/FragPipe/Radiant output, and the filter is skipped if absent.
+
+`--coverage-min` is different: it is **on** at 0.5 because a protein seen in one or
+two samples is an on/off observation, and letting such rows into `eBayes` destabilises
+the variance moderation for *every* protein, not just those rows.
+
 → detail: `references/de-analysis.md`.
 
 ### 8b. Generate figures

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -629,11 +629,27 @@ once `COMPLETED` and `report.parquet` exists. → detail: `references/watcher.md
 Rscript scripts/run_de.R --input ./search_out/report.parquet \
     --metadata conditions.csv --method <dpc|maxlfq> --outdir ./de_results
 ```
-Use the `de.method` from the bundle (`dpc` for DIA-NN/limpa, `maxlfq` for
-Sage/FragPipe). Writes `DE_<method>_<contrast>.csv` + `Expression_Matrix.csv` +
+**`dpc` (limpa) is THE DEFAULT — use it unless the user asks otherwise or the data
+cannot support it.** limpa models the detection-probability curve and quantifies from
+precursor intensities directly, so it uses the whole measurement rather than a
+pre-collapsed protein number. Don't switch away from it because a bundle happens to
+say `maxlfq`; switch only for the two reasons below.
+
+Use `maxlfq` when **either**:
+1. **The user asks for it** — e.g. they want QuantUMS quality filtering (below), or
+   to match a previous MaxLFQ-based analysis.
+2. **The input cannot support limpa.** `readDIANN()` needs PRECURSOR-level columns
+   (`Precursor.Id`, `Precursor.Normalised`). DIA-NN's own `report.parquet` has them.
+   The Sage / FragPipe / Radiant adapters collapse to one row per protein × run, so
+   limpa cannot run on their output — `run_de.R` checks this up front and says so.
+   (Radiant: `radiant_to_delimp.py` emits a precursor-level report that *does*
+   support `dpc` — point `--input` at that if you want limpa on Radiant results.)
+
+Writes `DE_<method>_<contrast>.csv` + `Expression_Matrix.csv` +
 `methods.txt` + `sessionInfo.txt` + `de_provenance.json` (exact R package versions).
 
-**QuantUMS quality filtering (`--method maxlfq`, DIA-NN input only).** DIA-NN's
+**QuantUMS quality filtering — opt-in, `--method maxlfq`, DIA-NN input only.**
+Only reach for this when the user asks. DIA-NN's
 QuantUMS scores how well MS1 and MS2 agree for each measurement, and filtering on it
 trades depth for quantitative reliability:
 

--- a/skill/ucdavis-proteomics-core-pipeline/references/de-analysis.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/de-analysis.md
@@ -55,6 +55,30 @@ Protein.Names`). `run_search.py` produces this for non-DIA-NN engines.
 or empty groups. Groups with <2 replicates have no within-group variance — warn the
 user at the design step (`collect_conditions.py --validate` flags singletons).
 
+## Method choice — limpa/DPC is the default
+
+`--method dpc` (limpa) is the default and should stay that way. It models the
+detection-probability curve and quantifies from precursor intensities, so it uses the
+whole measurement instead of a pre-collapsed protein number, and it handles missingness
+as information rather than as a hole to filter around.
+
+`--method maxlfq` is for two situations only:
+
+1. **The user asked** — usually because they want QuantUMS quality filtering, or to
+   match an earlier MaxLFQ analysis.
+2. **The input is protein-level.** `readDIANN()` keys on `Precursor.Id` and
+   `Precursor.Normalised`. DIA-NN's native `report.parquet` has them; the Sage /
+   FragPipe / Radiant adapters emit one row per protein x run and do not. `run_de.R`
+   checks before limpa is called and fails with the reason and the fix, rather than
+   letting limpa error on a missing column deep in its own code.
+
+   Radiant is the interesting case: `radiant_to_delimp.py` *does* emit precursor-level
+   output (that is what DE-LIMP's uploader needs), so pointing `--input` at that report
+   makes `dpc` work on Radiant results. `adapt_radiant`'s output does not.
+
+Do not read a bundle's `de.method: maxlfq` as a recommendation — it records what that
+engine's adapted output can support, not which method is better.
+
 ## Coverage filter (maxlfq path)
 
 `--coverage-min` (default 0.5) drops proteins quantified in fewer than that fraction

--- a/skill/ucdavis-proteomics-core-pipeline/references/de-analysis.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/de-analysis.md
@@ -55,6 +55,20 @@ Protein.Names`). `run_search.py` produces this for non-DIA-NN engines.
 or empty groups. Groups with <2 replicates have no within-group variance — warn the
 user at the design step (`collect_conditions.py --validate` flags singletons).
 
+## Coverage filter (maxlfq path)
+
+`--coverage-min` (default 0.5) drops proteins quantified in fewer than that fraction
+of samples **before** limma. The MaxLFQ matrix keeps every protein seen in *any* run,
+so rows with 1-2 finite values otherwise reach `eBayes`, which then moderates variance
+against rows whose variance is barely estimable — destabilising the whole fit, not just
+those rows. Dropped proteins are an on/off observation, not a differential-abundance
+result, and the count lands in `filters_applied` so the Methods text says so.
+
+Ported from DE-LIMP (`server_data.R`), whose default and rationale come from the
+UC Davis Bioinformatics Core. If it leaves <10 testable proteins the run stops rather
+than fitting noise — loosen `--coverage-min`, or the QuantUMS cutoffs if those are
+what emptied the matrix.
+
 ## Provenance (self-describing — DE-LIMP architectural rule #1)
 Each method path returns a `descriptor` (pipeline_id, display_label, rollup_method,
 de_engine, missing_policy, citation). `methods.txt` is built from it — **never
@@ -65,5 +79,13 @@ hardcode a description of what ran**, and hand `methods.txt` to the user verbati
   Li M, Smyth GK (2023) Bioinformatics 39(5):btad200. (DE-LIMP's
   `dpc_pipeline_descriptor()` mis-cites this as "Law CW, Smyth GK" — fix upstream.)
 - **MaxLFQ path:** DIA-NN MaxLFQ (Demichev et al. 2020, Nat Methods 17:41) +
-  limma (Ritchie et al. 2015, NAR 43:e47). (DE-LIMP's "Moschem et al. 2025"
-  reference could not be verified — reconcile before publishing methods text.)
+  limma (Ritchie et al. 2015, NAR 43:e47).
+- **QuantUMS quality filtering:** da Cruz Moschem J, Silva Campitelli de Barros BC,
+  de Toledo Serrano SM, Chaves AFA (2025) *Decoding the Impact of Isolation Window
+  Selection and QuantUMS Filtering in DIA-NN for DIA Quantification of Peptides and
+  Proteins.* J Proteome Res 24:3860-3873. doi:10.1021/acs.jproteome.5c00009.
+  **VERIFIED 2026-08-04** — an earlier note here said this "could not be verified";
+  that was wrong. DE-LIMP cites it as "Moschem et al." (the first author's surname is
+  da Cruz Moschem). QuantUMS computes three scores: protein-group MaxLFQ quality,
+  empirical quality, and quantity quality, all measuring MS1/MS2 feature agreement.
+  The skill filters on the first two (`--pgq-cutoff`, `--eq-cutoff`).

--- a/skill/ucdavis-proteomics-core-pipeline/references/de-analysis.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/de-analysis.md
@@ -66,15 +66,27 @@ as information rather than as a hole to filter around.
 
 1. **The user asked** — usually because they want QuantUMS quality filtering, or to
    match an earlier MaxLFQ analysis.
-2. **The input is protein-level.** `readDIANN()` keys on `Precursor.Id` and
-   `Precursor.Normalised`. DIA-NN's native `report.parquet` has them; the Sage /
-   FragPipe / Radiant adapters emit one row per protein x run and do not. `run_de.R`
-   checks before limpa is called and fails with the reason and the fix, rather than
-   letting limpa error on a missing column deep in its own code.
+2. **The file you point at is protein-level.** `readDIANN()` keys on `Precursor.Id`
+   and `Precursor.Normalised`. This is a property of the FILE, not of the engine —
+   most engines can feed limpa if you use the right output:
 
-   Radiant is the interesting case: `radiant_to_delimp.py` *does* emit precursor-level
-   output (that is what DE-LIMP's uploader needs), so pointing `--input` at that report
-   makes `dpc` work on Radiant results. `adapt_radiant`'s output does not.
+   - **DIA-NN** — `search_out/report.parquet`, native.
+   - **FragPipe** — `dia-quant-output/report.tsv` with `--format tsv`. Its DIA route
+     bundles DIA-NN, so this is a DIA-NN report and carries `Lib.Q.Value` /
+     `Lib.PG.Q.Value` (columns 39-40). Verified end-to-end on the 9-file class data:
+     22,425 precursors -> 12,485 proteins, both contrasts written.
+   - **Radiant** — `radiant_to_delimp.py` output. Verified twice: 3-run HeLa
+     (25,722 precursors x 3) and 18-run Poplar (21,370 precursors x 18).
+
+   The ADAPTED `report.parquet` from `adapt_*` is the exception: it collapses to one
+   row per protein x run on purpose, to feed the maxlfq path. `run_de.R` checks the
+   columns before limpa is called and names the precursor-level file to use instead.
+
+**q-value columns.** `readDIANN()` prints `Q-value columns <x> not found.` and then
+continues with that filter simply not applied — a message, not an error, easy to miss
+in a long log. `run_de.R` resolves `q.columns` against the real header, states which
+filters it applied, and stops if none are usable, so an unfiltered result can never
+look filtered.
 
 Do not read a bundle's `de.method: maxlfq` as a recommendation — it records what that
 engine's adapted output can support, not which method is better.

--- a/skill/ucdavis-proteomics-core-pipeline/references/diann_parallel.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/diann_parallel.md
@@ -75,6 +75,8 @@ bash scripts/hive_exec.sh 'bash <out>/submit.sh'
 ```
 It writes `file_list.txt`, `step{1..5}_*.sbatch`, and `submit.sh` (which submits all
 five with dependencies and prints the job ids). **Watch the final job** with
+`watch_run.sh --all <out> --hive` (reads `jobs.txt`; covers all five steps — watching
+only step 5 hides an upstream failure as a permanent `PENDING`), or for one step
 `watch_run.sh --slurm <jid5> --log <out>/s5_report_<jid5>.log --hive`. When step 5
 completes, point `run_de.R` at `<out>/report.parquet`.
 

--- a/skill/ucdavis-proteomics-core-pipeline/references/watcher.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/watcher.md
@@ -8,6 +8,22 @@ authorization for this — see golden rule #1's compute confirmation is for *sta
 the search, not for recovering a run that's already approved and in flight). Surface
 what you did afterwards; don't ask permission to unstick a job.
 
+## Watch the WHOLE chain, not its last job
+
+For any multi-step chain (`diann_parallel.py`, `radiant_parallel.py`), watch with:
+
+```bash
+bash scripts/watch_run.sh --all <search out dir> --hive
+```
+
+It reads `jobs.txt` (written by `submit.sh`) and reports every job's state at once.
+**Do not** watch only the final job. If an earlier step dies, the final job sits
+`PENDING` on a dependency that can never be satisfied — which is indistinguishable
+from "still queued" if that is the only job you are looking at. This actually
+happened: a step-4 array hit `TIMEOUT`, step 5 went `CANCELLED`, and a watcher
+pointed at step 5 alone reported "pending" for hours. `--all` returns
+`failed:true` with `first_failed_job` in that situation.
+
 `watch_run.sh` does one poll + diagnosis (state, **stall**, error class, fix); loop it
 until the run finishes, and on `failed` **or** `stalled` apply the fix and resubmit.
 

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
@@ -323,6 +323,8 @@ def main():
         f'  --report "{D}/{report}" --watch-job "$jid5" --watch-log "{D}/s5_report_${{jid5}}.log" \\',
         f'  --next "Rscript run_de.R --input {D}/{report} --metadata {sess}/input/conditions.csv --method dpc --outdir {sess}/output/tables" \\',
         '  >/dev/null 2>&1 || true',
+        f'printf "%s\\n" {jobs.replace(",", " ")} > "{D}/jobs.txt"',
+        f'echo "all chain job ids -> {D}/jobs.txt  (watch the WHOLE chain: watch_run.sh --all {D})"',
         f'echo "recovery notes written to {sess}/RECOVERY.md — you can safely close your terminal"']
     write("submit.sh", "\n".join(sub_lines))
 

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/hive_exec.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/hive_exec.sh
@@ -18,7 +18,13 @@
 # Heavy compute must go through SLURM (sbatch), never the login node.
 # =============================================================================
 set -uo pipefail
-HU="${HIVE_USER:?set HIVE_USER (ask the user for their HIVE username)}"
+# Env vars do not survive between tool calls / shells, so requiring HIVE_USER in the
+# environment means every helper that shells out (watch_run.sh especially) silently
+# fails with an empty result -- which downstream code reads as "nothing there".
+# Persist it once to a config file and every later invocation just works.
+CFG="${HIVE_ENV_FILE:-$HOME/.config/ucdavis-proteomics/hive.env}"
+if [ -z "${HIVE_USER:-}" ] && [ -f "$CFG" ]; then . "$CFG"; fi
+HU="${HIVE_USER:?set HIVE_USER, or save it once: mkdir -p ~/.config/ucdavis-proteomics && printf \'HIVE_USER=<user>\\nHIVE_KEY=~/.ssh/id_ed25519\\n\' > ~/.config/ucdavis-proteomics/hive.env}"
 KEY="${HIVE_KEY:?set HIVE_KEY to the private-key path the user gave you}"
 KEY="${KEY/#\~/$HOME}"
 HOST="${HIVE_HOST:-hive.hpc.ucdavis.edu}"

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/hive_exec.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/hive_exec.sh
@@ -29,5 +29,9 @@ case "${1:-}" in
   --put) shift; rsync -e "ssh -i $KEY -o IdentitiesOnly=yes" -a "$1" "$HU@$HOST:$2" ;;
   --get) shift; rsync -e "ssh -i $KEY -o IdentitiesOnly=yes" -a "$HU@$HOST:$1" "$2" ;;
   "")    echo "usage: hive_exec.sh '<command>' | --put <local> <remote> | --get <remote> <local>" >&2; exit 2 ;;
-  *)     "${SSH[@]}" "$@" ;;
+  # LOGIN shell (bash -l). ssh with a bare command runs a NON-login shell, where
+  # HIVE does not put sacct/squeue/sbatch on PATH. Every SLURM query then returned
+  # nothing, and watch_run.sh read that emptiness as "PENDING" -- so a job array with
+  # 14 TIMEOUT tasks reported as still running. Silence must never look like health.
+  *)     "${SSH[@]}" "bash -l -c $(printf '%q' "$*")" ;;
 esac

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
@@ -92,7 +92,28 @@ message(sprintf("[run_de] method=%s  q=%.3f  samples=%d  covariates=%s",
 
 descriptor <- NULL
 
+# limpa/DPC is the DEFAULT path. It needs PRECURSOR-level input: readDIANN() keys on
+# Precursor.Id + Precursor.Normalised. DIA-NN's native report.parquet has them; the
+# adapters for Sage/FragPipe/Radiant collapse to one protein x run row, so limpa
+# cannot run on their output. Check up front and say so in one line, rather than
+# letting limpa fail deep inside with a column error the user cannot act on.
 if (method == "dpc") {
+  have_cols <- tryCatch({
+    if (identical(format, "parquet")) names(arrow::open_dataset(input)$schema)
+    else names(utils::read.delim(input, nrows = 1, check.names = FALSE))
+  }, error = function(e) character(0))
+  need_dpc <- c("Precursor.Id", "Precursor.Normalised")
+  miss_dpc <- setdiff(need_dpc, have_cols)
+  if (length(have_cols) > 0 && length(miss_dpc) > 0)
+    stop(sprintf(paste0(
+      "--method dpc (limpa) needs PRECURSOR-level input but %s has no %s.\n",
+      "  DIA-NN's own report.parquet is precursor-level and works.\n",
+      "  Sage / FragPipe / Radiant reports are adapted to one row per protein x run,\n",
+      "  so limpa cannot run on them -- use --method maxlfq for those.\n",
+      "  (Radiant: radiant_to_delimp.py emits a precursor-level report that DOES\n",
+      "   support dpc; point --input at that instead.)"),
+      basename(input), paste(miss_dpc, collapse = " / ")))
+
   if (!requireNamespace("limpa", quietly = TRUE))
     stop("limpa is required for --method dpc. BiocManager::install('limpa') (needs R 4.5+, Bioc 3.22+).")
   suppressMessages({ library(limpa); library(limma) })

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
@@ -107,19 +107,48 @@ if (method == "dpc") {
   if (length(have_cols) > 0 && length(miss_dpc) > 0)
     stop(sprintf(paste0(
       "--method dpc (limpa) needs PRECURSOR-level input but %s has no %s.\n",
-      "  DIA-NN's own report.parquet is precursor-level and works.\n",
-      "  Sage / FragPipe / Radiant reports are adapted to one row per protein x run,\n",
-      "  so limpa cannot run on them -- use --method maxlfq for those.\n",
-      "  (Radiant: radiant_to_delimp.py emits a precursor-level report that DOES\n",
-      "   support dpc; point --input at that instead.)"),
+      "  Precursor-level reports that DO work with dpc:\n",
+      "    DIA-NN   search_out/report.parquet          (native)\n",
+      "    FragPipe dia-quant-output/report.tsv        (--format tsv; its DIA route\n",
+      "             bundles DIA-NN, so this IS a DIA-NN report)\n",
+      "    Radiant  radiant_to_delimp.py --out <x>.parquet\n",
+      "  What does NOT work is the ADAPTED report.parquet from adapt_sage /\n",
+      "  adapt_fragpipe / adapt_radiant -- those collapse to one row per protein x\n",
+      "  run for the maxlfq path. Point --input at the precursor-level file above,\n",
+      "  or use --method maxlfq."),
       basename(input), paste(miss_dpc, collapse = " / ")))
 
   if (!requireNamespace("limpa", quietly = TRUE))
     stop("limpa is required for --method dpc. BiocManager::install('limpa') (needs R 4.5+, Bioc 3.22+).")
   suppressMessages({ library(limpa); library(limma) })
 
-  dat <- limpa::readDIANN(input, format = format, q.cutoffs = q_cutoff)
-  message(sprintf("[run_de] readDIANN: %d precursors x %d runs", nrow(dat$E), ncol(dat$E)))
+  # readDIANN() prints "Q-value columns <x> not found." for a missing q-column and
+  # then CARRIES ON with that filter simply not applied -- a message, not an error,
+  # easy to lose in a long log. Resolving against the real header instead means the
+  # run log states exactly which FDR filters were applied, and a report with no usable
+  # q-column stops rather than producing unfiltered results that look filtered.
+  # (FragPipe's own report.tsv does carry Lib.Q.Value / Lib.PG.Q.Value -- columns 39
+  # and 40 -- so it needs no special handling; it works with limpa's defaults.)
+  q_want <- c("Q.Value", "Lib.Q.Value", "Lib.PG.Q.Value")
+  q_alt  <- c("Global.Q.Value", "Global.PG.Q.Value", "PG.Q.Value")
+  q_use  <- intersect(q_want, have_cols)
+  q_extra <- intersect(setdiff(q_alt, q_use), have_cols)
+  if (length(setdiff(q_want, have_cols)) > 0) {
+    q_use <- unique(c(q_use, q_extra))
+    message(sprintf(paste0("[run_de] this report has no %s; limpa would apply NO filter ",
+                           "for those columns without saying so. Filtering on %s instead."),
+                    paste(setdiff(q_want, have_cols), collapse = " / "),
+                    paste(q_use, collapse = " / ")))
+  }
+  if (length(q_use) == 0)
+    stop("No usable q-value column found in ", basename(input),
+         " -- cannot apply identification FDR. Columns present: ",
+         paste(have_cols, collapse = ", "))
+
+  dat <- limpa::readDIANN(input, format = format, q.cutoffs = q_cutoff,
+                          q.columns = q_use)
+  message(sprintf("[run_de] readDIANN: %d precursors x %d runs (FDR %.3f on %s)",
+                  nrow(dat$E), ncol(dat$E), q_cutoff, paste(q_use, collapse = ", ")))
 
   dpcfit    <- limpa::dpcCN(dat)
   y_protein <- limpa::dpcQuant(dat, "Protein.Group", dpc = dpcfit)

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
@@ -56,6 +56,9 @@ contrasts <- getarg("--contrasts", NULL)
 q_cutoff  <- as.numeric(getarg("--q-cutoff", "0.01"))
 eq_cutoff <- as.numeric(getarg("--eq-cutoff", "0"))
 pgq_cutoff<- as.numeric(getarg("--pgq-cutoff", "0"))
+# Fraction of samples a protein must be quantified in to be TESTED (maxlfq path).
+# 0.5 matches DE-LIMP's default and the UC Davis Bioinformatics Core recommendation.
+cov_min_frac <- as.numeric(getarg("--coverage-min", "0.5"))
 outdir    <- getarg("--outdir", "de_results")
 # --logfc is a REFERENCE LINE ONLY -- it is drawn and labelled on the volcano and never
 # filters anything. Significance is the BH-adjusted p-value alone, which is the exact
@@ -129,6 +132,33 @@ if (method == "dpc") {
   descriptor <- ml$descriptor
   message(sprintf("[run_de] MaxLFQ matrix: %d proteins x %d runs (%.1f%% missing)",
                   nrow(E), ncol(E), 100 * mean(is.na(E))))
+
+  # ---- coverage filter (ported from DE-LIMP server_data.R) -----------------
+  # The MaxLFQ matrix keeps every protein seen in ANY run, so rows with 1-2
+  # finite values reach limma. eBayes then moderates variance against rows whose
+  # variance is barely estimable, which destabilises the whole fit -- not just
+  # those rows. Require a protein to be quantified in at least `--coverage-min`
+  # of samples before testing; the rest are an on/off observation, not a
+  # differential-abundance result.
+  n_samples     <- ncol(E)
+  min_obs       <- max(2, ceiling(cov_min_frac * n_samples))
+  n_obs_per_row <- rowSums(!is.na(E))
+  keep_cov      <- n_obs_per_row >= min_obs
+  n_dropped     <- sum(!keep_cov)
+  message(sprintf("[run_de] coverage filter: keep proteins with >= %d/%d non-NA (%.0f%%). Kept %d, dropped %d.",
+                  min_obs, n_samples, 100 * cov_min_frac, sum(keep_cov), n_dropped))
+  if (sum(keep_cov) < 10)
+    stop(sprintf(paste0("Coverage filter left only %d testable proteins (needed >= %d non-NA ",
+                        "of %d samples). Loosen --coverage-min, or the QuantUMS cutoffs ",
+                        "(--eq-cutoff / --pgq-cutoff) if those are doing the damage."),
+                 sum(keep_cov), min_obs, n_samples))
+  E <- E[keep_cov, , drop = FALSE]
+  if (!is.null(genes) && nrow(genes) == length(keep_cov))
+    genes <- genes[keep_cov, , drop = FALSE]
+  prev_filters <- if (is.null(descriptor$filters_applied)) character(0) else descriptor$filters_applied
+  descriptor$filters_applied <- c(prev_filters,
+    sprintf("coverage >= %d/%d non-NA samples (%.0f%%); %d proteins dropped",
+            min_obs, n_samples, 100 * cov_min_frac, n_dropped))
 }
 
 # ---- align metadata to the matrix columns -----------------------------------

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
@@ -16,9 +16,10 @@
 #   while not done: watch_run.sh ...; sleep 60; done   # then act on failed/fix
 # =============================================================================
 set -uo pipefail
-MODE="local"; JOB=""; LOG=""; HIVE=false; STALL_MIN=15; OUTDIR=""; POLL=0
+MODE="local"; JOB=""; LOG=""; HIVE=false; STALL_MIN=15; OUTDIR=""; POLL=0; CHAINDIR=""
 while [ $# -gt 0 ]; do case "$1" in
   --slurm)     MODE="slurm"; JOB="$2"; shift 2;;
+  --all)       MODE="chain"; CHAINDIR="$2"; shift 2;;   # watch EVERY job in a chain
   --log)       LOG="$2"; shift 2;;
   --hive)      HIVE=true; shift;;
   --stall-min) STALL_MIN="$2"; shift 2;;   # RUNNING + log frozen this long ⇒ stalled
@@ -30,6 +31,37 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 run() { if $HIVE; then bash "$HERE/hive_exec.sh" "$*"; else bash -c "$*"; fi; }
 
 state="unknown"; done=false; failed=false; q_failed=false; fix_qf=""
+
+# --all <dir>: watch the WHOLE chain, not just its last link. Watching only the final
+# job is why a step-4 array that timed out went unnoticed for hours -- step 5 simply
+# sat PENDING on a dependency that could never be satisfied, which reads as "still
+# running". jobs.txt is written by submit.sh with every id in the chain.
+if [ "$MODE" = "chain" ]; then
+  JT="$CHAINDIR/jobs.txt"
+  ids="$(run "cat $JT 2>/dev/null | tr '\n' ' '" 2>/dev/null)"
+  if [ -z "$ids" ]; then
+    echo "{\"error\":\"no jobs.txt under $CHAINDIR — was this chain submitted via submit.sh?\"}"
+    exit 2
+  fi
+  worst=""; anyfail=false; allterm=true; summary=""
+  for id in $ids; do
+    js="$(run "sacct -j $id -X --noheader -o State 2>/dev/null | tr -d ' ' | sed 's/+$//' | sort -u | tr '\n' ','" 2>/dev/null)"
+    [ -z "$js" ] && js="UNKNOWN"
+    summary="$summary $id=${js%,}"
+    printf '%s' "$js" | grep -qE "FAILED|TIMEOUT|OUT_OF_ME|NODE_FAIL" && { anyfail=true; worst="$id"; }
+    printf '%s' "$js" | grep -qE "RUNNING|PENDING|UNKNOWN" && allterm=false
+  done
+  if $anyfail; then
+    echo "{\"mode\":\"chain\",\"dir\":\"$CHAINDIR\",\"failed\":true,\"done\":true,\"first_failed_job\":\"$worst\",\"chain\":\"${summary# }\",\"fix\":\"A step FAILED. Inspect it: watch_run.sh --slurm $worst --hive. Downstream steps will sit PENDING with DependencyNeverSatisfied forever until you fix and resubmit them.\"}"
+    exit 0
+  fi
+  if $allterm; then
+    echo "{\"mode\":\"chain\",\"dir\":\"$CHAINDIR\",\"failed\":false,\"done\":true,\"chain\":\"${summary# }\"}"
+  else
+    echo "{\"mode\":\"chain\",\"dir\":\"$CHAINDIR\",\"failed\":false,\"done\":false,\"chain\":\"${summary# }\"}"
+  fi
+  exit 0
+fi
 if [ "$MODE" = "slurm" ] && [ -n "$JOB" ]; then
   # -X = one row per JOB STEP, not per .batch/.extern subrecord. For a job ARRAY this
   # is many rows; `head -1` would report one arbitrary task's state as the whole job's

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
@@ -29,11 +29,37 @@ esac; done
 HERE="$(cd "$(dirname "$0")" && pwd)"
 run() { if $HIVE; then bash "$HERE/hive_exec.sh" "$*"; else bash -c "$*"; fi; }
 
-state="unknown"; done=false; failed=false
+state="unknown"; done=false; failed=false; q_failed=false; fix_qf=""
 if [ "$MODE" = "slurm" ] && [ -n "$JOB" ]; then
-  st="$(run "sacct -j $JOB --noheader -o State 2>/dev/null | head -1 | tr -d ' '" 2>/dev/null)"
-  [ -z "$st" ] && st="$(run "squeue -j $JOB -h -o %T 2>/dev/null" 2>/dev/null)"
-  state="${st:-PENDING}"
+  # -X = one row per JOB STEP, not per .batch/.extern subrecord. For a job ARRAY this
+  # is many rows; `head -1` would report one arbitrary task's state as the whole job's
+  # -- how a 4-COMPLETED / 14-TIMEOUT array read as healthy. Aggregate instead:
+  # failed if ANY task failed, done only when ALL tasks are terminal.
+  all_states="$(run "sacct -j $JOB -X --noheader -o State 2>/dev/null | tr -d ' ' | sed 's/+$//' | sort | uniq -c" 2>/dev/null)"
+  if [ -z "$all_states" ]; then
+    live="$(run "squeue -j $JOB -h -o %T 2>/dev/null | tr -d ' ' | sort -u" 2>/dev/null)"
+    if [ -n "$live" ]; then
+      all_states="$(printf '   1 %s\n' $live)"
+    else
+      # Neither sacct nor squeue answered. Do NOT call that PENDING -- that is how a
+      # dead job passes for a running one. Say the query failed and stop.
+      state="query_failed"; done=false; failed=true; q_failed=true
+      fix_qf="Could not read job state: sacct and squeue both returned nothing. Usually SLURM tools are not on PATH (hive_exec.sh must use a LOGIN shell), or the job id is wrong / aged out of sacct. Verify: hive_exec.sh 'sacct -j <id> -X'."
+    fi
+  fi
+  if [ "${state:-}" != "query_failed" ]; then
+    a_total=$(printf '%s\n' "$all_states" | awk '{s+=$1} END{print s+0}')
+    a_term=$(printf '%s\n' "$all_states" | awk '/COMPLETED|FAILED|TIMEOUT|OUT_OF_ME|CANCELLED|NODE_FAIL|PREEMPTED/{s+=$1} END{print s+0}')
+    a_bad=$(printf '%s\n' "$all_states"  | awk '/FAILED|TIMEOUT|OUT_OF_ME|NODE_FAIL/{s+=$1} END{print s+0}')
+    a_run=$(printf '%s\n' "$all_states"  | awk '/RUNNING/{s+=$1} END{print s+0}')
+    # worst state wins, so a partially-failed array is never reported as healthy
+    if   [ "$a_bad"  -gt 0 ]; then state="$(printf '%s\n' "$all_states" | awk '/FAILED|TIMEOUT|OUT_OF_ME|NODE_FAIL/{print $2; exit}')"
+    elif [ "$a_run"  -gt 0 ]; then state="RUNNING"
+    elif [ "$a_term" -gt 0 ] && [ "$a_term" -eq "$a_total" ]; then state="COMPLETED"
+    else state="PENDING"; fi
+    array_summary="$(printf '%s\n' "$all_states" | awk '{printf "%s=%s ", $2, $1}')"
+  fi
+  st="$state"
   reason="$(run "squeue -j $JOB -h -o %R 2>/dev/null" 2>/dev/null)"
   case "$state" in
     COMPLETED)                                   done=true;;
@@ -110,10 +136,12 @@ if [ -n "$OUTDIR" ]; then
 fi
 
 # ---- narration: what this stage is doing, plus something to read while waiting
+if $q_failed; then err_class="watcher_query_failed"; fix="$fix_qf"; fi
+
 notes="$(python3 "$HERE/pipeline_notes.py" --stage "$stage" --index "$POLL" 2>/dev/null)"
 
 STATE="$state" DONE="$done" FAILED="$failed" STALLED="$stalled" JOB="$JOB" MODE="$MODE" \
-ECLASS="$err_class" FIX="$fix" TAIL="$tail_txt" \
+ECLASS="$err_class" FIX="$fix" TAIL="$tail_txt" ATASKS="${array_summary:-}" \
 STAGE="$stage" NDONE="${n_done:-0}" NTOTAL="${n_total:-0}" NOTES="$notes" python3 - <<'PY'
 import os, json
 n_done, n_total = int(os.environ.get("NDONE") or 0), int(os.environ.get("NTOTAL") or 0)
@@ -123,6 +151,7 @@ out = {
     "done": os.environ["DONE"] == "true", "failed": os.environ["FAILED"] == "true",
     "stalled": os.environ.get("STALLED") == "true",
     "error_class": os.environ["ECLASS"], "fix": os.environ["FIX"],
+    **({"array_tasks": os.environ["ATASKS"].strip()} if os.environ.get("ATASKS","").strip() else {}),
 }
 step_no = stage[4:] if stage.startswith("step") else None
 progress = {"stage": stage, "files_done": n_done, "files_total": n_total}

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
@@ -38,9 +38,14 @@ state="unknown"; done=false; failed=false; q_failed=false; fix_qf=""
 # running". jobs.txt is written by submit.sh with every id in the chain.
 if [ "$MODE" = "chain" ]; then
   JT="$CHAINDIR/jobs.txt"
+  probe="$(run "echo __ok__" 2>&1)"
+  if ! printf '%s' "$probe" | grep -q __ok__; then
+    echo "{\"mode\":\"chain\",\"failed\":true,\"done\":true,\"err_class\":\"watcher_query_failed\",\"detail\":$(printf '%s' "$probe" | head -2 | python3 -c 'import sys,json;print(json.dumps(sys.stdin.read()))'),\"fix\":\"Cannot reach the cluster at all — this is NOT a job failure and NOT a missing file. Usually HIVE_USER/HIVE_KEY are unset: save them once to ~/.config/ucdavis-proteomics/hive.env. Re-run the watcher before drawing any conclusion about the run.\"}"
+    exit 3
+  fi
   ids="$(run "cat $JT 2>/dev/null | tr '\n' ' '" 2>/dev/null)"
   if [ -z "$ids" ]; then
-    echo "{\"error\":\"no jobs.txt under $CHAINDIR — was this chain submitted via submit.sh?\"}"
+    echo "{\"mode\":\"chain\",\"failed\":true,\"done\":true,\"err_class\":\"no_jobs_file\",\"fix\":\"Cluster is reachable but $JT does not exist — this chain was not submitted via submit.sh (older runs predate jobs.txt). Write it by hand with one job id per line, then re-run.\"}"
     exit 2
   fi
   worst=""; anyfail=false; allterm=true; summary=""

--- a/workflows/fragpipe_dia_thermo_human/workflow.yaml
+++ b/workflows/fragpipe_dia_thermo_human/workflow.yaml
@@ -50,7 +50,10 @@ search:
   estimate_params: false
 
 de:
-  method: maxlfq
+  method: dpc
+  input_note: >
+    dia-quant-output/report.tsv (--format tsv) — FragPipe's DIA route bundles DIA-NN,
+    so that file is precursor-level and limpa reads it. NOT the adapted report.parquet.
   q_cutoff: 0.01
   logfc: 1.0                                # volcano reference line only; not a filter
   adjp: 0.05

--- a/workflows/fragpipe_diatracer_timstof_dia_human/workflow.yaml
+++ b/workflows/fragpipe_diatracer_timstof_dia_human/workflow.yaml
@@ -50,7 +50,10 @@ search:
   estimate_params: false
 
 de:
-  method: maxlfq                            # FragPipe/DIA-NN quant -> MaxLFQ + limma
+  method: dpc
+  input_note: >
+    dia-quant-output/report.tsv (--format tsv) — FragPipe's DIA route bundles DIA-NN,
+    so that file is precursor-level and limpa reads it. NOT the adapted report.parquet.
   q_cutoff: 0.01
   logfc: 1.0                                # volcano reference line only; not a filter
   adjp: 0.05

--- a/workflows/index.json
+++ b/workflows/index.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "repo": "bsphinney/DE-LIMP",
-  "generated": "2026-07-31",
+  "generated": "2026-08-04",
   "workflows": [
     {
       "id": "diann_astral_dia_human",
@@ -138,7 +138,8 @@
         "extra_files": []
       },
       "de": {
-        "method": "maxlfq",
+        "method": "dpc",
+        "input_note": "dia-quant-output/report.tsv (--format tsv) — FragPipe's DIA route bundles DIA-NN, so that file is precursor-level and limpa reads it. NOT the adapted report.parquet.\n",
         "q_cutoff": 0.01,
         "logfc": 1.0,
         "adjp": 0.05
@@ -187,7 +188,8 @@
         "extra_files": []
       },
       "de": {
-        "method": "maxlfq",
+        "method": "dpc",
+        "input_note": "dia-quant-output/report.tsv (--format tsv) — FragPipe's DIA route bundles DIA-NN, so that file is precursor-level and limpa reads it. NOT the adapted report.parquet.\n",
         "q_cutoff": 0.01,
         "logfc": 1.0,
         "adjp": 0.05
@@ -241,7 +243,8 @@
         "extra_files": []
       },
       "de": {
-        "method": "maxlfq",
+        "method": "dpc",
+        "input_note": "radiant_to_delimp.py output — precursor-level. adapt_radiant's report.parquet is protein-level and only supports maxlfq.\n",
         "q_cutoff": 0.01,
         "logfc": 1.0,
         "adjp": 0.05

--- a/workflows/radiant_orbitrap_dia_human/workflow.yaml
+++ b/workflows/radiant_orbitrap_dia_human/workflow.yaml
@@ -49,7 +49,10 @@ search:
   estimate_params: false
 
 de:
-  method: maxlfq
+  method: dpc
+  input_note: >
+    radiant_to_delimp.py output — precursor-level. adapt_radiant's report.parquet is
+    protein-level and only supports maxlfq.
   q_cutoff: 0.01
   logfc: 1.0                                # volcano reference line only; not a filter
   adjp: 0.05


### PR DESCRIPTION
Checked the DE-LIMP repo as asked. **The QuantUMS quality-filter + limma workflow was already ported** — `build_maxlfq.R` has `eq_cutoff`/`pgq_cutoff`, and `run_de.R` exposes `--eq-cutoff` / `--pgq-cutoff`. Three things were missing.

## 1. The coverage filter was never ported

DE-LIMP drops proteins quantified in fewer than 50% of samples **before** limma (`server_data.R`). The skill kept every protein seen in *any* run.

That matters more than it looks. The MaxLFQ matrix is sparse by construction, so rows with 1–2 finite values were reaching `eBayes` — and eBayes moderates variance **across** proteins, so a mass of barely-estimable rows destabilises the fit for *everything*, not just for themselves.

Added `--coverage-min` (default **0.5**, DE-LIMP's default and the UC Davis Bioinformatics Core's recommendation), with DE-LIMP's guard: stop rather than fit noise if fewer than 10 testable proteins survive, naming which cutoff to loosen. The dropped count appends to `filters_applied`, so it reaches `methods.txt`.

## 2. Nothing in SKILL.md mentioned the filters

The code existed but was **undiscoverable** — the orchestrator would never have offered it. SKILL.md now carries the flag table and, more usefully, *when* to reach for it:

| flag | column | default | effect |
|---|---|---|---|
| `--eq-cutoff` | `Empirical.Quality` | 0 (off) | drop low-quality precursors |
| `--pgq-cutoff` | `PG.MaxLFQ.Quality` | 0 (off) | drop low-quality protein groups |
| `--coverage-min` | — | 0.5 | require a protein in ≥ this fraction of samples |

Both QuantUMS cutoffs stay **off** by default because they discard real measurements — that's the user's call, not a silent default. `--coverage-min` is **on** because the failure it prevents is contagious across proteins. Also noted: these need DIA-NN input; the columns don't exist in Sage/FragPipe/Radiant output, and the filter is skipped if absent.

## 3. The citation was flagged unverifiable — and that was wrong

`references/de-analysis.md` said DE-LIMP's "Moschem et al. 2025" reference *"could not be verified"*. It's real, and it's squarely about this workflow:

> da Cruz Moschem J, Silva Campitelli de Barros BC, de Toledo Serrano SM, Chaves AFA (2025). *Decoding the Impact of Isolation Window Selection and QuantUMS Filtering in DIA-NN for DIA Quantification of Peptides and Proteins.* **J Proteome Res 24:3860–3873.** doi:[10.1021/acs.jproteome.5c00009](https://doi.org/10.1021/acs.jproteome.5c00009)

The first author's surname is **da Cruz Moschem**, which is why the short form didn't resolve. Corrected, with the three QuantUMS scores (protein-group MaxLFQ quality, empirical quality, quantity quality) described. DE-LIMP's own `helpers.R` comment cites "page 3861", consistent with the 3860–3873 span.

## Also

Fixed a bug I introduced while writing this: the descriptor append used `%||%`, which `run_de.R` doesn't define — it would have errored at runtime on the maxlfq path. Replaced with an explicit `is.null()` check and exercised.