### PR TITLE
fix(diann_parallel): XIC extraction needs --out on step 4, or it silently produces nothing

### DIFF
--- a/skill/ucdavis-proteomics-core-pipeline/references/diann_parallel.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/diann_parallel.md
@@ -52,6 +52,17 @@ empirical-library round-trip.
 - **No MBR** (`--reanalyse` is dropped) — the 5-step replaces it.
 - **`--quant-ori-names`** on every step so `.quant` files are `<basename>.quant`.
 - Step 4 **skips** files that failed step 2 (missing `.quant`).
+- **XICs require `--out` on step 4, not just `--xic`.** DIA-NN names the XIC folder after
+  the `--out` report basename. Step 4 otherwise has no `--out`, so DIA-NN resolves the
+  folder against the filesystem **root** and aborts with
+  `cannot create directory: Permission denied [/report_xic]` — *after* writing the
+  `.quant`, and **still exiting 0**. Verified on DIA-NN 2.6.0: zero `.xic.parquet`
+  produced, SLURM records `COMPLETED`, and the `afterok` chain advances as if XICs
+  existed. Step 4 therefore gets `--out <out>/xic/t<TASKID>.parquet` whenever `--xic` is
+  in the cfg, and DIA-NN writes `<out>/xic/t<TASKID>_xic/<run>.xic.parquet`.
+  *Why step 4 and not step 5:* extraction needs the raw spectra. Step 5 runs
+  `--use-quant`, which never re-reads them — DIA-NN accepts `--xic` there, logs that it
+  will extract, and writes nothing.
 - Step 4 hands each task **its own copy** of the empirical library
   (`libpriv/t<TASKID>/lib.parquet`, removed by a `trap` on exit). This is not an
   optimisation — DIA-NN re-saves the library it is given as `<lib>.skyline.speclib`,

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
@@ -367,6 +367,15 @@ def main():
         must_exist(empirical, "the empirical spectral library")]))
 
     # Step 4 — final pass (array): empirical lib -> per-file .quant
+    # --xic alone is not enough. DIA-NN names the XIC folder after the --out report
+    # basename; with no --out it resolves that against the filesystem ROOT and dies with
+    # "cannot create directory: Permission denied [/report_xic]" -- AFTER writing the
+    # .quant, and STILL EXITING 0. Verified on DIA-NN 2.6.0 (single file, --xic, no
+    # --out): zero .xic.parquet produced, SLURM records COMPLETED, afterok advances.
+    # So step 4 needs its own --out whenever XICs are requested. DIA-NN then writes
+    # <out>/xic/t<TASKID>_xic/<run>.xic.parquet, one folder per array task.
+    xic_out = f' --out {D}/xic/t${{SLURM_ARRAY_TASK_ID}}.parquet' if xic else ''
+
     s4 = write("step4_finalpass.sbatch", "\n".join([
         header("s4_finalpass", a.threads_per_file, a.mem_per_file, a.time_per_file, _pa, _aa, qos=_qa, array=array), "",
         f'echo "Step 4/5 final pass, task ${{SLURM_ARRAY_TASK_ID}} of {n}"; date', pick,
@@ -376,12 +385,13 @@ def main():
         # NEXT TO --lib. With one shared path every concurrent array task writes the same
         # file; most win the race in seconds, the losers block until the wall clock kills
         # them. Give each task its own copy so there is nothing to contend on.
+        (f'mkdir -p {D}/xic' if xic else ''),
         f'LIBPRIV={D}/libpriv/t${{SLURM_ARRAY_TASK_ID}}',
         'mkdir -p "$LIBPRIV"',
         f'cp -f {empirical} "$LIBPRIV/lib.parquet"',
         'trap \'rm -rf "$LIBPRIV"\' EXIT',
         f'{DN} --f "$FILE" --fasta {fasta} --lib "$LIBPRIV/lib.parquet" \\',
-        f'  --temp {D}/quant_step4 --no-ifs-removal --quant-ori-names {xic} \\',
+        f'  --temp {D}/quant_step4 --no-ifs-removal --quant-ori-names {xic}{xic_out} \\',
         f'  --threads {a.threads_per_file} {wflag}{flags}',
         must_exist(f'{D}/quant_step4/$QUANT', "this file's final-pass .quant")]))
 


### PR DESCRIPTION
# fix(diann_parallel): XIC extraction needs `--out` on step 4, or it silently produces nothing

## Summary

`--xic` is correctly routed to step 4 — but **step 4 has no `--out`**, and DIA-NN names the
XIC output folder after the `--out` report basename. With no `--out` it resolves that
folder against the **filesystem root** and aborts.

## Reproduction

DIA-NN 2.6.0, one raw file, exactly the step-4 command line this script generates
(`--xic`, no `--out`):

```
XICs within 10 seconds from the apex will be extracted for each precursor and saved
in .parquet format, a folder will be created next to the main report for the XICs storage
[10:14] Quantification information saved to .../04Aug2026_..._23351.quant
ERROR: unhandled std::exception: filesystem error: cannot create directory:
       Permission denied [/report_xic]
```

Result:

| | |
|---|---|
| `.xic.parquet` files produced | **0** |
| DIA-NN exit code | **0** |
| SLURM state | **COMPLETED** |

## Why this is worse than a normal failure

The `.quant` is written **before** the exception, so step 4 leaves a complete, valid
`.quant`. DIA-NN then throws, **exits 0 anyway**, SLURM records `COMPLETED`, and the
`afterok` dependency releases step 5. The run finishes clean with a full cross-run report
and **no XICs anywhere** — the user only discovers it when they go looking for
chromatograms that were never written.

This is the same hazard that motivated `must_exist()` in this file: DIA-NN's exit status
cannot be trusted, so every step must assert the artefact it was meant to produce.

## Fix

When the cfg requests `--xic`, give step 4 its own output path and create the directory:

```
mkdir -p <out>/xic
diann-linux --f "$FILE" ... --temp <out>/quant_step4 --no-ifs-removal \
    --quant-ori-names --xic --out <out>/xic/t${SLURM_ARRAY_TASK_ID}.parquet ...
```

DIA-NN then writes `<out>/xic/t<TASKID>_xic/<run>.xic.parquet`, one folder per array task.
A small per-task report parquet is written alongside as a side effect.

**Unchanged when `--xic` is absent** — no `--out`, no `mkdir`, byte-identical command.
Verified by generating a chain both ways; `bash -n` clean on both.

## Also documented

`references/diann_parallel.md` now records **why extraction must happen on step 4 rather
than step 5**, which is not obvious from the DIA-NN docs (they say the folder is created
"next to the main report", which points at step 5):

> Extraction needs the raw spectra. Step 5 runs `--use-quant`, which never re-reads them.
> DIA-NN accepts `--xic` there, logs that it will extract, and writes nothing.

Verified directly: the same invocation with `--use-quant --xic` produced no XIC folder and
no files, while the raw-reading pass with `--xic --out` produced
`<report>_xic/<run>.xic.parquet`.

---

Found while extracting XICs for a 399-run, four-year short-course cohort.
