### PR TITLE
fix(diann): `--mass-acc 0` is a literal 0 ppm tolerance, not "auto" — generic-Orbitrap DIA-NN runs return 0 IDs

### DIFF
--- a/skill/ucdavis-proteomics-core-pipeline/references/parameters.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/parameters.md
@@ -22,12 +22,18 @@ trypsin/LFQ default:
 | Orbitrap by MS2 resolution | 240k→4, 120k→7, 60k→10, 30k→15 ppm | (when resolution is known) |
 | Bruker timsTOF (dia-PASEF / ddaPASEF) | 15 / 15 ppm | name contains "tims" |
 | SCIEX TripleTOF / ZenoTOF | 20 / 20 ppm | name contains tripletof/zenotof/sciex |
-| Orbitrap, resolution unknown | **automatic calibration** (`--mass-acc 0`) | generic orbitrap names |
+| Orbitrap, resolution unknown | **automatic calibration** (flags omitted) | generic orbitrap names |
 | Instrument not detected | **automatic calibration** | fallback |
 
 Automatic calibration is DIA-NN's own recommended default — it optimises mass
 accuracy on the first run and reuses it. We fall back to it (never to a guessed
 number) whenever the instrument class can't be pinned down.
+
+⚠ **Automatic calibration means OMITTING `--mass-acc`/`--mass-acc-ms1`, not
+setting them to 0.** `--mass-acc 0` fixes the tolerance at a literal 0 ppm — the
+log reads `Mass accuracy will be fixed to 0 (MS2) and 0 (MS1)` and the search
+returns **0 identifications**. The same applies to `--window 0`, which DIA-NN
+rejects with `scan window radius should be a positive integer`.
 
 ## Sage tolerances are derived
 

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/estimate_params.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/estimate_params.py
@@ -105,7 +105,7 @@ def classify_instrument(name, ms1_res=None, ms2_res=None):
         return ("orbitrap_generic", None, None,
                 "Orbitrap (resolution unknown — using DIA-NN automatic calibration; "
                 "pass --ms1-resolution/--ms2-resolution to pin it)",
-                "DIA-NN default (--mass-acc 0 auto-optimises per run)")
+                "DIA-NN automatic calibration (mass-accuracy flags omitted)")
     return ("unknown", None, None, f"unrecognized instrument '{name}'", "auto-calibration fallback")
 
 
@@ -180,14 +180,28 @@ def build_diann(acq, instr_class, ms1, ms2, label, src, var_mods, overrides,
         r["variable_mods"] = tagged("none",
             "DIA-NN README: variable mods do not improve depth for relative quant; left off")
 
-    # mass accuracy — the data-type-dependent part
+    # mass accuracy — the data-type-dependent part.
+    #
+    # CRITICAL: `--mass-acc 0` is NOT "automatic" in DIA-NN. It fixes the tolerance
+    # at a literal 0 ppm, so no fragment can ever match and the run yields 0 IDs
+    # ("Mass accuracy will be fixed to 0 (MS2) and 0 (MS1)" in the log). Automatic
+    # calibration is what you get by OMITTING the flags entirely. So when we have no
+    # instrument-derived value, record the rationale but emit nothing (render=False).
+    # diann_parallel.parallel_safe() treats an absent flag exactly like 0 (both are
+    # "not fixed"), so the parallel-chain gate is unaffected.
     if ms2 is None:
-        add("--mass-acc", 0, src)        # 0 = automatic
-        add("--mass-acc-ms1", 0, src)
+        auto_src = (f"{src}; flags omitted so DIA-NN auto-calibrates per run "
+                    "(--mass-acc 0 would pin the tolerance at 0 ppm -> 0 IDs)")
+        add("--mass-acc", "auto (flag omitted)", auto_src, render=False)
+        add("--mass-acc-ms1", "auto (flag omitted)", auto_src, render=False)
     else:
         add("--mass-acc", ms2, f"{label}: MS2 {ms2} ppm [{src}]")
         add("--mass-acc-ms1", ms1, f"{label}: MS1 {ms1} ppm [{src}]")
-    add("--window", 0, "scan window auto-optimised per run (DIA-NN default)")
+    # --window 0 is likewise rejected ("scan window radius should be a positive
+    # integer"); omitting it lets DIA-NN set the radius from the observed peak width.
+    add("--window", "auto (flag omitted)",
+        "scan window radius auto-optimised per run from observed peak width",
+        render=False)
 
     # Contaminants: identify them, but keep them out of quant + normalisation.
     # The tag comes from fetch_fasta.py's sidecar so the cfg self-describes the


### PR DESCRIPTION
# fix(diann): `--mass-acc 0` is a literal 0 ppm tolerance, not "auto" — every generic-Orbitrap DIA-NN run returns 0 IDs

## Summary

`estimate_params.py` emits `--mass-acc 0 --mass-acc-ms1 0` whenever it can't derive a
tolerance from the instrument, with the comment `# 0 = automatic` and the rationale
string *"DIA-NN default (--mass-acc 0 auto-optimises per run)"*.

That belief is wrong. DIA-NN treats `0` as a **fixed 0 ppm tolerance**. No fragment can
match, and the search returns **zero identifications**.

This fires for **every instrument that lands in the `orbitrap_generic` class** —
Fusion, Lumos, Eclipse, Exploris, Q Exactive, and any Orbitrap whose resolution isn't
supplied. Those are the default path for most facility DIA data.

## Why it's easy to miss

The run looks completely healthy until the very end. Files are read, mass calibration
succeeds and even prints a sensible recommendation, `.quant` files are written for every
run. The only signal is:

```
Mass accuracy will be fixed to 0 (MS2) and 0 (MS1)
WARNING: the MS1 mass accuracy setting (0 ppm) deviates significantly from the value
         recommended (10 ppm) for the Orbitrap resolution of this run (60000)
...
[0:36] Recommended MS1 mass accuracy setting: 5 ppm
[2:09] Number of IDs at 0.01 FDR: 0
```

DIA-NN then exits **255**, and because the second MBR pass gets an empty library it also
prints `WARNING: library is empty, cannot perform the second MBR pass`.

## Measurements

28 Orbitrap Fusion Lumos DIA runs (human, library-free, DIA-NN 2.6.1). One file,
identical predicted library and FASTA, only the mass-accuracy flags varied:

| cfg | IDs at 1% FDR |
|---|---|
| `--mass-acc 0 --mass-acc-ms1 0` (current behaviour) | **0** |
| `--mass-acc 15 --mass-acc-ms1 10` (hand-picked) | 70,168 |
| **flags omitted (this patch)** | **70,369** |

Omitting the flags also slightly beats hand-picked values, because DIA-NN calibrates per
run — which is what the code intended in the first place.

## Independently reproduced on a second DIA-NN build

Confirmed on **DIA-NN 2.6.0** (a different build from the 2.6.1 used above), on HIVE,
parse-only with no input files:

| invocation | DIA-NN's response |
|---|---|
| `--mass-acc 0 --mass-acc-ms1 0` | `Mass accuracy will be fixed to 0 (MS2) and 0 (MS1)` |
| `--mass-acc 15 --mass-acc-ms1 15` | `Mass accuracy will be fixed to 1.5e-05 (MS2) and 1.5e-05 (MS1)` |
| flags omitted | *(no mass-accuracy line at all — automatic)* |
| `--window 0` | `WARNING: scan window radius should be a positive integer` |
| `--window 8` | `Scan window radius set to 8` |

The decisive detail is the second row: **15 ppm renders as `1.5e-05`**, so the value is
stored as a fraction. `0` is therefore a literal zero-width tolerance on that same scale,
not a sentinel meaning "auto" — no fragment can match it. DIA-NN also uses the word
*fixed* in both cases.

Patch verified applied against `main` at `a7fb3a2` (the current HEAD, and the commit the
workflow registry pins):

```
generic Orbitrap  -> 0 mass-acc/window lines emitted   (the fix)
Orbitrap Astral   -> --mass-acc 10 --mass-acc-ms1 4    (unchanged)
timsTOF HT        -> --mass-acc 15 --mass-acc-ms1 15   (unchanged)
mass_acc_status() -> Lumos auto  = fixed:False  (5-step chain still correctly refused)
                     Astral      = fixed:True ms2:10.0 ms1:4.0
                     timsTOF     = fixed:True ms2:15.0 ms1:15.0
```

## The fix

Automatic calibration is what DIA-NN does when the flags are **absent**. `add()` already
supports `render=False`, so the rationale is still recorded for provenance while nothing
is written to the cfg.

`--window 0` is corrected the same way — DIA-NN rejects it with
`scan window radius should be a positive integer`, then picks a radius itself.

## Blast radius

- **Instruments with a known tolerance are unaffected.** Astral, timsTOF, SCIEX, and
  Orbitraps with a known resolution still emit explicit values. Verified by regenerating
  the Astral cfg: `--mass-acc 10 --mass-acc-ms1 4`.
- **The parallel-chain gate is unchanged.** `diann_parallel.mass_acc_status()` already
  treats an absent flag exactly like `0` (both fall into "not fixed"), so a cfg on auto
  still correctly refuses the 5-step chain. Verified against both cfgs:

  ```
  Lumos (auto)   -> fixed=False  ms2=None  ms1=None  reason=not set: --mass-acc, --mass-acc-ms1
  Astral (fixed) -> fixed=True   ms2=10.0  ms1=4.0   reason=fixed (MS1 4.0 ppm / MS2 10.0 ppm)
  ```

- `references/parameters.md` documented the same misconception and is corrected.

## Suggested follow-ups (not in this PR)

1. **`run_search.py` should fail loudly on an empty result.** It currently checks only
   that `report.parquet` exists. A search that identifies 0 precursors should be an
   error with the log excerpt attached, not a file that flows into the DE step.
2. **`watch_run.sh` already has an `empty_results` class** keyed on `0 proteins|No
   fragment ions|...`. Adding `Number of IDs at 0.01 FDR: 0` to that pattern would catch
   this on the *first file*, ~2 minutes in, instead of after a full multi-hour cohort.
3. **`--min-pr-mz 380 / --max-pr-mz 980`** are hardcoded universal defaults. They
   silently truncate acquisitions that run to 1000 m/z. Worth deriving from the data or
   at least surfacing in the rationale as an assumption to confirm.

---

Found while analysing a 28-run Fusion Lumos DIA cohort; the first full search burned
57 minutes to produce an empty report.
