### PR TITLE
fix(skill): stop recommending "run locally" to users who have HIVE

### DIFF
--- a/skill/ucdavis-proteomics-core-pipeline/scripts/check_access.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/check_access.sh
@@ -33,9 +33,30 @@ GRP=false; [ -d /quobyte/proteomics-grp ] && ls /quobyte/proteomics-grp >/dev/nu
 HIVE_SSH="not_tested"; SSH_SBATCH=false; SSH_GRP=false; KEY_FOUND=true
 [ -n "$KEY" ] && [ ! -f "$KEY" ] && KEY_FOUND=false
 if ! $ON_HIVE && [ -n "$HU" ] && [ "$KEY_FOUND" = true ]; then
-  KEY_OPT=""; [ -n "$KEY" ] && KEY_OPT="-i $KEY"
-  out="$(timeout 25 ssh $KEY_OPT -o BatchMode=yes -o ConnectTimeout=12 -o IdentitiesOnly=yes "$HU@$HIVE_HOST" \
-        'command -v sbatch >/dev/null 2>&1 && echo HAS_SBATCH; ls -d /quobyte/proteomics-grp 2>/dev/null && echo HAS_GRP' 2>/dev/null)"
+  # `timeout` is GNU coreutils and a stock macOS does not have it -- there is no
+  # /usr/bin/timeout. Unguarded, the probe below died with "command not found", $out
+  # came back empty, and hive_ssh was reported "failed"; that then drops MODE to
+  # "local", so a user with a perfectly good HIVE key silently ran the whole analysis
+  # on their laptop. Degrading to no wrapper is safe: ssh's own ConnectTimeout already
+  # bounds a stalled connect, and this only additionally bounds a hang after the
+  # connection is up.
+  TMO=()
+  if   have timeout;  then TMO=(timeout 25)
+  elif have gtimeout; then TMO=(gtimeout 25)     # coreutils installed via Homebrew
+  fi
+  # Arrays, not a spliced string: a key path containing a space has to reach ssh as
+  # ONE argument. ${A[@]+"${A[@]}"} because the system bash on macOS is 3.2, where
+  # "${A[@]}" on an empty array is an unbound-variable error under `set -u`.
+  KEY_OPT=(); [ -n "$KEY" ] && KEY_OPT=(-i "$KEY")
+  # bash -l -c, exactly as hive_exec.sh does. ssh with a BARE command runs a NON-login
+  # shell, and HIVE does not put sbatch on PATH there -- so this probe reported
+  # HAS_SBATCH missing for an account that has it, can_use_slurm went false, and the
+  # recommended mode fell back to "local". A Core user with a working cluster account
+  # was told to run a multi-hour search on their laptop. Verified against HIVE: bare
+  # command -> no HAS_SBATCH, `bash -l -c` -> HAS_SBATCH.
+  out="$(${TMO[@]+"${TMO[@]}"} ssh ${KEY_OPT[@]+"${KEY_OPT[@]}"} \
+        -o BatchMode=yes -o ConnectTimeout=12 -o IdentitiesOnly=yes "$HU@$HIVE_HOST" \
+        "bash -l -c 'command -v sbatch >/dev/null 2>&1 && echo HAS_SBATCH; ls -d /quobyte/proteomics-grp 2>/dev/null && echo HAS_GRP'" 2>/dev/null)"
   if [ -n "$out" ]; then
     HIVE_SSH="ok"
     echo "$out" | grep -q HAS_SBATCH && SSH_SBATCH=true

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/hive_exec.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/hive_exec.sh
@@ -32,8 +32,11 @@ HOST="${HIVE_HOST:-hive.hpc.ucdavis.edu}"
 SSH=(ssh -i "$KEY" -o IdentitiesOnly=yes -o ConnectTimeout=20 "$HU@$HOST")
 
 case "${1:-}" in
-  --put) shift; rsync -e "ssh -i $KEY -o IdentitiesOnly=yes" -a "$1" "$HU@$HOST:$2" ;;
-  --get) shift; rsync -e "ssh -i $KEY -o IdentitiesOnly=yes" -a "$HU@$HOST:$1" "$2" ;;
+  # $KEY is single-quoted inside -e: rsync parses that string itself and DOES honour
+  # quotes (verified -- a path with a space arrives as one argv entry), whereas bare
+  # $KEY gets split and ssh is handed a truncated path. Matches the SSH=() array above.
+  --put) shift; rsync -e "ssh -i '$KEY' -o IdentitiesOnly=yes" -a "$1" "$HU@$HOST:$2" ;;
+  --get) shift; rsync -e "ssh -i '$KEY' -o IdentitiesOnly=yes" -a "$HU@$HOST:$1" "$2" ;;
   "")    echo "usage: hive_exec.sh '<command>' | --put <local> <remote> | --get <remote> <local>" >&2; exit 2 ;;
   # LOGIN shell (bash -l). ssh with a bare command runs a NON-login shell, where
   # HIVE does not put sacct/squeue/sbatch on PATH. Every SLURM query then returned

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_search.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_search.py
@@ -27,7 +27,8 @@ compute never lands on a login node) — the orchestrator submits it.
 Usage:
   python3 run_search.py --tools tools.json --bundle wf/workflow.manifest.json \
       --params wf/diann.cfg --fasta search.fasta --out search_out \
-      --files /data/*.raw --threads 16 [--engine diann|sage|fragpipe] [--sbatch job.sh]
+      --files /data/*.raw --threads 16 [--sbatch job.sh]
+      [--engine diann|alphadia|sage|fragpipe|radiant]
 """
 import sys, os, json, glob, shlex, argparse, subprocess, shutil
 

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/watch_run.sh
@@ -30,6 +30,14 @@ esac; done
 HERE="$(cd "$(dirname "$0")" && pwd)"
 run() { if $HIVE; then bash "$HERE/hive_exec.sh" "$*"; else bash -c "$*"; fi; }
 
+# mtime of a file, in the syntax of whichever kernel `run` will actually execute on.
+# GNU stat wants -c %Y, BSD/macOS stat wants -f %m. This CANNOT key off the local
+# uname alone: with --hive the command is sent to HIVE, which is Linux no matter what
+# the laptop is, so a darwin check here would send BSD syntax to a GNU stat. Getting
+# this wrong is silent -- stat writes to stderr, the substitution yields "", and stall
+# detection below just never fires.
+if $HIVE || [ "$(uname -s)" = "Linux" ]; then STAT_MTIME="stat -c %Y"; else STAT_MTIME="stat -f %m"; fi
+
 state="unknown"; done=false; failed=false; q_failed=false; fix_qf=""
 
 # --all <dir>: watch the WHOLE chain, not just its last link. Watching only the final
@@ -140,7 +148,7 @@ fi
 stalled=false
 if [ -z "$err_class" ] && [ -n "$LOG" ] && printf '%s' "$state" | grep -qiE "RUNNING|^R$"; then
   now="$(run "date +%s" 2>/dev/null)"
-  mt="$(run "stat -c %Y $(printf %q "$LOG") 2>/dev/null" 2>/dev/null | tr -dc 0-9)"
+  mt="$(run "$STAT_MTIME $(printf %q "$LOG") 2>/dev/null" 2>/dev/null | tr -dc 0-9)"
   if [ -n "$now" ] && [ -n "$mt" ]; then
     age=$(( now - mt ))
     if [ "$age" -ge $(( STALL_MIN * 60 )) ]; then


### PR DESCRIPTION
Came out of verifying an external review of the skill. Two of its findings were real, one was already fixed, one was false — and chasing the real ones turned up a worse bug the review missed.

## The main bug (not in the review)

`check_access.sh` decides where the entire analysis runs. It probed for `sbatch` as a **bare ssh command**, which is a non-login shell — and HIVE doesn't put `sbatch` on `PATH` there. So `HAS_SBATCH` never came back, `can_use_slurm` went false, and `recommended_mode` fell to `local`. **A user with a working HIVE account was told to run a multi-hour DIA-NN search on their laptop.**

`hive_exec.sh` had already hit this and fixed it, with a comment saying exactly why:

> `ssh` with a bare command runs a NON-login shell, where HIVE does not put sacct/squeue/sbatch on PATH

The probe never got the same treatment. Verified against HIVE — bare command returns no `HAS_SBATCH`; `bash -l -c` returns it.

## The review's `timeout` finding — real, and the same ending by another route

`timeout 25 ssh …` is GNU coreutils; stock macOS has no `/usr/bin/timeout`. The probe died with "command not found", `$out` came back empty, `hive_ssh` reported `failed`. Now uses `timeout`/`gtimeout` when present and runs unwrapped otherwise — `ssh -o ConnectTimeout=12` already bounds a stalled connect.

### Measured against the real cluster

| | hive_ssh | sbatch | slurm | mode |
|---|---|---|---|---|
| before, stock-macOS PATH | `failed` | false | false | **local** |
| before, Homebrew PATH | `ok` | false | false | **local** |
| after, either | `ok` | true | true | **hive_remote** |

Note row 2: with `timeout` available the old code *still* said `local`, because bug 1 alone is enough.

## Also fixed

- **`watch_run.sh` `stat -c %Y`** — real, but narrower than the review said, and its suggested fix would have made things worse. That `stat` goes through `run()`, which sends it **over ssh to HIVE (Linux)** when `--hive`, where GNU syntax is correct. It only broke on the local branch. Keying the fix off the local `uname`, as suggested, would send BSD syntax to HIVE and break the path that works today — so the format follows whichever kernel `run()` will actually use. Verified: before, local returned empty and HIVE was fine; now both return an mtime.
- **`hive_exec.sh` rsync `-e`** — single-quotes `$KEY`. I assumed rsync word-split its `-e` string and couldn't carry a spaced path; tested it, and rsync **does** honour quotes (a spaced path arrives as one argv entry). Verified with a real `--get`.
- **`check_access.sh` ssh key flag** — now an array, using `${A[@]+"${A[@]}"}` because system bash on macOS is 3.2, where `"${A[@]}"` on an empty array is an unbound-variable error under `set -u`.
- **`run_search.py` docstring** — listed `diann|sage|fragpipe`; argparse has accepted `alphadia` and `radiant` for a while.

## Deliberately not changed

- **`ensure_dotnet8.sh` `readlink -f`** — reported as a macOS bug; it isn't. `/usr/bin/readlink` supports `-f` (verified on 26.5.2; present since 12.3).
- **`__pycache__` → `.gitignore`** — already there and committed; zero tracked `.pyc`. The artifacts in the reviewer's copy came from running the scripts, not the clone.
- **"Claude-specific language"** — the strings are all really there, but this is a Claude Code plugin installed via `claude plugin install` from `marketplace.json`. The `Agent` reference is correct for its runtime, and the `claude plugin …` lines in `provenance.py` are *accurate provenance* — genericizing them would make the reproducibility record wrong.

All four scripts pass `bash -n` under bash 3.2; `check_access.sh` was exercised end to end against HIVE on a stock-macOS `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)