### PR TITLE
fix(diann_parallel): step-4 array tasks race on a shared library file and stall indefinitely

### DIFF
--- a/skill/ucdavis-proteomics-core-pipeline/references/diann_parallel.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/diann_parallel.md
@@ -52,6 +52,18 @@ empirical-library round-trip.
 - **No MBR** (`--reanalyse` is dropped) — the 5-step replaces it.
 - **`--quant-ori-names`** on every step so `.quant` files are `<basename>.quant`.
 - Step 4 **skips** files that failed step 2 (missing `.quant`).
+- Step 4 hands each task **its own copy** of the empirical library
+  (`libpriv/t<TASKID>/lib.parquet`, removed by a `trap` on exit). This is not an
+  optimisation — DIA-NN re-saves the library it is given as `<lib>.skyline.speclib`,
+  written *next to* `--lib`. Pointing every array task at one shared `empirical.parquet`
+  makes them all write the same file; most win the race in seconds and the losers block
+  until the wall clock kills them. Observed on a 399-file run: 51 tasks `TIMEOUT` at 3 h,
+  then after raising the limit to 12 h, 8 tasks stalled for over 3.5 h at
+  `[0:04] Saving the library`. With private copies the same 8 finished in 2 minutes.
+  **Raising `--time-per-file` does not fix this** — it only moves the stall further out.
+  Step 2 is unaffected because it is handed `step1.predicted.speclib`, already in
+  DIA-NN's processed form, so there is nothing to re-save. Step 5 is a single job and
+  cannot contend with itself.
 - **The `--temp` folders MUST pre-exist.** DIA-NN aborts immediately with
   `ERROR: cannot find the temp folder .../quant_step2. Specify an existing folder` if
   the `--temp` dir is missing — it will **not** create it. `submit.sh` therefore does

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
@@ -277,7 +277,15 @@ def main():
         f'echo "Step 4/5 final pass, task ${{SLURM_ARRAY_TASK_ID}} of {n}"; date', pick,
         'QUANT="${FILE##*/}"; QUANT="${QUANT%.*}.quant"',
         f'if [ ! -f "{D}/quant_step2/$QUANT" ]; then echo "SKIP: no step-2 quant for $QUANT"; exit 0; fi',
-        f'{DN} --f "$FILE" --fasta {fasta} --lib {empirical} \\',
+        # DIA-NN re-saves the library it is handed as "<lib>.skyline.speclib", written
+        # NEXT TO --lib. With one shared path every concurrent array task writes the same
+        # file; most win the race in seconds, the losers block until the wall clock kills
+        # them. Give each task its own copy so there is nothing to contend on.
+        f'LIBPRIV={D}/libpriv/t${{SLURM_ARRAY_TASK_ID}}',
+        'mkdir -p "$LIBPRIV"',
+        f'cp -f {empirical} "$LIBPRIV/lib.parquet"',
+        'trap \'rm -rf "$LIBPRIV"\' EXIT',
+        f'{DN} --f "$FILE" --fasta {fasta} --lib "$LIBPRIV/lib.parquet" \\',
         f'  --temp {D}/quant_step4 --no-ifs-removal --quant-ori-names \\',
         f'  --threads {a.threads_per_file} {flags}']))
 


### PR DESCRIPTION
# fix(diann_parallel): step-4 array tasks race on a shared library file and stall indefinitely

## Summary

DIA-NN re-saves the library it is handed as **`<lib>.skyline.speclib`, written next to the
path given to `--lib`**. Step 4 points *every* array task at the single shared
`empirical.parquet`, so all concurrent tasks write the same file. Most win the race in
1 s–2.5 min; the losers block until the wall clock kills them.

## What it looks like

Measured on a 399-file, four-year timsTOF cohort (DIA-NN 2.6.0, 30-wide array):

| round | outcome |
|---|---|
| `--time-per-file 3` | **51 / 399 tasks `TIMEOUT`** |
| raised to 12 h | **8 tasks stalled > 3.5 h**, chain dead |
| **private library copy (this PR)** | **same 8 tasks completed in 2 minutes** |

Every stalled task sat at exactly this line with **no further output for hours**:

```
[0:04] Saving the library to .../empirical.parquet.skyline.speclib
```

while a task that won the race moved straight on:

```
[0:05] Saving the library to .../empirical.parquet.skyline.speclib
[0:05] File #1/1
```

**Raising `--time-per-file` is not a fix** — it only moves the stall further out. It also
looks convincingly like a data problem: because the timeouts land on the later array
indices (which run in the more contended waves), the failures correlate with whichever
runs happen to sort last. I initially misread this as "those runs are intrinsically
slower" and raised the limit; the stalls simply reappeared.

It is easy to miss because `afterok` does not save you. The chain stalls rather than
failing: `s5_report` waits on a dependency that can never be satisfied, and nothing
reports an error.

## The fix

Each task copies the empirical library to `libpriv/t<TASKID>/lib.parquet`, points `--lib`
there, and removes it with `trap ... EXIT`. Nothing is shared, so nothing races.

```bash
LIBPRIV=<out>/libpriv/t${SLURM_ARRAY_TASK_ID}
mkdir -p "$LIBPRIV"
cp -f <out>/empirical.parquet "$LIBPRIV/lib.parquet"
trap 'rm -rf "$LIBPRIV"' EXIT
diann-linux --f "$FILE" --fasta ... --lib "$LIBPRIV/lib.parquet" ...
```

Cost is one ~60 MB copy per task, which is negligible next to the multi-hour search it
protects.

## Blast radius

- **Step 2 is unaffected and unchanged.** It is handed `step1.predicted.speclib`, already
  in DIA-NN's processed form, so there is nothing to re-save — 400/400 clean in the same
  run that lost 51 tasks in step 4. This is also the clue that identifies the mechanism.
- **Step 5 is unchanged.** Single job; it cannot contend with itself.
- **`bash -n` clean** on the generated `step4_finalpass.sbatch` and `step5_report.sbatch`.
- **Results produced before the fix remain valid.** `empirical.parquet` is only ever read,
  never modified (mtime unchanged across the whole run), so every task loaded an identical
  library. Only the written side-effect file was contended — the search output is sound.

## Alternatives considered

1. **Point step 4 at the `.skyline.speclib`** that step 3 could emit directly. Cheaper (no
   per-task copy), but depends on DIA-NN's derived-filename behaviour, which is not
   documented and could change between versions.
2. **Node-local scratch** for the copy. Faster where available, but not portable across
   clusters.

The per-task copy was chosen because it is portable and depends on nothing beyond POSIX
file semantics.

---

Found while re-searching four years of short-course data; the race cost roughly a day
across two rounds of failure that looked like different problems.
