### PR TITLE
fix(skill): --xic alone writes mobilograms full of zeros; emit --mobilograms too

### DIFF
--- a/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
@@ -34,7 +34,7 @@ import os, sys, glob, argparse, shlex, subprocess
 # NOTE: --dda is intentionally NOT stripped — for DDA data put --dda in the --cfg and it
 # flows into every step (DIA-NN 2.6 searches DDA per file exactly as it does DIA).
 STRIP = ("--fasta-search", "--predictor", "--gen-spec-lib", "--matrices", "--reanalyse",
-         "--rt-profiling", "--no-norm", "--xic", "--out-lib", "--lib", "--out", "--f",
+         "--rt-profiling", "--no-norm", "--xic", "--mobilograms", "--out-lib", "--lib", "--out", "--f",
          # NOTE: --xic is stripped here on purpose and re-added to step 4 ONLY (see
          # xic_flag() below) -- step 2 IDs are not final, and step 5 runs --use-quant,
          # which never re-reads the raw spectra so --xic is silently a no-op there.
@@ -75,7 +75,7 @@ def read_cfg_flags(cfg):
 
 
 def xic_flag(cfg):
-    """Return the '--xic N' flag from the cfg, or '' if XICs were not requested.
+    """Return the '--xic N' flag (plus --mobilograms when requested), or '' if not.
 
     XIC extraction must happen on the FINAL per-file pass (step 4): step 2 works
     against the predicted library so its IDs are not final, and step 5 runs with
@@ -88,12 +88,19 @@ def xic_flag(cfg):
         toks = shlex.split(open(cfg).read(), comments=True)
     except ValueError:
         toks = open(cfg).read().split()
+    out = ""
     for i, t in enumerate(toks):
         if t == "--xic":
             if i + 1 < len(toks) and not toks[i + 1].startswith("-"):
-                return f"--xic {toks[i + 1]}"
-            return "--xic"
-    return ""
+                out = f"--xic {toks[i + 1]}"
+            else:
+                out = "--xic"
+    # --mobilograms must ride along with --xic or the mobilogram parquets are written
+    # full of zeros. Emitted only when XICs are requested; DIA-NN ignores it on
+    # instruments without ion mobility.
+    if out and "--mobilograms" in toks:
+        out += " --mobilograms"
+    return out
 
 def mass_acc_status(cfg):
     """Is this cfg PARALLEL-SAFE? Steps 3/5 reuse the .quant files from steps 2/4, so

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/estimate_params.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/estimate_params.py
@@ -159,6 +159,14 @@ def build_diann(acq, instr_class, ms1, ms2, label, src, var_mods, overrides,
     # DIA-NN's own default window and is cheap; the documented disk-space caveat
     # applies to --xic-theoretical-fr and large windows, which are NOT enabled here.
     add("--xic", 10, "extract XICs for identification validation (DIA-NN default 10s window)")
+    # --xic ALONE writes mobilogram files containing nothing but zeros. DIA-NN
+    # allocates ms1_mobilogram/ms2_mobilogram parquets but never populates them
+    # unless --mobilograms is ALSO passed -- silently, at plausible file size.
+    # On timsTOF the mobilograms are the ion-mobility axis: a real peptide should
+    # form a coherent peak in BOTH retention time and mobility, which a
+    # chromatogram alone cannot show. DIA-NN ignores the flag on instruments
+    # without ion mobility, so it is safe to emit unconditionally.
+    add("--mobilograms", True, "populate the mobilogram files -- --xic alone leaves them all zeros")
     add("--fasta-search", True, "library-free (predicted spectral library)")
     add("--gen-spec-lib", True, UNIV)
     add("--predictor", True, "deep-learning predictor for library-free DIA")


### PR DESCRIPTION
## The bug

`--xic` without `--mobilograms` makes DIA-NN **allocate** `ms1_mobilogram.parquet` / `ms2_mobilogram.parquet` and then never populate them. No error, no warning, plausible file size — invisible unless you open the files.

Measured on a real 6-file timsTOF dia-PASEF cohort:

| Run | Flags | Rows | Non-zero | Distinct values |
|---|---|---|---|---|
| DIA-NN 2.3.0 | `--xic 30` | 2,560,064 | **0 (0.0%)** | 1 |
| DIA-NN 2.6.0 | `--xic 30 --mobilograms` | 2,560,064 | **747,741 (29.2%)** | **11,005** |

The XICs from the same run were fine — 15.0 M rows, 100% non-zero, 281 distinct values. So `--xic` worked; only the mobilograms were hollow.

**The tell we walked past:** every mobilogram file was byte-identical in size (20,482,216) across MS1 *and* MS2 *and* every sample. Different data does not compress to identical sizes. We checked size and presence, not content — and reported the mobilograms in a collaborator report as a usable ion-mobility validation axis when they were empty. That report has been corrected.

## Why on by default

On timsTOF the mobilograms **are** the ion-mobility dimension. A genuine peptide should form a coherent peak in *both* retention time and mobility — a second validation axis a chromatogram alone cannot provide. DIA-NN ignores the flag on instruments without ion mobility, so emitting it unconditionally is safe.

## Changes

- **`estimate_params.py`** — emit `--mobilograms` alongside `--xic`
- **`diann_parallel.py`** — add it to `STRIP`, and have `xic_flag()` re-attach it to **step 4 only**, same step and same reasoning as `--xic`

## Verification (on top of current `main`)

```
estimate_params.py              -> --xic 10 + --mobilograms
cfg: --xic + --mobilograms      -> step4: both + per-file --out; step2/step5 clean
cfg: --xic only                 -> step4: --xic only  (not invented)
cfg: neither                    -> step4: clean
```

## Note on history

This was originally a third commit on #42, but did not survive the rewrite that landed that PR — `--xic` and the step-4 `--out` fix are both in `main` (via #42 and #44) while `--mobilograms` is not. This re-applies it cleanly against current `main`, so it completes the set: `--xic` silently stripped (#42), `--xic` without `--out` crashing the search (#44), and mobilograms written empty (here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)