### PR TITLE
fix(skill): per-column q-cutoffs, and say why z=1 is excluded

### DIFF
--- a/docs/SKILL_OPEN_DEFECTS.md
+++ b/docs/SKILL_OPEN_DEFECTS.md
@@ -13,10 +13,8 @@ reusable, add a row there instead. A shrinking file is the point.
 
 ## Status at a glance
 
-| # | Defect | Severity | Evidence |
-|---|---|---|---|
-| 1 | One `--q-cutoff` applied to all six q-columns | Low | `scripts/run_de.R`, `scripts/build_maxlfq.R` |
-| 2 | `--min-pr-charge 2` narrows DIA-NN's own default with no stated reason | Low — decision, not a bug | `scripts/estimate_params.py:181` |
+**No open defects.** Every entry from the 2026-08-17 audit has been fixed; the fixed list is
+below and in `docs/GOTCHAS.md`. When a new one is found, add a row here.
 
 ---
 
@@ -61,53 +59,30 @@ available column would under-filter.
 
 ---
 
-## 3. A single `--q-cutoff` is applied to all six q-columns
+## ~~3. A single `--q-cutoff` for all six columns~~ — FIXED 2026-08-17
 
-**What.** Both paths apply `--q-cutoff` (default 0.01) uniformly. DIA-NN's README recommends
-`PG.Q.Value` **"at 0.01 to 0.05, typically 0.05 is sufficient"**, and documents it as a
-*run-specific* column, unlike the global ones.
+`COLUMN_CUTOFFS` in `scripts/diann_q_columns.py` (mirrored in the `.R`) gives `PG.Q.Value`
+DIA-NN's own recommended **0.05**; the other five keep `--q-cutoff`. `limpa::readDIANN()`
+recycles `q.cutoffs` against `q.columns` element-wise, verified in
+`EListFromLongFormatFile`, so the dpc path passes a vector; `build_maxlfq.R` applies the same map
+and labels any column whose cutoff differs as `PG.Q.Value@0.050` in `filters_applied`.
 
-**Why it is low severity.** Measured on a 373-run mouse DIA-NN 2.6 report, holding the other
-five at 0.01: `PG.Q.Value` at 0.01 vs 0.05 differs by **two protein groups** (6,564 vs 6,566),
-20,370 rows out of ~20 million. So the current uniform 0.01 is *conservative*, not wrong, and
-tightening beyond DIA-NN's advice costs almost nothing on that dataset.
+**This is a behaviour change that LOOSENS identification FDR.** Measured on a 2-run HeLa report:
+32,559 → 32,741 rows and 2,695 → 2,715 protein groups. `cutoff_for(..., uniform=True)` restores
+one cutoff for all six.
 
-That is one measurement on one report, which is why this is recorded rather than dismissed. It
-is also worth knowing that `PG.Q.Value` is the **largest single contributor** to what the six
-columns exclude on that report (22,465 rows, 20,447 of them uniquely, against 15,752 for
-`Global.PG.Q.Value` and 7,873 for `Global.Q.Value`) — so a change to its cutoff has more room to
-matter than its "low severity" label suggests, on a dataset less forgiving than this one.
-
-**Proposed fix.** A per-column cutoff map, defaulting `PG.Q.Value` to 0.05 and the rest to 0.01.
-This is a **behaviour change**, not a bug fix: it would loosen current `maxlfq` behaviour for
-every existing user. It should land in its own change, touching both paths together, after
-defect #2 so there is one definition to edit. Deliberately not bundled into PR #48.
+Deliberately *not* clever about a tightened `--q-cutoff`: the pipeline default (0.01) is already
+stricter than 0.05, so a "never loosen what the caller asked for" rule would stop the
+recommendation ever applying. `--q-cutoff` governs the other five.
 
 ---
 
-## 4. `--min-pr-charge 2` narrows DIA-NN's own default without saying why
+## ~~4. `--min-pr-charge 2` narrows DIA-NN's default without saying why~~ — FIXED 2026-08-17
 
-**What.** `scripts/estimate_params.py:181` emits `--min-pr-charge 2`, tagged `UNIV`. DIA-NN's
-own default is 1–4, verified by measurement on the 2.6.0 binary with a 60-protein FASTA:
-
-| config | precursors generated |
-|---|---|
-| no charge flags (DIA-NN default) | 10,899 |
-| `--min-pr-charge 1 --max-pr-charge 4` | 10,899 |
-| `--min-pr-charge 2 --max-pr-charge 4` | 8,805 |
-
-So the emitted default discards **2,094 precursors, ~19% of the predicted library**. (The DIA-NN
-README documents the flags but states no default, which is why this was measured rather than
-looked up.)
-
-**This is probably the right choice** for tryptic bottom-up work — singly-charged precursors are
-rarely informative — so it is listed as a decision to record, not a bug to fix. The problem is
-only that it is tagged `UNIV` alongside genuinely universal settings, so a user reading the
-emitted parameters cannot tell that a deliberate narrowing has been applied on their behalf.
-
-**Proposed fix.** Change the tag text to state the rationale and the cost, e.g.
-`"z=1 excluded: rarely informative for tryptic bottom-up; DIA-NN's own default is 1-4"`. No
-behaviour change.
+Tag only; no behaviour change. It now reads: *"z=1 excluded: rarely informative for tryptic
+bottom-up. DIA-NN's own default is 1-4; this drops ~19% of the predicted library (measured:
+10,899 → 8,805 precursors on a 60-protein FASTA)"*. The narrowing is still applied — it is the
+right call — but a reader of the emitted parameters can now see that it was a decision.
 
 ---
 

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/build_maxlfq.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/build_maxlfq.R
@@ -65,8 +65,12 @@ build_maxlfq <- function(report_path, format = "parquet", q_cutoff = 0.01,
     .fdr <- sub("\\.Value$", "", DIANN_FDR_REQUIRED)
     for (.qc in DIANN_FDR_OPTIONAL) {
       if (.qc %in% cols) {
-        flt <- dplyr::filter(flt, .data[[.qc]] <= !!q_cutoff)
-        .fdr <- c(.fdr, .qc)
+        .cut <- diann_cutoff_for(.qc, q_cutoff)
+        flt <- dplyr::filter(flt, .data[[.qc]] <= !!.cut)
+        # Label the column with its own cutoff when it differs, so the recorded
+        # provenance says what actually ran rather than implying one uniform value.
+        .fdr <- c(.fdr, if (isTRUE(all.equal(.cut, q_cutoff))) .qc
+                        else sprintf("%s@%.3f", .qc, .cut))
         q_columns <- c(q_columns, .qc)
       }
     }

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/diann_q_columns.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/diann_q_columns.R
@@ -34,6 +34,24 @@ DIANN_FDR_OPTIONAL <- c("PG.Q.Value", "Global.Q.Value", "Global.PG.Q.Value")
 DIANN_PROTEIN_Q_PREFERENCE <- c("Global.PG.Q.Value", "Global.Q.Value",
                                 "Lib.PG.Q.Value", "PG.Q.Value", "Q.Value")
 
+# Per-column cutoffs -- see diann_q_columns.py for the measurements. DIA-NN
+# recommends PG.Q.Value at 0.01-0.05 ("typically 0.05 is sufficient") and
+# documents it as RUN-SPECIFIC, unlike the Global.* pair.
+DIANN_COLUMN_CUTOFFS <- list("PG.Q.Value" = 0.05)
+
+#' The cutoff to apply to `column` given the run's --q-cutoff.
+#'
+#' A column listed in DIANN_COLUMN_CUTOFFS uses its own value; everything else
+#' uses q_cutoff. uniform = TRUE disables the map, restoring one cutoff for all
+#' six. It deliberately does not try to be clever about a tightened --q-cutoff:
+#' the pipeline default (0.01) is already stricter than PG.Q.Value's recommended
+#' 0.05, so any "never loosen" rule would stop the recommendation ever applying.
+diann_cutoff_for <- function(column, q_cutoff, uniform = FALSE) {
+  if (isTRUE(uniform)) return(q_cutoff)
+  own <- DIANN_COLUMN_CUTOFFS[[column]]
+  if (is.null(own)) q_cutoff else own
+}
+
 #' Columns to FILTER on, restricted to those the report actually has.
 #'
 #' Never returns a column the report lacks: limpa::readDIANN() errors on an

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/diann_q_columns.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/diann_q_columns.py
@@ -72,6 +72,37 @@ PROTEIN_Q_PREFERENCE = [
 ]
 
 
+# Per-column cutoffs. DIA-NN's README recommends PG.Q.Value "at 0.01 to 0.05,
+# typically 0.05 is sufficient" and documents it as RUN-SPECIFIC, unlike the
+# Global.* pair -- so applying one uniform cutoff to all six was tighter than its
+# own author advises. Measured on a 373-run mouse report, holding the other five
+# at 0.01, PG.Q.Value at 0.01 vs 0.05 differs by two protein groups (6,564 vs
+# 6,566). Small there, but PG.Q.Value is the LARGEST single contributor to what
+# the six columns exclude on that report (22,465 rows, 20,447 uniquely), so it has
+# more room to matter on a less forgiving dataset.
+#
+# Anything not named here uses the run's --q-cutoff.
+COLUMN_CUTOFFS = {"PG.Q.Value": 0.05}
+
+
+def cutoff_for(column, q_cutoff, uniform=False):
+    """The cutoff to apply to `column` given the run's --q-cutoff.
+
+    A column listed in COLUMN_CUTOFFS uses its own value; everything else uses
+    q_cutoff. `uniform=True` disables the per-column map entirely, restoring the
+    pre-2026-08 behaviour of one cutoff for all six.
+
+    Note this deliberately does NOT try to be clever about a caller who tightened
+    --q-cutoff. The pipeline default (0.01) is already stricter than PG.Q.Value's
+    recommended 0.05, so any "never loosen what the caller asked for" rule would
+    prevent the recommendation from ever applying. --q-cutoff governs the other
+    five columns; pass uniform=True to make it govern all six.
+    """
+    if uniform:
+        return q_cutoff
+    return COLUMN_CUTOFFS.get(column, q_cutoff)
+
+
 def fdr_columns(available=None):
     """The columns to FILTER on, restricted to those the report has.
 

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/estimate_params.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/estimate_params.py
@@ -202,7 +202,16 @@ def build_diann(acq, instr_class, ms1, ms2, label, src, var_mods, overrides,
         add("--max-pr-mz", 980,
             "FALLBACK -- acquired range unknown for this input; NOT measured. "
             "If the method acquired outside 380-980, widen it")
-    add("--min-pr-charge", 2, UNIV)
+    # NOT a universal default: DIA-NN's own default is 1-4. Measured on the 2.6.0
+    # binary with a 60-protein FASTA -- no charge flags and --min-pr-charge 1 both
+    # give 10,899 precursors, --min-pr-charge 2 gives 8,805. So this discards ~19%
+    # of the predicted library. That is the right call for tryptic bottom-up work
+    # (z=1 precursors are rarely informative), but a reader must be able to see
+    # that a deliberate narrowing was applied on their behalf.
+    add("--min-pr-charge", 2,
+        "z=1 excluded: rarely informative for tryptic bottom-up. DIA-NN's own "
+        "default is 1-4; this drops ~19% of the predicted library (measured: "
+        "10,899 -> 8,805 precursors on a 60-protein FASTA)")
     add("--max-pr-charge", 4, UNIV)
     add("--min-fr-mz", 200, UNIV)
     add("--max-fr-mz", 1800, UNIV)

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
@@ -239,10 +239,17 @@ if (method == "dpc") {
     message("[run_de] QuantUMS pre-filter for dpc: ", paste(quantums_applied, collapse = " | "))
   }
 
-  dat <- limpa::readDIANN(dpc_input, format = format, q.cutoffs = q_cutoff,
+  # Per-column cutoffs. limpa recycles q.cutoffs against q.columns
+  # (EListFromLongFormatFile: rep_len(q.cutoffs, length(q.columns)), then
+  # Report[[q.columns[j]]] > q.cutoffs[j]), so a vector is honoured element-wise.
+  # PG.Q.Value takes DIA-NN's own recommended 0.05 rather than the uniform
+  # --q-cutoff -- see diann_q_columns.R.
+  q_cuts <- vapply(q_use, diann_cutoff_for, numeric(1), q_cutoff = q_cutoff)
+  dat <- limpa::readDIANN(dpc_input, format = format, q.cutoffs = unname(q_cuts),
                           q.columns = q_use)
-  message(sprintf("[run_de] readDIANN: %d precursors x %d runs (FDR %.3f on %s)",
-                  nrow(dat$E), ncol(dat$E), q_cutoff, paste(q_use, collapse = ", ")))
+  message(sprintf("[run_de] readDIANN: %d precursors x %d runs (FDR on %s)",
+                  nrow(dat$E), ncol(dat$E),
+                  paste(sprintf("%s<=%.3f", q_use, q_cuts), collapse = ", ")))
 
   # ---- FIX: reconcile against the metadata BEFORE quantifying -----------------
   # dpcQuant() on a 274-run report takes ~90 min. The run/metadata check used to sit

--- a/skill/ucdavis-proteomics-core-pipeline/tests/test_q_columns.py
+++ b/skill/ucdavis-proteomics-core-pipeline/tests/test_q_columns.py
@@ -27,8 +27,8 @@ SCRIPTS = os.path.join(os.path.dirname(HERE), "scripts")
 sys.path.insert(0, SCRIPTS)
 
 from diann_q_columns import (  # noqa: E402
-    FDR_REQUIRED, FDR_OPTIONAL, PROTEIN_Q_PREFERENCE,
-    fdr_columns, protein_q_column,
+    FDR_REQUIRED, FDR_OPTIONAL, PROTEIN_Q_PREFERENCE, COLUMN_CUTOFFS,
+    fdr_columns, protein_q_column, cutoff_for,
 )
 
 R_FILE = os.path.join(SCRIPTS, "diann_q_columns.R")
@@ -126,6 +126,50 @@ class TestPreferenceSemantics(unittest.TestCase):
     def test_every_preference_entry_is_a_real_diann_column(self):
         self.assertTrue(set(PROTEIN_Q_PREFERENCE)
                         <= set(FDR_REQUIRED + FDR_OPTIONAL))
+
+
+class TestPerColumnCutoffs(unittest.TestCase):
+    """SKILL_OPEN_DEFECTS #3: one --q-cutoff was applied to all six columns."""
+
+    def test_pg_q_value_uses_diann_recommended_cutoff(self):
+        # DIA-NN: "PG.Q.Value at 0.01 to 0.05, typically 0.05 is sufficient".
+        self.assertEqual(cutoff_for("PG.Q.Value", 0.01), 0.05)
+
+    def test_other_columns_use_the_run_cutoff(self):
+        for c in ("Q.Value", "Global.Q.Value", "Global.PG.Q.Value",
+                  "Lib.Q.Value", "Lib.PG.Q.Value"):
+            self.assertEqual(cutoff_for(c, 0.01), 0.01)
+            self.assertEqual(cutoff_for(c, 0.005), 0.005)
+
+    def test_pg_cutoff_is_independent_of_the_run_cutoff(self):
+        # --q-cutoff governs the other five; PG.Q.Value keeps DIA-NN's own value.
+        for q in (0.001, 0.01, 0.05, 0.10):
+            self.assertEqual(cutoff_for("PG.Q.Value", q), 0.05)
+
+    def test_uniform_restores_one_cutoff_for_all_six(self):
+        # The escape hatch for anyone who wants the pre-2026-08 behaviour.
+        for c in FDR_REQUIRED + FDR_OPTIONAL:
+            self.assertEqual(cutoff_for(c, 0.01, uniform=True), 0.01)
+
+    def test_unknown_column_falls_through_to_the_run_cutoff(self):
+        self.assertEqual(cutoff_for("Not.A.Column", 0.02), 0.02)
+
+    def test_only_pg_q_value_has_an_override(self):
+        # Adding more overrides is a behaviour change for every user; make it
+        # a deliberate test edit rather than a silent one.
+        self.assertEqual(set(COLUMN_CUTOFFS), {"PG.Q.Value"})
+
+    def test_r_mirror_agrees_on_cutoffs(self):
+        if not _have_rscript():
+            self.skipTest("Rscript not available")
+        cases = [("PG.Q.Value", 0.01), ("PG.Q.Value", 0.001),
+                 ("PG.Q.Value", 0.10), ("Q.Value", 0.01), ("Global.Q.Value", 0.02)]
+        expr = f'source("{R_FILE}"); cat(' + ", ".join(
+            f'diann_cutoff_for("{c}", {q})' for c, q in cases) + ')'
+        out = subprocess.run(["Rscript", "-e", expr], capture_output=True, text=True)
+        self.assertEqual(out.returncode, 0, out.stderr)
+        got = [float(x) for x in out.stdout.split()]
+        self.assertEqual(got, [cutoff_for(c, q) for c, q in cases])
 
 
 class TestNoHandWrittenCopiesRemain(unittest.TestCase):


### PR DESCRIPTION
Closes the last two entries in `docs/SKILL_OPEN_DEFECTS.md` — the file now has **no open defects**.

## #3 — one `--q-cutoff` for all six columns

DIA-NN recommends `PG.Q.Value` *"at 0.01 to 0.05, typically 0.05 is sufficient"* and documents it as **run-specific**, unlike the `Global.*` pair. A uniform 0.01 was tighter than its own author advises on the one column that isn't experiment-wide.

`COLUMN_CUTOFFS` now gives `PG.Q.Value` 0.05 and leaves the other five on `--q-cutoff`. `limpa::readDIANN()` recycles `q.cutoffs` against `q.columns` element-wise — verified in `EListFromLongFormatFile`, not assumed — so the dpc path passes a vector. `build_maxlfq.R` applies the same map and labels differing columns as `PG.Q.Value@0.050` in `filters_applied`.

⚠️ **This loosens identification FDR.** Measured on a 2-run HeLa report: 32,559 → 32,741 rows, 2,695 → 2,715 protein groups. The prior audit measured 2 protein groups on a 373-run report, so magnitude is dataset-dependent. `cutoff_for(..., uniform=True)` restores the old behaviour.

It deliberately isn't clever about a tightened `--q-cutoff`: my first attempt applied *"never loosen what the caller asked for"*, which is self-contradictory here — the default (0.01) is already stricter than 0.05, so that rule would have stopped the recommendation ever applying. The new test caught it immediately.

## #4 — `--min-pr-charge 2` tagged as universal

DIA-NN's own default is 1–4, and the narrowing drops ~19% of the predicted library (measured: 10,899 → 8,805 precursors). It's the right call for tryptic bottom-up, so **behaviour is unchanged** — but the tag now states the rationale and the cost, so a reader can see a decision was made on their behalf.

32 tests pass, including R/Python agreement on the cutoff map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7kCGXB2Gqy7idYrVBffyC