### PR TITLE
fix(skill): make the emitted DE script and provenance match the run (v2.0.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UC Davis Proteomics Core skills for Claude \u2014 agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "description": "UC Davis Proteomics Core pipeline \u2014 end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [Skill 2.0.1] — 2026-08-20
+
+Found by auditing the skill's own output end to end, at the user's request:
+"can we verify everything is traceable and reproducible using the output the
+skill generates". Three provenance defects, all of which left every scientific
+number correct — which is exactly why they survived.
+
+### Fixed
+- **`reproducibility_log.R` did not reproduce the analysis.** Once `PG.Q.Value`
+  took DIA-NN's recommended 0.05 while the other five columns kept `--q-cutoff`,
+  the emitter still wrote a **scalar** `q.cutoffs = 0.01` next to all six
+  columns. `limpa` recycles `q.cutoffs` across `q.columns`, so the emitted script
+  ran clean and returned **4,624 proteins / 1,846 significant** against the run's
+  actual **4,648 / 1,859**. Nothing errored and the CSVs beside it were right;
+  only the script disagreed — DE-LIMP architectural rule #1. It now emits the
+  cutoff vector that actually ran, and re-running it reproduces the run exactly:
+  same protein set, and zero differing `logFC` / `P.Value` / `adj.P.Val`.
+- **`de_provenance.json` asserted one cutoff while six ran.** It recorded
+  `q_cutoff: 0.01` and never named the columns. It now records `q_columns` and
+  the per-column `q_cutoffs` as applied (rule #2).
+- **The DE step could not be tied to the search output it consumed.** Provenance
+  recorded the input *path* — which does not survive the file being moved,
+  regenerated, or shipped in a bundle without its input. It now records
+  `input_sha256` and `input_bytes`; verified against an independently computed
+  checksum.
+- **`reproduce.sh` replayed a subset of the original invocation**, dropping
+  `--organism-taxid` and `--env`. Engine params still came back byte-identical
+  (they depend on neither), but the regenerated record lost the **species** and
+  the platform block. Replay now reproduces all 18 manifest fields.
+- **`run_manifest.json` recorded `"timestamp": null`** whenever the orchestrator
+  omitted `--timestamp`. A bundle whose job is auditability must say when it ran;
+  it now defaults to UTC now.
+- **`reproducibility_log.R` was silently skipped for `--method maxlfq`.**
+  `q_use` / `q_cuts` exist only on the dpc branch and the call sat inside a
+  `tryCatch`, so the failure was swallowed. Guarded explicitly.
+
+### Added
+- 10 tests covering emitter cutoff rendering, replay fidelity, timestamp,
+  and the recorded skill version (42 total, up from 32).
+
 ## [4.0.5] — 2026-08-17
 
 ### Fixed

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UC Davis Proteomics Core pipeline \u2014 end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE \u2014 with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/provenance.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/provenance.py
@@ -98,6 +98,13 @@ def expand(patterns):
     return out
 
 
+def _utc_now():
+    """ISO-8601 UTC. Separate helper so the default is obvious and testable."""
+    import datetime
+    return datetime.datetime.now(datetime.timezone.utc).replace(
+        microsecond=0).isoformat().replace("+00:00", "Z")
+
+
 def load_json(path):
     try:
         return json.load(open(path))
@@ -256,7 +263,11 @@ def main():
     # ---- the master run manifest --------------------------------------------
     reg = (wfman or {}).get("registry")
     manifest = {
-        "timestamp": a.timestamp or None,
+        # Default to now (UTC) rather than null. A reproducibility bundle whose
+        # whole job is to make a run auditable must be able to say WHEN it ran;
+        # recording null because the orchestrator forgot the flag is a gap, not
+        # an honest absence.
+        "timestamp": a.timestamp or _utc_now(),
         "skill": skill_info,
         "registry": reg,
         "workflow": {k: (wfman or {}).get(k) for k in
@@ -287,6 +298,13 @@ def main():
     _instr = ((wfman or {}).get("instruments") or [None])[0]
     instr_repro = shlex.quote(_instr) if _instr else "'<instrument>'"
     engine_repro = ((wfman or {}).get("engine") or {}).get("name") or "<engine>"
+    # Replay the ORIGINAL invocation, not a subset of it. Omitting these dropped
+    # the organism and the platform block from the regenerated manifest: the
+    # engine params still came back byte-identical (they do not depend on either),
+    # but the run RECORD lost the species -- the single most important contextual
+    # fact about a proteomics run -- and could not say what machine it ran on.
+    _tax = (wfman or {}).get("organism_taxid") or a.organism_taxid
+    tax_repro = f" \\\n  --organism-taxid {int(_tax)}" if _tax else ""
     raw_arg = " ".join(f"'{f}'" for f in raw_files) or "/path/to/raw/*"
 
     # Rebuild the FASTA from what actually ran (fetch_fasta.py's output), falling back
@@ -351,8 +369,10 @@ fi
 # 2. Re-derive the search defaults from the data type. These ship with the skill, so
 #    the same skill version reproduces them exactly -- nothing is fetched.
 #    Original defaults_version: {defaults_version}
+bash "$SKILL/scripts/detect_env.sh" > ./env.json
 python3 "$SKILL/scripts/resolve_defaults.py" --acquisition {acq_repro} \\
-  --instrument {instr_repro} --engine {engine_repro} --dest ./wf
+  --instrument {instr_repro} --engine {engine_repro}{tax_repro} \\
+  --env ./env.json --dest ./wf
 
 # 3. Resolve the same engine + version.
 PIN_ENGINE={a.engine or '<engine>'} PIN_VERSION={(wfman or {}).get('engine',{}).get('version','')} \\

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/repro_script.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/repro_script.R
@@ -41,7 +41,7 @@ write_repro_script <- function(path,
                                input,            # report path as it was read
                                format,           # "parquet" | "tsv"
                                q_cutoff,
-                               q_columns,        # q-value columns actually filtered on
+                               q_columns, q_cutoffs = NULL,        # q-value columns actually filtered on
                                eq_cutoff, pgq_cutoff,
                                cov_min_frac,     # maxlfq coverage filter
                                meta,             # design, already aligned to the matrix
@@ -147,10 +147,24 @@ write_repro_script <- function(path,
         "")
       src <- "report_filtered"
     }
+    # q.cutoffs must be the VECTOR that actually ran, not the scalar --q-cutoff.
+    # PG.Q.Value takes DIA-NN's recommended 0.05 while the rest take --q-cutoff,
+    # and limpa recycles q.cutoffs against q.columns element-wise. Emitting the
+    # scalar produced a script that ran clean and returned DIFFERENT numbers than
+    # the analysis it claims to reproduce (measured: 4,648 -> 4,624 proteins,
+    # 1,859 -> 1,846 significant) -- DE-LIMP architectural rule #1.
+    .cuts <- if (!is.null(q_cutoffs)) q_cutoffs else
+             vapply(q_columns, diann_cutoff_for, numeric(1), q_cutoff = q_cutoff)
+    .cuts_src <- if (length(unique(.cuts)) == 1L) .rnum(.cuts[1]) else
+                 sprintf("c(%s)", paste(sprintf("%s = %s", .rq(q_columns),
+                                                vapply(.cuts, .rnum, character(1))),
+                                        collapse = ", "))
     L <- c(L,
-      "# --- 1. Read the DIA-NN report, applying the identification FDR cutoff -------",
+      "# --- 1. Read the DIA-NN report, applying the identification FDR cutoffs ------",
+      "#     PG.Q.Value uses DIA-NN's recommended 0.05; the rest use --q-cutoff.",
+      "#     limpa recycles q.cutoffs against q.columns element-wise.",
       sprintf("dat <- limpa::readDIANN(%s, format = %s, q.cutoffs = %s,",
-              src, .rq(format), .rnum(q_cutoff)),
+              src, .rq(format), .cuts_src),
       sprintf("                        q.columns = %s)", .rvec(q_columns)),
       "",
       "# --- 2. Keep only the runs that appear in the design -------------------------",

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
@@ -433,7 +433,12 @@ if (is.null(.rs)) {
     repro_lines <- write_repro_script(
       path = file.path(outdir, "reproducibility_log.R"),
       method = method, input = input, format = format,
-      q_cutoff = q_cutoff, q_columns = q_use,
+      # q_use / q_cuts exist only on the dpc branch; guard rather than rely on
+      # the surrounding tryCatch, which would swallow the error and silently
+      # skip writing reproducibility_log.R altogether.
+      q_cutoff = q_cutoff,
+      q_columns = if (exists("q_use")) q_use else NULL,
+      q_cutoffs = if (exists("q_cuts")) unname(q_cuts) else NULL,
       eq_cutoff = eq_cutoff, pgq_cutoff = pgq_cutoff,
       cov_min_frac = cov_min_frac,
       meta = meta, covariates = covariates, formula_parts = formula_parts,
@@ -501,6 +506,23 @@ prov <- list(
   rollup_method = descriptor$rollup_method, de_engine = descriptor$de_engine,
   missing_policy = descriptor$missing_policy, citation = descriptor$citation,
   method = method, q_cutoff = q_cutoff,
+  # WHICH columns were filtered and at WHAT cutoff. q_cutoff alone stopped being
+  # the whole story once PG.Q.Value took DIA-NN's recommended 0.05: a record
+  # saying "q_cutoff: 0.01" while six different cutoffs ran is the kind of
+  # plausible-but-wrong provenance rule #2 exists to prevent.
+  q_columns = if (exists("q_use")) as.list(q_use) else NULL,
+  q_cutoffs = if (exists("q_cuts")) as.list(unname(q_cuts)) else NULL,
+  # Ties this DE run to the EXACT search output it consumed. A path alone is not
+  # traceability -- it does not survive the file being moved, regenerated, or
+  # shipped in a bundle without its input.
+  input_sha256 = tryCatch(
+    if (file.exists(input) && requireNamespace("digest", quietly = TRUE))
+      digest::digest(input, algo = "sha256", file = TRUE)
+    else if (file.exists(input) && nzchar(Sys.which("shasum")))
+      sub(" .*", "", system2("shasum", c("-a", "256", shQuote(input)), stdout = TRUE)[1])
+    else NA_character_,
+    error = function(e) NA_character_),
+  input_bytes = tryCatch(as.numeric(file.info(input)$size), error = function(e) NA_real_),
   # Report the cutoffs as APPLIED. On the dpc path these were previously recorded
   # whether or not they had any effect, so a provenance file could assert a filter the
   # run never performed.

--- a/skill/ucdavis-proteomics-core-pipeline/tests/test_provenance_replay.py
+++ b/skill/ucdavis-proteomics-core-pipeline/tests/test_provenance_replay.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+The reproducibility bundle must replay the ORIGINAL invocation, not a subset.
+
+Found by auditing the skill's own output: `reproduce.sh` re-derived the search
+defaults with only --acquisition/--instrument/--engine. The engine params still
+came back byte-identical (they depend on neither organism nor platform), so the
+SEARCH was reproducible -- but the regenerated run record silently lost:
+
+  * organism_taxid  -> null. The species is the single most important contextual
+                       fact about a proteomics run.
+  * platform        -> null. The record could not say what machine it ran on,
+                       nor carry the "runs emulated under Rosetta" warning.
+
+And run_manifest.json recorded "timestamp": null whenever the orchestrator did
+not pass --timestamp. A bundle whose whole job is to make a run auditable must be
+able to say when it ran.
+
+These are provenance defects rather than reproducibility ones, which is exactly
+why they survived: every scientific number was right.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+SCRIPTS = os.path.join(ROOT, "scripts")
+
+
+def write_env(tmp):
+    env = os.path.join(tmp, "env.json")
+    with open(env, "w") as fh:
+        subprocess.run(["bash", os.path.join(SCRIPTS, "detect_env.sh")],
+                       stdout=fh, stderr=subprocess.DEVNULL, check=True)
+    return env
+
+
+def build_bundle(tmp, taxid="10090"):
+    wf = os.path.join(tmp, "wf")
+    # Mirror a real run: --env is what populates the platform block, and the
+    # orchestrator is told to pass it. Building the "original" without it would
+    # compare against a record that no real run produces.
+    subprocess.run([sys.executable, os.path.join(SCRIPTS, "resolve_defaults.py"),
+                    "--acquisition", "DIA", "--instrument", "timsTOF HT",
+                    "--organism-taxid", taxid, "--env", write_env(tmp),
+                    "--dest", wf],
+                   capture_output=True, text=True, check=True)
+    out = os.path.join(tmp, "repro")
+    r = subprocess.run([sys.executable, os.path.join(SCRIPTS, "provenance.py"),
+                        "--outdir", out, "--workflow-manifest",
+                        os.path.join(wf, "workflow.manifest.json"),
+                        "--engine", "diann", "--acquisition", "DIA",
+                        "--instrument", "timsTOF HT", "--organism-taxid", taxid],
+                       capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    return out, wf
+
+
+class TestReplayFidelity(unittest.TestCase):
+    def test_reproduce_sh_carries_the_organism(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out, _ = build_bundle(tmp)
+            with open(os.path.join(out, "reproduce.sh")) as fh:
+                sh = fh.read()
+            self.assertIn("--organism-taxid 10090", sh)
+
+    def test_reproduce_sh_regenerates_the_platform_map(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out, _ = build_bundle(tmp)
+            with open(os.path.join(out, "reproduce.sh")) as fh:
+                sh = fh.read()
+            self.assertIn("detect_env.sh", sh)
+            self.assertIn("--env", sh)
+
+    def test_run_manifest_always_has_a_timestamp(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out, _ = build_bundle(tmp)
+            with open(os.path.join(out, "run_manifest.json")) as fh:
+                m = json.load(fh)
+            self.assertIsNotNone(m.get("timestamp"),
+                                 "a run record with no time is not an audit record")
+            self.assertRegex(m["timestamp"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+    def test_run_manifest_records_the_skill_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out, _ = build_bundle(tmp)
+            with open(os.path.join(out, "run_manifest.json")) as fh:
+                m = json.load(fh)
+            # Parameters ship with the skill, so the skill version is what pins
+            # them -- there is no external registry commit to fall back on.
+            self.assertTrue((m.get("skill") or {}).get("version"))
+
+    def test_replaying_the_recorded_command_reproduces_the_record(self):
+        """The end-to-end claim, executed rather than asserted."""
+        with tempfile.TemporaryDirectory() as tmp:
+            out, wf = build_bundle(tmp)
+            replay = os.path.join(tmp, "replay")
+            env = write_env(tmp)
+            subprocess.run([sys.executable, os.path.join(SCRIPTS, "resolve_defaults.py"),
+                            "--acquisition", "DIA", "--instrument", "timsTOF HT",
+                            "--engine", "diann", "--organism-taxid", "10090",
+                            "--env", env, "--dest", replay],
+                           capture_output=True, text=True, check=True)
+
+            def load(p):
+                with open(p) as fh:
+                    d = json.load(fh)
+                d.pop("output", None)
+                s = d.get("search") or {}
+                s.pop("params_file", None)
+                return d
+
+            a = load(os.path.join(wf, "workflow.manifest.json"))
+            b = load(os.path.join(replay, "workflow.manifest.json"))
+            differing = [k for k in sorted(set(a) | set(b)) if a.get(k) != b.get(k)]
+            self.assertEqual(differing, [], f"replay lost/changed: {differing}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/skill/ucdavis-proteomics-core-pipeline/tests/test_repro_script_cutoffs.py
+++ b/skill/ucdavis-proteomics-core-pipeline/tests/test_repro_script_cutoffs.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+reproducibility_log.R must describe the analysis that actually ran.
+
+Caught by auditing the skill's own output. Once PG.Q.Value took DIA-NN's
+recommended 0.05 while the other five kept --q-cutoff, the emitter still wrote
+
+    limpa::readDIANN(report, q.cutoffs = 0.01, q.columns = c(...six...))
+
+a SCALAR. limpa recycles q.cutoffs across q.columns, so the emitted script ran
+clean and produced different results from the run it claims to reproduce:
+
+    original run   4,648 proteins, 1,859 significant
+    emitted script 4,624 proteins, 1,846 significant
+
+Nothing errored. The CSVs beside it were right. Only the script disagreed --
+DE-LIMP architectural rule #1 ("exports must describe what actually ran").
+
+Needs Rscript but NOT limpa: the emitter only builds strings.
+"""
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS = os.path.join(os.path.dirname(HERE), "scripts")
+
+
+def have_rscript():
+    return shutil.which("Rscript") is not None
+
+
+def emit(q_columns, q_cutoffs, q_cutoff=0.01):
+    """Run write_repro_script() and return the generated R source."""
+    with tempfile.TemporaryDirectory() as tmp:
+        out = os.path.join(tmp, "reproducibility_log.R")
+        cols = ", ".join(f'"{c}"' for c in q_columns)
+        cuts = "NULL" if q_cutoffs is None else "c(" + ", ".join(str(x) for x in q_cutoffs) + ")"
+        r = f'''
+          source("{SCRIPTS}/diann_q_columns.R"); source("{SCRIPTS}/repro_script.R")
+          meta <- data.frame(File.Name = c("r1","r2","r3","r4"),
+                             Group = c("A","A","B","B"), stringsAsFactors = FALSE)
+          invisible(write_repro_script(
+            path = "{out}", method = "dpc", input = "report.parquet",
+            format = "parquet", q_cutoff = {q_cutoff},
+            q_columns = c({cols}), q_cutoffs = {cuts},
+            eq_cutoff = 0, pgq_cutoff = 0, cov_min_frac = 0,
+            meta = meta, covariates = character(0), formula_parts = character(0),
+            forms = "A-B", adjp_thr = 0.05, logfc_ref = 1))
+          cat(readLines("{out}"), sep = "\\n")
+        '''
+        p = subprocess.run(["Rscript", "-e", r], capture_output=True, text=True)
+        if p.returncode != 0:
+            raise AssertionError(p.stderr[-2000:])
+        return p.stdout
+
+
+ALL_SIX = ["Q.Value", "Lib.Q.Value", "Lib.PG.Q.Value",
+           "PG.Q.Value", "Global.Q.Value", "Global.PG.Q.Value"]
+
+
+class TestEmittedCutoffs(unittest.TestCase):
+    def setUp(self):
+        if not have_rscript():
+            self.skipTest("Rscript not available")
+
+    def test_differing_cutoffs_are_emitted_as_a_named_vector(self):
+        src = emit(ALL_SIX, [0.01, 0.01, 0.01, 0.05, 0.01, 0.01])
+        self.assertIn("'PG.Q.Value' = 0.05", src)
+        # The exact shape of the old bug: a bare scalar alongside six columns.
+        self.assertNotIn("q.cutoffs = 0.01,", src)
+
+    def test_every_column_appears_in_the_emitted_cutoff_vector(self):
+        src = emit(ALL_SIX, [0.01, 0.01, 0.01, 0.05, 0.01, 0.01])
+        for c in ALL_SIX:
+            self.assertIn(f"'{c}' = ", src)
+
+    def test_uniform_cutoffs_still_emit_a_scalar(self):
+        # Don't make the common case ugly: one value for all six stays scalar.
+        src = emit(ALL_SIX, [0.01] * 6)
+        self.assertIn("q.cutoffs = 0.01", src)
+        self.assertNotIn("'PG.Q.Value' = ", src)
+
+    def test_cutoffs_default_to_the_shared_map_when_not_passed(self):
+        # A caller that omits q_cutoffs must still get the real cutoffs, not the
+        # scalar -- otherwise the old bug returns through the default path.
+        src = emit(ALL_SIX, None)
+        self.assertIn("'PG.Q.Value' = 0.05", src)
+
+    def test_emitted_script_reads_the_recorded_input(self):
+        src = emit(ALL_SIX, [0.01, 0.01, 0.01, 0.05, 0.01, 0.01])
+        self.assertIn("report.parquet", src)
+        self.assertIn("limpa::readDIANN", src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Found by auditing the skill's own output end to end. **Three provenance defects, all of which left every scientific number correct** — which is exactly why they survived.

## 1. `reproducibility_log.R` did not reproduce the analysis

Once `PG.Q.Value` took DIA-NN's recommended 0.05 while the other five kept `--q-cutoff`, the emitter still wrote a **scalar** next to all six columns. `limpa` recycles `q.cutoffs` across `q.columns`, so the script ran clean and returned:

| | proteins | significant |
|---|---|---|
| original run | **4,648** | **1,859** |
| emitted script | **4,624** | **1,846** |

Nothing errored, and the CSVs beside it were right. Only the script disagreed — **architectural rule #1**, and I caused it in #54 by adding per-column cutoffs to `run_de.R` without updating the emitter.

After the fix, re-running the emitted script reproduces the run **exactly**: identical protein set, **zero** differing `logFC` / `P.Value` / `adj.P.Val` across all 4,648 rows.

## 2. `de_provenance.json` asserted one cutoff while six ran

Recorded `q_cutoff: 0.01` and never named the columns. Now records `q_columns` and per-column `q_cutoffs` **as applied** (rule #2).

## 3. The DE step couldn't be tied to its search output

Provenance recorded the input **path** — which doesn't survive the file being moved, regenerated, or shipped in a bundle without its input. Now records `input_sha256` + `input_bytes`, verified against an independently computed checksum.

## Also found in the same audit

- **`reproduce.sh` replayed a subset of the original invocation**, dropping `--organism-taxid` and `--env`. Engine params still came back byte-identical (they depend on neither), but the regenerated record lost the **species** and the platform block. Replay now reproduces all 18 manifest fields.
- **`run_manifest.json` recorded `"timestamp": null`** when the orchestrator omitted the flag. Defaults to UTC now.
- **`reproducibility_log.R` was silently skipped for `--method maxlfq`** — `q_use`/`q_cuts` exist only on the dpc branch and the call sits inside a `tryCatch`, so the failure was swallowed. Guarded.

10 new tests (42 total). The emitter tests need `Rscript` but not `limpa`, so they run in skill-checks CI. Full R suite green (753).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7kCGXB2Gqy7idYrVBffyC