### PR TITLE
fix(skill): one definition of the DIA-NN q-value columns

### DIFF
--- a/docs/SKILL_OPEN_DEFECTS.md
+++ b/docs/SKILL_OPEN_DEFECTS.md
@@ -15,9 +15,8 @@ reusable, add a row there instead. A shrinking file is the point.
 
 | # | Defect | Severity | Evidence |
 |---|---|---|---|
-| 1 | The q-value column set is hand-written in five files and they disagree | Medium — this is how defect #48 drifted in | five files, see below |
-| 2 | One `--q-cutoff` applied to all six q-columns | Low | `scripts/run_de.R`, `scripts/build_maxlfq.R` |
-| 3 | `--min-pr-charge 2` narrows DIA-NN's own default with no stated reason | Low — decision, not a bug | `scripts/estimate_params.py:181` |
+| 1 | One `--q-cutoff` applied to all six q-columns | Low | `scripts/run_de.R`, `scripts/build_maxlfq.R` |
+| 2 | `--min-pr-charge 2` narrows DIA-NN's own default with no stated reason | Low — decision, not a bug | `scripts/estimate_params.py:181` |
 
 ---
 
@@ -36,33 +35,29 @@ Kept here as a stub only until the next edit of this file; the lesson is in `doc
 
 ---
 
-## 2. The q-value column set is duplicated across five files, and they disagree
+## ~~2. The q-value column set is duplicated~~ — FIXED 2026-08-17
 
-**What.** Which DIA-NN q-value columns constitute "FDR filtering" is written out by hand in
-five places, with three different answers:
+Fixed in `fix/skill-q-column-definition`. The set now lives in
+`scripts/diann_q_columns.py`, mirrored by `scripts/diann_q_columns.R` (the two R scripts are
+standalone Rscripts that treat `jsonlite` as optional, so reading a shared JSON file would put
+a hard dependency in front of the identification filter). `tests/test_q_columns.py` parses the R
+source and asserts it equals the Python values, so drift is a CI failure rather than two subtly
+different FDR filters.
 
-| File | Columns |
-|---|---|
-| `scripts/run_de.R:166-167` | `Q.Value` / `Lib.Q.Value` / `Lib.PG.Q.Value` + `Global.Q.Value` / `Global.PG.Q.Value` / `PG.Q.Value` |
-| `scripts/build_maxlfq.R:29, 48` | the same six |
-| `scripts/run_search.py:554` | `col("Global.PG.Q.Value", "Q.Value")` — two, as a fallback chain |
-| `scripts/compare_searches.py:72` | `col("Global.PG.Q.Value", "Global.Q.Value", "Lib.PG.Q.Value", "Q.Value")` — four |
-| `scripts/radiant_to_delimp.py:180` | maps `Global.PG.Q.Value` onto `Lib.PG.Q.Value` |
+The audit undercounted: `run_search.py` alone held **six** hand-written copies, not one — four
+of them in output adapters (AlphaDIA, Sage, FragPipe DIA, FragPipe combined_protein,
+Radiant/Fulcrum) that emit the DE contract. A test asserts no call site restates the set inline,
+which is what found them.
 
-The last three are fallback chains for reading a single q-value out of a report rather than full
-FDR filters, so they are not all the same kind of thing — but that is precisely the problem: a
-reader cannot tell which copy is authoritative, and there is no single definition to consult.
+It also conflated **two distinct concepts**, and merging them would have been a bug:
 
-**Why it matters.** This is the mechanism behind **PR #48**. `run_de.R`'s dpc path and
-`build_maxlfq.R` disagreed about the same report for months because the definition lived in two
-hand-maintained copies and only one was updated. Since then the count has grown to five. The
-same failure mode produced a second, unrelated defect in a downstream session, where a control
-script copied from its sibling kept the sibling's filter description.
+* `FDR_REQUIRED` + `FDR_OPTIONAL` — the **filter set**: every column ANDed at the q-cutoff
+  (`run_de.R`, `build_maxlfq.R`).
+* `PROTEIN_Q_PREFERENCE` — a **preference chain**: the first available protein-level q-column
+  wins and the rest are ignored (`compare_searches.py`, `run_search.py`).
 
-**Proposed fix.** One exported definition — column names, the cutoff each takes, and a one-line
-description of what each controls — imported by both R scripts, with the Python readers pointing
-at it in a comment even where they cannot import it. The point is that a future change happens
-once and is reviewable in one place.
+Applying the preference order as a filter would over-filter; filtering on only the first
+available column would under-filter.
 
 ---
 

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/build_maxlfq.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/build_maxlfq.R
@@ -8,6 +8,20 @@
 
 `%||%` <- function(a, b) if (is.null(a) || length(a) == 0 || (length(a) == 1 && is.na(a))) b else a
 
+# ONE definition of the q-value column set (mirrored in diann_q_columns.py).
+# run_de.R sources this file, so the constants are usually already present;
+# source them here too so build_maxlfq.R also works when loaded on its own.
+if (!exists("DIANN_FDR_REQUIRED")) local({
+  d <- local({
+    f <- grep("^--file=", commandArgs(), value = TRUE)[1]
+    if (is.na(f)) getwd() else dirname(normalizePath(sub("^--file=", "", f), mustWork = FALSE))
+  })
+  for (p in c(file.path(d, "diann_q_columns.R"), "diann_q_columns.R"))
+    if (file.exists(p)) { source(p); return(invisible()) }
+  stop("diann_q_columns.R not found next to build_maxlfq.R -- it defines the ",
+       "identification-FDR columns and there is no safe default to guess.")
+})
+
 build_maxlfq <- function(report_path, format = "parquet", q_cutoff = 0.01,
                          eq_cutoff = 0, pgq_cutoff = 0, keep_runs = NULL) {
   stopifnot(requireNamespace("dplyr", quietly = TRUE),
@@ -22,11 +36,13 @@ build_maxlfq <- function(report_path, format = "parquet", q_cutoff = 0.01,
     cols <- names(ds)
   }
 
-  needed   <- c("Run", "Protein.Group", "PG.MaxLFQ", "Q.Value", "Lib.Q.Value", "Lib.PG.Q.Value")
-  # PG.Q.Value / Global.* are optional because older reports lack them, but they are
-  # what actually controls FDR at the protein and experiment level — see below.
+  needed   <- c("Run", "Protein.Group", "PG.MaxLFQ", DIANN_FDR_REQUIRED)
+  # DIANN_FDR_OPTIONAL is optional only because older reports lack those columns,
+  # not because applying them is discretionary. They MUST be listed here as well
+  # as filtered on: filtering an arrow dataset on a column select() dropped
+  # returns ZERO ROWS silently -- the defect that broke MaxLFQ in the DE-LIMP app.
   optional <- c("Empirical.Quality", "PG.MaxLFQ.Quality", "Genes", "Protein.Names",
-                "PG.Q.Value", "Global.Q.Value", "Global.PG.Q.Value")
+                DIANN_FDR_OPTIONAL)
   miss <- setdiff(needed, cols)
   if (length(miss)) stop("MaxLFQ: missing required columns: ", paste(miss, collapse = ", "))
 
@@ -43,9 +59,11 @@ build_maxlfq <- function(report_path, format = "parquet", q_cutoff = 0.01,
     flt <- dplyr::filter(flt, Q.Value <= !!q_cutoff,
                               Lib.Q.Value <= !!q_cutoff,
                               Lib.PG.Q.Value <= !!q_cutoff)
-    q_columns <- c("Q.Value", "Lib.Q.Value", "Lib.PG.Q.Value")
-    .fdr <- c("Q", "Lib.Q", "Lib.PG.Q")
-    for (.qc in c("PG.Q.Value", "Global.Q.Value", "Global.PG.Q.Value")) {
+    q_columns <- DIANN_FDR_REQUIRED
+    # Derived, not restated: this label was a third hand-written copy of the
+    # required set and would have gone stale the moment the set changed.
+    .fdr <- sub("\\.Value$", "", DIANN_FDR_REQUIRED)
+    for (.qc in DIANN_FDR_OPTIONAL) {
       if (.qc %in% cols) {
         flt <- dplyr::filter(flt, .data[[.qc]] <= !!q_cutoff)
         .fdr <- c(.fdr, .qc)

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/compare_searches.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/compare_searches.py
@@ -28,6 +28,11 @@ Usage:
 import argparse, json, math, os, statistics, sys
 from collections import defaultdict
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# ONE definition of the q-value columns, shared with run_search.py and (mirrored)
+# the R scripts -- see diann_q_columns.py. SKILL_OPEN_DEFECTS #2.
+from diann_q_columns import PROTEIN_Q_PREFERENCE
+
 
 def read_report(path, q_cut):
     """Read a DIA-NN-shaped report into {run: {protein: intensity}}.
@@ -69,7 +74,8 @@ def read_report(path, q_cut):
     c_int = col("PG.MaxLFQ", "PG.Quantity", "Intensity")
     if not all([c_run, c_pg, c_int]):
         sys.exit(f"{path} is not a DE-contract report (need Run, Protein.Group, PG.MaxLFQ).")
-    c_q = col("Global.PG.Q.Value", "Global.Q.Value", "Lib.PG.Q.Value", "Q.Value")
+    # Preference order, NOT a filter set: the first available column wins.
+    c_q = col(*PROTEIN_Q_PREFERENCE)
     q_basis = c_q or "(none — no q-value column, nothing filtered)"
 
     if is_tsv:

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/diann_q_columns.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/diann_q_columns.R
@@ -1,0 +1,53 @@
+# =============================================================================
+# diann_q_columns.R -- R mirror of scripts/diann_q_columns.py.
+#
+# The canonical definition and the full rationale live in the Python file; read
+# that one. This exists because run_de.R and build_maxlfq.R are standalone
+# Rscripts and treat jsonlite as OPTIONAL (run_de.R ships a manual JSON writer
+# fallback), so making the FDR filter depend on parsing a shared JSON file would
+# trade a duplication bug for a hard dependency on the identification filter --
+# a much worse failure.
+#
+# The two files are asserted identical by tests/test_q_columns.py, which parses
+# this file and compares it to the Python module. Drift is a CI failure, not a
+# silent divergence, which is the property that actually matters here.
+#
+# Two DISTINCT concepts -- do not merge them:
+#   DIANN_FDR_REQUIRED + DIANN_FDR_OPTIONAL
+#       the FILTER SET: every one is applied, ANDed, at the q-cutoff.
+#   DIANN_PROTEIN_Q_PREFERENCE
+#       a PREFERENCE ORDER for reading ONE protein-level q-column; first
+#       available wins and the rest are ignored.
+#
+# Column semantics (DIA-NN 2.6 README, "Main output reference"):
+#   Q.Value            run-specific precursor q-value
+#   Global.Q.Value     global (experiment-wide) precursor q-value
+#   Lib.Q.Value        library-entry q-value; 'global' when DIA-NN built the lib
+#   PG.Q.Value         RUN-SPECIFIC protein-group q-value, despite sitting beside
+#                      the Global.* pair
+#   Global.PG.Q.Value  global protein-group q-value
+#   Lib.PG.Q.Value     library-entry protein-group q-value
+# =============================================================================
+
+DIANN_FDR_REQUIRED <- c("Q.Value", "Lib.Q.Value", "Lib.PG.Q.Value")
+DIANN_FDR_OPTIONAL <- c("PG.Q.Value", "Global.Q.Value", "Global.PG.Q.Value")
+DIANN_PROTEIN_Q_PREFERENCE <- c("Global.PG.Q.Value", "Global.Q.Value",
+                                "Lib.PG.Q.Value", "PG.Q.Value", "Q.Value")
+
+#' Columns to FILTER on, restricted to those the report actually has.
+#'
+#' Never returns a column the report lacks: limpa::readDIANN() errors on an
+#' unknown name, and arrow silently returns ZERO ROWS when filtering a column
+#' that select() dropped -- the defect that made MaxLFQ produce nothing in
+#' DE-LIMP v4.0.2-4.0.3.
+diann_fdr_columns <- function(available = NULL) {
+  all_cols <- c(DIANN_FDR_REQUIRED, DIANN_FDR_OPTIONAL)
+  if (is.null(available)) return(all_cols)
+  all_cols[all_cols %in% available]
+}
+
+#' The single best protein-level q-column present, or NA_character_.
+diann_protein_q_column <- function(available) {
+  hit <- DIANN_PROTEIN_Q_PREFERENCE[DIANN_PROTEIN_Q_PREFERENCE %in% available]
+  if (length(hit)) hit[1] else NA_character_
+}

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/diann_q_columns.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/diann_q_columns.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+diann_q_columns.py -- ONE definition of DIA-NN's q-value columns for the skill.
+
+Fixes SKILL_OPEN_DEFECTS #2: the column set was hand-written in five files. That
+is how the dpc path in run_de.R drifted away from build_maxlfq.R and applied a
+different identification FDR to the same report for months (PR #48), and the same
+class of defect was later found in the DE-LIMP app itself.
+
+There are TWO distinct concepts here, and conflating them is a bug, not a
+simplification:
+
+  FDR_REQUIRED + FDR_OPTIONAL   the FILTER SET. Every one of these is applied,
+                               ANDed together, at the q-cutoff. Used by run_de.R
+                               (dpc) and build_maxlfq.R.
+
+  PROTEIN_Q_PREFERENCE         a PREFERENCE ORDER for picking ONE protein-level
+                               q-column to read for reporting or cross-tool
+                               comparison. The first available wins; the rest are
+                               ignored. Used by compare_searches.py and
+                               run_search.py.
+
+Applying the preference order as a filter would over-filter; filtering on only
+the first available column would under-filter. They are not interchangeable.
+
+COLUMN SEMANTICS -- from the DIA-NN 2.6 README, "Main output reference"
+(github.com/vdemichev/DiaNN@master; the 1.8 tag serves a much shorter, different
+README, so re-check against master):
+
+  Q.Value            L1242  run-specific precursor q-value
+  Global.Q.Value     L1244  global (experiment-wide) precursor q-value
+  Lib.Q.Value        L1245  library-entry q-value; 'global' when DIA-NN built the
+                            library, so NOT reliably run-level
+  PG.Q.Value         L1255  RUN-SPECIFIC protein-group q-value -- despite sitting
+                            beside the Global.* pair. Do not call it
+                            experiment-wide.
+  Global.PG.Q.Value  L1259  global protein-group q-value
+  Lib.PG.Q.Value     L1260  library-entry protein-group q-value
+
+Run-level q-values alone do not control FDR across an experiment: a union of
+run-level-passing IDs over N runs sits above the nominal cutoff and grows with N,
+and the inflated protein list also inflates the family size m that BH corrects
+over. Hence the Global.* pair is applied whenever present.
+
+Measured caveat on Lib.*: their values are not dependable across reports. On one
+2-run HeLa report both were identically 0.0 in 100% of rows (no filtering power
+at all); on a 399-run mouse report they filtered 0.56% / 0.19%. So neither "the
+Lib columns already give global control" nor "there is no global control" is true
+in general -- which is exactly why Global.* is named explicitly rather than
+assumed to be covered.
+
+The R mirror is diann_q_columns.R. The two are asserted identical by
+tests/test_q_columns.py, so drift is a CI failure rather than a silent
+divergence.
+"""
+
+# Required by both quant paths; a report lacking these is not a DIA-NN report.
+FDR_REQUIRED = ["Q.Value", "Lib.Q.Value", "Lib.PG.Q.Value"]
+
+# Applied additionally WHEN PRESENT. Optional only because older reports predate
+# them -- not because they are discretionary.
+FDR_OPTIONAL = ["PG.Q.Value", "Global.Q.Value", "Global.PG.Q.Value"]
+
+# Preference order for reading a SINGLE protein-level q-value. Most global and
+# most protein-specific first, degrading toward the run-level precursor q-value.
+PROTEIN_Q_PREFERENCE = [
+    "Global.PG.Q.Value",
+    "Global.Q.Value",
+    "Lib.PG.Q.Value",
+    "PG.Q.Value",
+    "Q.Value",
+]
+
+
+def fdr_columns(available=None):
+    """The columns to FILTER on, restricted to those the report has.
+
+    `available` is any container of column names; None means "assume all present".
+    Never returns a column the report lacks -- limpa::readDIANN() errors on an
+    unknown name, and arrow silently returns ZERO ROWS when filtering a column
+    that was not selected.
+    """
+    if available is None:
+        return list(FDR_REQUIRED) + list(FDR_OPTIONAL)
+    have = set(available)
+    return [c for c in (FDR_REQUIRED + FDR_OPTIONAL) if c in have]
+
+
+def protein_q_column(available):
+    """The single best protein-level q-column present, or None."""
+    have = set(available)
+    for c in PROTEIN_Q_PREFERENCE:
+        if c in have:
+            return c
+    return None
+
+
+if __name__ == "__main__":  # tiny self-report, handy when debugging a report
+    import json
+    import sys
+    cols = sys.argv[1:] or None
+    print(json.dumps({
+        "fdr_columns": fdr_columns(cols),
+        "protein_q_column": protein_q_column(cols) if cols else None,
+    }, indent=2))

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
@@ -83,6 +83,17 @@ if (is.null(input) || is.null(meta_path))
   for (p in c(file.path(.script_dir, nm), nm)) if (file.exists(p)) return(p)
   NULL
 }
+# ONE definition of the q-value column set, shared with build_maxlfq.R (and
+# mirrored in diann_q_columns.py for the Python scripts). Hand-copied duplicates
+# are what let this path drift away from build_maxlfq.R and apply a different
+# identification FDR to the same report -- see SKILL_OPEN_DEFECTS #2.
+local({
+  f <- .sibling("diann_q_columns.R")
+  if (is.null(f))
+    stop("diann_q_columns.R not found next to run_de.R -- it defines the ",
+         "identification-FDR columns and there is no safe default to guess.")
+  source(f)
+})
 if (!method %in% c("dpc", "maxlfq"))
   stop("--method must be 'dpc' or 'maxlfq'")
 dir.create(outdir, showWarnings = FALSE, recursive = TRUE)
@@ -163,8 +174,8 @@ if (method == "dpc") {
   # sufficient". This applies the single --q-cutoff (default 0.01) to it, a deliberate
   # tightening that matches build_maxlfq.R so the two --method values agree on FDR. On this
   # report the choice is nearly free: 0.01 vs 0.05 differs by 2 protein groups (6,564/6,566).
-  q_want <- c("Q.Value", "Lib.Q.Value", "Lib.PG.Q.Value")
-  q_alt  <- c("Global.Q.Value", "Global.PG.Q.Value", "PG.Q.Value")
+  q_want <- DIANN_FDR_REQUIRED
+  q_alt  <- DIANN_FDR_OPTIONAL
   q_use  <- intersect(q_want, have_cols)
   q_extra <- intersect(setdiff(q_alt, q_use), have_cols)
   if (length(q_extra)) {

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_search.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_search.py
@@ -32,8 +32,14 @@ Usage:
 """
 import sys, os, json, glob, shlex, argparse, subprocess, shutil
 
-DIANN_CONTRACT = ["Run", "Protein.Group", "PG.MaxLFQ",
-                  "Q.Value", "Lib.Q.Value", "Lib.PG.Q.Value"]
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# ONE definition of the q-value columns -- see diann_q_columns.py.
+from diann_q_columns import FDR_REQUIRED, PROTEIN_Q_PREFERENCE
+
+# The minimum an adapted report must carry for the DE step to run. The q-columns
+# are exactly the REQUIRED filter set: an adapter that emits fewer leaves limpa
+# silently applying no filter for the missing ones.
+DIANN_CONTRACT = ["Run", "Protein.Group", "PG.MaxLFQ"] + FDR_REQUIRED
 
 
 def sh(cmd, **kw):
@@ -286,9 +292,13 @@ def adapt_alphadia(out):
 
     n = len(prots)
     report = os.path.join(out, "report.parquet")
+    # AlphaDIA has already applied its own FDR, so the contract's q-columns are
+    # emitted as 0.0 placeholders -- the downstream filter is deliberately a
+    # no-op here rather than a second, different FDR. Names come from the shared
+    # definition so this adapter cannot fall behind the contract it satisfies.
     pq.write_table(pa.table({
         "Run": runs, "Protein.Group": prots, "PG.MaxLFQ": ints,
-        "Q.Value": [0.0]*n, "Lib.Q.Value": [0.0]*n, "Lib.PG.Q.Value": [0.0]*n,
+        **{c: [0.0] * n for c in FDR_REQUIRED},
     }), report)
     print(f"  [adapt] AlphaDIA -> {report}  ({n} protein×run rows)")
     return report
@@ -551,7 +561,12 @@ def adapt_radiant(out):
                 "Precursor.Quantity")
     if not all([c_run, c_pg, c_int]):
         sys.exit(f"Radiant output missing expected columns; saw {t.column_names}")
-    c_q = col("Global.PG.Q.Value", "Q.Value")
+    # Preference order, NOT a filter set: the first available column wins. Shared
+    # with compare_searches.py so the two cannot disagree about which q-value a
+    # given report is being judged on (SKILL_OPEN_DEFECTS #2). Widens the old
+    # two-column chain -- Global.Q.Value / Lib.PG.Q.Value / PG.Q.Value are now
+    # tried before falling all the way back to the run-level Q.Value.
+    c_q = col(*PROTEIN_Q_PREFERENCE)
 
     runs = [_radiant_run_name(r) for r in t.column(c_run).to_pylist()]
     pgs = [str(p) for p in t.column(c_pg).to_pylist()]
@@ -578,9 +593,12 @@ def adapt_radiant(out):
     qv = [v[1] for v in best.values()]
     n = len(pgs2)
     report = os.path.join(out, "report.parquet")
+    # Fulcrum reports ONE q-value per protein x run, so it is broadcast to every
+    # column of the contract rather than invented per column. Names derived from
+    # the shared definition -- see the AlphaDIA adapter above.
     pq.write_table(pa.table({
         "Run": runs2, "Protein.Group": pgs2, "PG.MaxLFQ": ints,
-        "Q.Value": qv, "Lib.Q.Value": qv, "Lib.PG.Q.Value": qv,
+        **{c: qv for c in FDR_REQUIRED},
     }), report)
     print(f"  [adapt] Radiant/Fulcrum -> {report}  ({n} protein×run rows)")
     return report
@@ -666,9 +684,8 @@ def adapt_sage(out):
         "Run": run,
         "Protein.Group": [str(p) for p in prot],
         "PG.MaxLFQ": [float(x) if x is not None else float("nan") for x in inten],
-        "Q.Value": [0.0] * n,            # Sage already FDR-filtered at write time
-        "Lib.Q.Value": [0.0] * n,
-        "Lib.PG.Q.Value": [0.0] * n,
+        # Sage already FDR-filtered at write time, so these are 0.0 placeholders.
+        **{c: [0.0] * n for c in FDR_REQUIRED},
     })
     report = os.path.join(out, "report.parquet")
     pq.write_table(out_tbl, report)
@@ -766,15 +783,17 @@ def adapt_fragpipe_dia(out):
     if not all([c_run, c_pg, c_q]):
         sys.exit(f"{tsv} lacks Run / Protein.Group / PG.MaxLFQ — cannot build the DE contract.")
     # Carry the q-value columns through when present; the DE step filters on them.
-    cq, clq, clpq = col("Q.Value"), col("Lib.Q.Value"), col("Lib.PG.Q.Value")
+    # Carry each contract q-column through when the source has it, else 0.0.
+    # Driven off FDR_REQUIRED so adding a column to the contract cannot leave
+    # this adapter silently emitting one fewer.
+    src_q = {c: col(c) for c in FDR_REQUIRED}
     n = len(rows)
     tbl = pa.table({
         "Run": [r[c_run] for r in rows],
         "Protein.Group": [r[c_pg] for r in rows],
         "PG.MaxLFQ": [num(r[c_q]) for r in rows],
-        "Q.Value": [num(r[cq]) if cq else 0.0 for r in rows],
-        "Lib.Q.Value": [num(r[clq]) if clq else 0.0 for r in rows],
-        "Lib.PG.Q.Value": [num(r[clpq]) if clpq else 0.0 for r in rows],
+        **{c: [num(r[src_q[c]]) if src_q[c] else 0.0 for r in rows]
+           for c in FDR_REQUIRED},
     })
     report = os.path.join(out, "report.parquet")
     pq.write_table(tbl, report)
@@ -831,7 +850,8 @@ def adapt_fragpipe_dda(out):
             runs.append(sample); prots.append(pg); ints.append(v if v > 0 else float("nan"))
     n = len(prots)
     tbl = pa.table({"Run": runs, "Protein.Group": prots, "PG.MaxLFQ": ints,
-                    "Q.Value": [0.0]*n, "Lib.Q.Value": [0.0]*n, "Lib.PG.Q.Value": [0.0]*n})
+                    # already FDR-filtered upstream -> 0.0 placeholders
+                    **{c: [0.0] * n for c in FDR_REQUIRED}})
     report = os.path.join(out, "report.parquet")
     pq.write_table(tbl, report)
     print(f"  [adapt] FragPipe -> {report}  ({n} protein×run rows)")

--- a/skill/ucdavis-proteomics-core-pipeline/tests/test_q_columns.py
+++ b/skill/ucdavis-proteomics-core-pipeline/tests/test_q_columns.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+The q-value column definition must exist once, and the R mirror must not drift.
+
+SKILL_OPEN_DEFECTS #2: the set was hand-written in five files with three
+different answers. That is how run_de.R's dpc path drifted away from
+build_maxlfq.R and applied a different identification FDR to the same report for
+months (PR #48), and the same class of defect turned up again in the DE-LIMP app.
+
+The definition now lives in scripts/diann_q_columns.py, with scripts/
+diann_q_columns.R as a mirror -- because run_de.R and build_maxlfq.R are
+standalone Rscripts that treat jsonlite as OPTIONAL, so reading a shared JSON
+file would put a hard dependency in front of the identification filter.
+
+A mirror is only safe if drift is impossible to miss. That is what this file is
+for: it parses the R source and asserts the values equal the Python ones, so a
+divergence is a CI failure rather than two subtly different FDR filters.
+"""
+import os
+import re
+import subprocess
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS = os.path.join(os.path.dirname(HERE), "scripts")
+sys.path.insert(0, SCRIPTS)
+
+from diann_q_columns import (  # noqa: E402
+    FDR_REQUIRED, FDR_OPTIONAL, PROTEIN_Q_PREFERENCE,
+    fdr_columns, protein_q_column,
+)
+
+R_FILE = os.path.join(SCRIPTS, "diann_q_columns.R")
+
+
+def r_vector(name):
+    """Pull a c("a", "b", ...) assignment out of the R source, spanning lines."""
+    with open(R_FILE) as fh:
+        src = fh.read()
+    m = re.search(rf'^{re.escape(name)}\s*<-\s*c\((.*?)\)\s*$',
+                  src, re.M | re.S)
+    if not m:
+        raise AssertionError(f"{name} not found in {R_FILE}")
+    return re.findall(r'"([^"]+)"', m.group(1))
+
+
+class TestRMirrorMatchesPython(unittest.TestCase):
+    def test_fdr_required_matches(self):
+        self.assertEqual(r_vector("DIANN_FDR_REQUIRED"), FDR_REQUIRED)
+
+    def test_fdr_optional_matches(self):
+        self.assertEqual(r_vector("DIANN_FDR_OPTIONAL"), FDR_OPTIONAL)
+
+    def test_protein_preference_matches_including_ORDER(self):
+        # Order is the whole point of a preference chain, so compare as a list.
+        self.assertEqual(r_vector("DIANN_PROTEIN_Q_PREFERENCE"),
+                         PROTEIN_Q_PREFERENCE)
+
+    def test_r_functions_agree_with_python(self):
+        """Run the R side for real -- parsing the literals is not enough if the
+        accessor functions differ."""
+        if not _have_rscript():
+            self.skipTest("Rscript not available")
+        available = ["Q.Value", "Lib.Q.Value", "Global.PG.Q.Value", "Junk"]
+        r_expr = (
+            f'source("{R_FILE}"); '
+            f'a <- c({",".join(repr(c) for c in available)}); '
+            'cat(paste(diann_fdr_columns(a), collapse=","), "|", '
+            'diann_protein_q_column(a))'
+        ).replace("'", '"')
+        out = subprocess.run(["Rscript", "-e", r_expr],
+                             capture_output=True, text=True)
+        self.assertEqual(out.returncode, 0, out.stderr)
+        r_fdr, r_pq = [x.strip() for x in out.stdout.split("|")]
+        self.assertEqual(r_fdr.split(","), fdr_columns(available))
+        self.assertEqual(r_pq, protein_q_column(available))
+
+
+def _have_rscript():
+    from shutil import which
+    return which("Rscript") is not None
+
+
+class TestFilterSetSemantics(unittest.TestCase):
+    def test_fdr_columns_never_names_an_absent_column(self):
+        # limpa::readDIANN() errors on an unknown name, and arrow silently
+        # returns ZERO ROWS when filtering a column select() dropped -- the
+        # defect that made MaxLFQ produce nothing in DE-LIMP v4.0.2-4.0.3.
+        got = fdr_columns(["Q.Value", "Lib.Q.Value", "Lib.PG.Q.Value"])
+        self.assertEqual(got, ["Q.Value", "Lib.Q.Value", "Lib.PG.Q.Value"])
+        self.assertNotIn("Global.PG.Q.Value", got)
+
+    def test_all_six_when_the_report_has_them(self):
+        every = FDR_REQUIRED + FDR_OPTIONAL
+        self.assertEqual(fdr_columns(every), every)
+        self.assertEqual(len(fdr_columns(None)), 6)
+
+    def test_required_and_optional_do_not_overlap(self):
+        self.assertEqual(set(FDR_REQUIRED) & set(FDR_OPTIONAL), set())
+
+    def test_pg_q_value_is_in_the_filter_set(self):
+        # Run-specific, but still applied: DE-LIMP's two --method values must
+        # agree on FDR for the same report.
+        self.assertIn("PG.Q.Value", FDR_REQUIRED + FDR_OPTIONAL)
+
+
+class TestPreferenceSemantics(unittest.TestCase):
+    def test_first_available_wins(self):
+        self.assertEqual(protein_q_column(
+            ["Q.Value", "Global.Q.Value", "Global.PG.Q.Value"]),
+            "Global.PG.Q.Value")
+        self.assertEqual(protein_q_column(["Q.Value", "Lib.PG.Q.Value"]),
+                         "Lib.PG.Q.Value")
+
+    def test_none_when_no_q_column_present(self):
+        self.assertIsNone(protein_q_column(["Run", "Protein.Group"]))
+
+    def test_preference_is_a_chain_not_a_filter_set(self):
+        # Guard against a future "simplification" that merges the two concepts.
+        # Applying the preference order as a filter would over-filter; filtering
+        # on only the first available would under-filter.
+        self.assertNotEqual(PROTEIN_Q_PREFERENCE, FDR_REQUIRED + FDR_OPTIONAL)
+        self.assertEqual(len(PROTEIN_Q_PREFERENCE), 5)
+
+    def test_every_preference_entry_is_a_real_diann_column(self):
+        self.assertTrue(set(PROTEIN_Q_PREFERENCE)
+                        <= set(FDR_REQUIRED + FDR_OPTIONAL))
+
+
+class TestNoHandWrittenCopiesRemain(unittest.TestCase):
+    """The point of the exercise: no call site may restate the set inline."""
+
+    WIRED = {
+        "run_de.R": "DIANN_FDR_REQUIRED",
+        "build_maxlfq.R": "DIANN_FDR_REQUIRED",
+        "compare_searches.py": "PROTEIN_Q_PREFERENCE",
+        "run_search.py": "PROTEIN_Q_PREFERENCE",
+    }
+
+    def test_call_sites_reference_the_shared_definition(self):
+        for fname, token in self.WIRED.items():
+            with open(os.path.join(SCRIPTS, fname)) as fh:
+                src = fh.read()
+            self.assertIn(token, src, f"{fname} does not use the shared definition")
+
+    def test_no_call_site_hardcodes_the_full_set(self):
+        # An inline list of three-or-more q-columns in a call site means someone
+        # started a fourth copy.
+        pat = re.compile(r'"(?:Global\.)?(?:Lib\.)?(?:PG\.)?Q\.Value"')
+        for fname in self.WIRED:
+            path = os.path.join(SCRIPTS, fname)
+            with open(path) as fh:
+                lines = list(fh)
+            for i, line in enumerate(lines, 1):
+                if line.lstrip().startswith("#"):
+                    continue
+                if len(pat.findall(line)) >= 3:
+                    self.fail(f"{fname}:{i} hardcodes a q-column set: {line.strip()}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes **SKILL_OPEN_DEFECTS #2**. #49 recorded it; this fixes it.

> **Stacks on #51** — base is `fix/skill-precursor-mz-range`, so this diff shows only the q-column work. Merge #51 first, or retarget to `main` after it lands.

## Why it matters

The set was hand-written across the skill. That is how `run_de.R`'s dpc path drifted away from `build_maxlfq.R` and applied a different identification FDR to the same report (#48) — and the same class of defect was then found in the DE-LIMP app, where it had made MaxLFQ return **zero rows for two releases** (#50).

## The audit undercounted

`run_search.py` alone held **six** hand-written copies, not one: the `DIANN_CONTRACT` constant, the protein-q preference chain, and four output adapters (AlphaDIA, Sage, FragPipe DIA, FragPipe `combined_protein`, Radiant/Fulcrum) that each restated the contract's q-columns when writing it.

A test asserting *no call site restates the set inline* is what found them — I declared the job done twice before it stopped failing.

## Two concepts, deliberately kept apart

| | |
|---|---|
| `FDR_REQUIRED` + `FDR_OPTIONAL` | the **filter set** — every column ANDed at the q-cutoff (`run_de.R`, `build_maxlfq.R`) |
| `PROTEIN_Q_PREFERENCE` | a **preference chain** — first available protein q-column wins, rest ignored (`compare_searches.py`, `run_search.py`) |

The audit listed these as one defect with "three different answers", but merging them would be a bug: applying the preference order as a filter **over-filters**; filtering on only the first available column **under-filters**.

## Why a mirror rather than one shared file

`run_de.R` and `build_maxlfq.R` are standalone Rscripts, and `run_de.R` treats `jsonlite` as **optional** (it ships a manual JSON-writer fallback). Reading a shared JSON definition would put a hard dependency in front of the identification filter — trading a duplication bug for a worse failure.

So `diann_q_columns.R` mirrors `diann_q_columns.py`, and `tests/test_q_columns.py` parses the R source, compares it to the Python values, **and executes the R accessors** to confirm they agree. Drift is a CI failure, which is the property that actually matters.

## Behaviour changes — both widenings, both deliberate

- `run_search.py`'s protein-q chain was `("Global.PG.Q.Value", "Q.Value")`; it now tries `Global.Q.Value` / `Lib.PG.Q.Value` / `PG.Q.Value` before falling back to the run-level `Q.Value`, matching `compare_searches.py` so the two cannot disagree about which q-value a report is judged on.
- `compare_searches.py`'s four-column chain gains `PG.Q.Value` in the same order.

The FragPipe DIA adapter was the only rewrite touching real logic rather than placeholders. Verified the new comprehension is identical to the old code for both present and absent source columns, **including key order**.

## Tests

25 pass. Retires the entry from `docs/SKILL_OPEN_DEFECTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7kCGXB2Gqy7idYrVBffyC