### PR TITLE
docs: record the skill's open defects, audited against c29f269

### DIFF
--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -2,6 +2,8 @@
 
 Quick-reference tables for known issues and their solutions. **This is the single source of truth for gotchas** — CLAUDE.md keeps only a category index that points here. When you hit (or fix) a non-obvious bug, add a row to the relevant table below.
 
+For **open** defects in the `ucdavis-proteomics-core-pipeline` skill — things that still need fixing rather than things already solved — see [`SKILL_OPEN_DEFECTS.md`](SKILL_OPEN_DEFECTS.md). When one of those is fixed, delete its entry there and add a row here if the lesson is reusable.
+
 ## R Shiny / bslib
 
 | Problem | Solution |

--- a/docs/SKILL_OPEN_DEFECTS.md
+++ b/docs/SKILL_OPEN_DEFECTS.md
@@ -1,0 +1,163 @@
+# ucdavis-proteomics-core-pipeline — open defects
+
+**Audited:** 2026-08-17 against `c29f269` (`main`, immediately after PR #48 merged).
+**Scope:** `skill/ucdavis-proteomics-core-pipeline/`. Every claim below was checked against the
+tree, not recalled — file and line references are from that commit, and the audited files are
+byte-identical between `main` and the `skill-v2.0.0` branch, so both carry what follows.
+
+This file is for **open** defects. `docs/GOTCHAS.md` is the quick reference for problems that
+already have solutions; when something here is fixed, delete its entry and, if the lesson is
+reusable, add a row there instead. A shrinking file is the point.
+
+---
+
+## Status at a glance
+
+| # | Defect | Severity | Evidence |
+|---|---|---|---|
+| 1 | Precursor *m/z* range hardcoded to 380–980 regardless of the acquisition | **High — silently discards acquired data** | `scripts/estimate_params.py:179-180` |
+| 2 | The q-value column set is hand-written in five files and they disagree | Medium — this is how defect #48 drifted in | five files, see below |
+| 3 | One `--q-cutoff` applied to all six q-columns | Low | `scripts/run_de.R`, `scripts/build_maxlfq.R` |
+| 4 | `--min-pr-charge 2` narrows DIA-NN's own default with no stated reason | Low — decision, not a bug | `scripts/estimate_params.py:181` |
+
+---
+
+## 1. The precursor *m/z* range is hardcoded and ignores the acquisition
+
+**What.** `estimate_params.py` emits a fixed range for every dataset:
+
+```python
+# scripts/estimate_params.py:179-180
+add("--min-pr-mz", 380, UNIV)
+add("--max-pr-mz", 980, UNIV)
+```
+
+`UNIV` marks it as a universal default. Nothing consults the run.
+
+**Why it matters — measured, not hypothetical.** On a two-platform pilot (UC Davis, 2026-08-12)
+this emitted 380–980 for **both** instruments, matching neither acquisition:
+
+| Platform | Acquired range | Emitted | Discarded |
+|---|---|---|---|
+| timsTOF HT dia-PASEF | 299.5 – 1200.5 | 380 – 980 | 300–380 and 980–1200 |
+| Orbitrap Lumos DIA | 350 – 1200 | 380 – 980 | 350–380 and 980–1200 |
+
+The stated purpose of that run was measuring proteome depth, so silently searching a narrower
+window than was acquired is the worst possible failure mode for it: it does not error, and the
+loss is invisible in the output. It was caught only because a human read the emitted parameters
+against the instrument method.
+
+**The information is already available.** `detect_acquisition.py` parses the isolation windows
+it needs to classify DIA vs DDA — `DiaFrameMsMsWindowGroups` for Bruker `.d`, and MS2 isolation
+windows for mzML (`scripts/detect_acquisition.py:81, 133-143`) — but returns only the
+acquisition type, a confidence and a reason string. The window centres and widths are read and
+then thrown away.
+
+**Proposed fix.** Return the observed precursor *m/z* range from detection, and have
+`estimate_params.py` use it, widened to the nearest sensible bound. Keep 380–980 only as the
+fallback when no range can be read, and tag it in the output as a fallback rather than as
+`UNIV`, so a reader can tell a measured value from a guess. A one-line warning when the fallback
+is used would have surfaced this on the first run.
+
+---
+
+## 2. The q-value column set is duplicated across five files, and they disagree
+
+**What.** Which DIA-NN q-value columns constitute "FDR filtering" is written out by hand in
+five places, with three different answers:
+
+| File | Columns |
+|---|---|
+| `scripts/run_de.R:166-167` | `Q.Value` / `Lib.Q.Value` / `Lib.PG.Q.Value` + `Global.Q.Value` / `Global.PG.Q.Value` / `PG.Q.Value` |
+| `scripts/build_maxlfq.R:29, 48` | the same six |
+| `scripts/run_search.py:554` | `col("Global.PG.Q.Value", "Q.Value")` — two, as a fallback chain |
+| `scripts/compare_searches.py:72` | `col("Global.PG.Q.Value", "Global.Q.Value", "Lib.PG.Q.Value", "Q.Value")` — four |
+| `scripts/radiant_to_delimp.py:180` | maps `Global.PG.Q.Value` onto `Lib.PG.Q.Value` |
+
+The last three are fallback chains for reading a single q-value out of a report rather than full
+FDR filters, so they are not all the same kind of thing — but that is precisely the problem: a
+reader cannot tell which copy is authoritative, and there is no single definition to consult.
+
+**Why it matters.** This is the mechanism behind **PR #48**. `run_de.R`'s dpc path and
+`build_maxlfq.R` disagreed about the same report for months because the definition lived in two
+hand-maintained copies and only one was updated. Since then the count has grown to five. The
+same failure mode produced a second, unrelated defect in a downstream session, where a control
+script copied from its sibling kept the sibling's filter description.
+
+**Proposed fix.** One exported definition — column names, the cutoff each takes, and a one-line
+description of what each controls — imported by both R scripts, with the Python readers pointing
+at it in a comment even where they cannot import it. The point is that a future change happens
+once and is reviewable in one place.
+
+---
+
+## 3. A single `--q-cutoff` is applied to all six q-columns
+
+**What.** Both paths apply `--q-cutoff` (default 0.01) uniformly. DIA-NN's README recommends
+`PG.Q.Value` **"at 0.01 to 0.05, typically 0.05 is sufficient"**, and documents it as a
+*run-specific* column, unlike the global ones.
+
+**Why it is low severity.** Measured on a 373-run mouse DIA-NN 2.6 report, holding the other
+five at 0.01: `PG.Q.Value` at 0.01 vs 0.05 differs by **two protein groups** (6,564 vs 6,566),
+20,370 rows out of ~20 million. So the current uniform 0.01 is *conservative*, not wrong, and
+tightening beyond DIA-NN's advice costs almost nothing on that dataset.
+
+That is one measurement on one report, which is why this is recorded rather than dismissed. It
+is also worth knowing that `PG.Q.Value` is the **largest single contributor** to what the six
+columns exclude on that report (22,465 rows, 20,447 of them uniquely, against 15,752 for
+`Global.PG.Q.Value` and 7,873 for `Global.Q.Value`) — so a change to its cutoff has more room to
+matter than its "low severity" label suggests, on a dataset less forgiving than this one.
+
+**Proposed fix.** A per-column cutoff map, defaulting `PG.Q.Value` to 0.05 and the rest to 0.01.
+This is a **behaviour change**, not a bug fix: it would loosen current `maxlfq` behaviour for
+every existing user. It should land in its own change, touching both paths together, after
+defect #2 so there is one definition to edit. Deliberately not bundled into PR #48.
+
+---
+
+## 4. `--min-pr-charge 2` narrows DIA-NN's own default without saying why
+
+**What.** `scripts/estimate_params.py:181` emits `--min-pr-charge 2`, tagged `UNIV`. DIA-NN's
+own default is 1–4, verified by measurement on the 2.6.0 binary with a 60-protein FASTA:
+
+| config | precursors generated |
+|---|---|
+| no charge flags (DIA-NN default) | 10,899 |
+| `--min-pr-charge 1 --max-pr-charge 4` | 10,899 |
+| `--min-pr-charge 2 --max-pr-charge 4` | 8,805 |
+
+So the emitted default discards **2,094 precursors, ~19% of the predicted library**. (The DIA-NN
+README documents the flags but states no default, which is why this was measured rather than
+looked up.)
+
+**This is probably the right choice** for tryptic bottom-up work — singly-charged precursors are
+rarely informative — so it is listed as a decision to record, not a bug to fix. The problem is
+only that it is tagged `UNIV` alongside genuinely universal settings, so a user reading the
+emitted parameters cannot tell that a deliberate narrowing has been applied on their behalf.
+
+**Proposed fix.** Change the tag text to state the rationale and the cost, e.g.
+`"z=1 excluded: rarely informative for tryptic bottom-up; DIA-NN's own default is 1-4"`. No
+behaviour change.
+
+---
+
+## Fixed since the last audit — recorded so they are not re-litigated
+
+All verified present in `c29f269`:
+
+- **Experiment-wide FDR columns on the dpc path** — PR #48. `--method dpc` treated
+  `Global.Q.Value` / `Global.PG.Q.Value` / `PG.Q.Value` as fallbacks and so never applied them on
+  any modern DIA-NN report. Worth 227 protein groups (median one precursor, present in 9.4% of
+  runs) on a 373-run report.
+- **Executable bits.** Every directly-invoked `scripts/*.sh` is `100755` in the index.
+  `diann_release.sh` is `100644` and correctly so — it is `. sourced`, never executed.
+- **`--requeue`** is emitted for generated SLURM steps, so a preempted array task on a
+  preemptible partition no longer breaks an `afterok` chain hours in.
+- **The step-4 shared-library write race.** Each array task now gets a private library copy;
+  previously all tasks re-saved the same file and the losers blocked indefinitely.
+- **The glob hazard** in generated commands — `shlex.split` / `shlex.quote` now handle
+  `--cut K*,R*` and `--var-mod ...,*n`, which would otherwise be expanded by the shell against
+  the working directory.
+- **The deprecated one-stage DIA-NN invocation.** `run_search.py` detects the library-free flag
+  combination, strips it, and emits two dependent SLURM jobs — the two-stage workflow DIA-NN 2.3+
+  requires.


### PR DESCRIPTION
Documentation only — no behaviour change, nothing to test.

PR #48 fixed one defect and, in the process, surfaced several more plus the root cause that let it drift in unnoticed. This records them against the tree so each can be fixed and deleted independently, rather than living in a session transcript.

**Every claim was checked against `c29f269`, not recalled.** The audited files are byte-identical between `main` and `skill-v2.0.0`, so both branches carry all of it.

## Open

| # | Defect | Severity | Evidence |
|---|---|---|---|
| 1 | Precursor *m/z* range hardcoded 380–980 regardless of acquisition | **High** | `estimate_params.py:179-180` |
| 2 | q-value column set hand-written in five files, three different answers | Medium | five files |
| 3 | One `--q-cutoff` for all six q-columns | Low | `run_de.R`, `build_maxlfq.R` |
| 4 | `--min-pr-charge 2` narrows DIA-NN's 1–4 default, tagged as universal | Low | `estimate_params.py:181` |

**#1 is the one worth acting on.** On a two-platform pilot it emitted 380–980 for both instruments, matching neither acquisition — timsTOF acquired 299.5–1200.5, Lumos 350–1200 — silently discarding the 300–380 and 980–1200 regions on a run whose stated purpose was measuring proteome depth. It does not error and the loss is invisible in the output; it was caught only by reading the emitted parameters against the instrument method. `detect_acquisition.py` already parses the isolation windows (`DiaFrameMsMsWindowGroups`, mzML MS2 windows) to classify DIA vs DDA and then throws the range away, so the fix is plumbing rather than new capability.

**#2 is the root cause of #48.** `run_de.R`'s dpc path and `build_maxlfq.R` disagreed about the same report because the column set lived in two hand-maintained copies and only one was updated. It is now in five files with three different answers. The same failure mode produced a second, unrelated defect downstream, where a control script copied from its sibling kept the sibling's filter description.

**#3 and #4 are recorded rather than actioned**, with the measurements that make them low priority: the `PG.Q.Value` cutoff is worth 2 protein groups on the report measured (6,564 at 0.01 vs 6,566 at 0.05), and the charge narrowing costs ~19% of the predicted library but is probably the right call for tryptic bottom-up — only its tag needs to say so. #3's fix is a behaviour change that would loosen current `maxlfq` behaviour for every user, so it belongs in its own PR, after #2 gives it one definition to edit.

## Also recorded

The six defects **already fixed** in `c29f269` — the FDR columns, executable bits, `--requeue`, the step-4 library race, the glob hazard, and the deprecated one-stage DIA-NN invocation — so they are not re-litigated by the next person to look.

`GOTCHAS.md` (solved problems) is cross-linked to the new file (open ones), with the convention that fixing an entry means deleting it there and adding a row here if the lesson is reusable. A shrinking file is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2PsHztmjHwYPHn2xjLo4j
