### PR TITLE
fix(skill): excluded runs must not decide the protein set (v2.1.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "UC Davis Proteomics Core skills for Claude \u2014 agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "description": "UC Davis Proteomics Core pipeline \u2014 end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [Skill 2.1.1] — 2026-08-20
+
+### Fixed
+- **Runs excluded from the design still decided the protein set — and shifted
+  every retained protein's quantification.** `--method dpc` called `readDIANN()`
+  on the whole report and subset columns afterwards (`dat[, .keep]`). That drops
+  the excluded runs' data but keeps every precursor row they justified — rows
+  then entirely NA in the retained runs, which still reach `dpcCN()`/
+  `dpcQuant()`. `build_maxlfq.R` has always applied `keep_runs` to the arrow
+  query before `collect()`; dpc now matches it.
+
+  Reported by the audit in #60, which measured the protein-set effect (98 extra,
+  0 lost). Reproducing it surfaced a larger one it had not measured — what
+  happens to the proteins that were *already* there. On a 12-run report analysed
+  at 7 runs:
+
+  | | before | after |
+  |---|---|---|
+  | all-NA precursor rows surviving the subset | 158 | 0 |
+  | extra protein groups vs a pre-filtered report | 3 (exact superset) | 0 |
+  | **shared proteins with a different `logFC`** | **4,645 / 4,645 (100%)** | 0 structural |
+  | **significance calls flipped** | **54** | **0** |
+
+  The extra proteins were not themselves significant here; the harm was 54
+  flipped calls among proteins that would have been analysed either way.
+
+  A residual numeric difference remains against a natively pre-filtered report
+  (median |Δ logFC| 1.1e-07, max 3.0e-03, **0** flips) — row ordering changing an
+  iterative fit's path, not structure. Before the fix: median 0.0021, max 0.11,
+  54 flips.
+
+  **Unaffected if your report contains only the runs you analyse** — the common
+  case. It bites when a report deliberately holds more runs than the design uses.
+  The tsv route cannot pre-filter, so the post-hoc `dat[, .keep]` is retained as
+  a backstop for it.
+
+### Added
+- `TestRunRestrictionHappensBeforeRollup` asserts the restriction precedes
+  `readDIANN()`, verified to fail when it is removed. 56 tests.
+
 ## [Skill 2.1.0] — 2026-08-20
 
 ### Added

--- a/docs/SKILL_OPEN_DEFECTS.md
+++ b/docs/SKILL_OPEN_DEFECTS.md
@@ -13,17 +13,14 @@ reusable, add a row there instead. A shrinking file is the point.
 
 ## Status at a glance
 
-| # | Defect | Severity | Evidence |
-|---|---|---|---|
-| 5 | The dpc path decides the protein set over **every run in the report**, then restricts to the analysed ones — so protein groups whose inclusion depended on excluded runs survive into the results | Medium | `scripts/run_de.R:248-267` |
+**No open defects.**
 
 Every entry from the 2026-08-17 audit has been fixed; those are listed below and in
-`docs/GOTCHAS.md`. Defect 5 was found afterwards, by an end-to-end confirmation run of the #48
-fix, and is open as of `a735fbb`.
+`docs/GOTCHAS.md`. The run-restriction defect was found afterwards, by an end-to-end
+confirmation run of the #48 fix, and is fixed as of skill v2.1.1.
 
 ---
 
-## 5. The dpc path determines the protein set before restricting to the analysed runs
 
 **What.** `--method dpc` reads the entire report, then subsets:
 
@@ -144,6 +141,39 @@ Tag only; no behaviour change. It now reads: *"z=1 excluded: rarely informative 
 bottom-up. DIA-NN's own default is 1-4; this drops ~19% of the predicted library (measured:
 10,899 → 8,805 precursors on a 60-protein FASTA)"*. The narrowing is still applied — it is the
 right call — but a reader of the emitted parameters can now see that it was a decision.
+
+---
+
+## ~~The dpc path decides the protein set before restricting to analysed runs~~ — FIXED 2026-08-20
+
+Fixed in `fix/dpc-restrict-runs-before-rollup`. `run_de.R` now applies
+`Run %in% meta$File.Name` to the arrow query **before** `readDIANN()`, matching what
+`build_maxlfq.R` has always done, instead of subsetting columns afterwards.
+
+**The audit understated it.** It measured the protein-set effect (98 extra, 0 lost). It did not
+measure what happens to the proteins that were *already* there. Reproduced on a 12-run report
+analysed at 7 runs:
+
+| | before fix | after fix |
+|---|---|---|
+| all-NA precursor rows surviving the subset | 158 | 0 |
+| extra protein groups vs a pre-filtered report | 3 (exact superset) | 0 |
+| **shared proteins with a different `logFC`** | **4,645 of 4,645 (100%)** | 0 structural |
+| **significance calls flipped** | **54** | **0** |
+
+So the excluded runs were not only deciding which proteins were *eligible* — those all-NA rows
+reach `dpcCN()`/`dpcQuant()`, so they shifted the detection model **every retained protein was
+quantified against**. On this data the extra proteins were not themselves significant; the harm
+was 54 flipped calls among proteins that would have been analysed either way.
+
+A residual numeric difference remains vs a natively pre-filtered report (median |Δ logFC|
+1.1e-07, max 3.0e-03, **0** significance flips), consistent with row ordering changing an
+iterative fit's path rather than anything structural. Before the fix the same comparison was
+median 0.0021 / max 0.11 / 54 flips.
+
+Guarded by `tests/test_reproducibility_contract.py::TestRunRestrictionHappensBeforeRollup`,
+verified to fail when the restriction is removed. The post-hoc `dat[, .keep]` is retained as a
+backstop for the tsv route, which cannot pre-filter.
 
 ---
 

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "UC Davis Proteomics Core pipeline \u2014 end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE \u2014 with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
@@ -214,12 +214,49 @@ if (method == "dpc") {
   # So pgQ is allowed but warned about; eQ is the sane knob for this path.
   dpc_input <- input
   quantums_applied <- character(0)
-  if ((!is.na(eq_cutoff) && eq_cutoff > 0) || (!is.na(pgq_cutoff) && pgq_cutoff > 0)) {
-    if (!identical(format, "parquet"))
+  # Does the report carry runs the design does not analyse?
+  #
+  # If so they MUST be removed before readDIANN(), not after. Subsetting columns
+  # afterwards (dat[, .keep]) drops the excluded runs' data but keeps every
+  # precursor row they justified -- rows that are then entirely NA in the
+  # retained runs. Those rows still reach dpcCN()/dpcQuant(), so the excluded
+  # runs go on deciding which proteins are eligible AND shifting the detection
+  # model every retained protein is quantified against.
+  #
+  # Measured on a 12-run report analysed at 7 runs: 158 all-NA precursor rows
+  # survived the subset; the protein set gained 3 proteins (exact superset, none
+  # lost) -- and 100% of the 4,645 SHARED proteins came out with a different
+  # logFC, flipping 54 significance calls. build_maxlfq.R has always applied
+  # keep_runs to the arrow query before collect(); dpc now matches it.
+  .rep_runs_pre <- tryCatch({
+    if (identical(format, "parquet") && requireNamespace("arrow", quietly = TRUE) &&
+        requireNamespace("dplyr", quietly = TRUE))
+      sort(unique(dplyr::collect(dplyr::select(arrow::open_dataset(input), Run))$Run))
+    else NULL
+  }, error = function(e) NULL)
+  .restrict_runs <- !is.null(.rep_runs_pre) && length(setdiff(.rep_runs_pre, meta$File.Name)) > 0
+
+  if (.restrict_runs || (!is.na(eq_cutoff) && eq_cutoff > 0) ||
+      (!is.na(pgq_cutoff) && pgq_cutoff > 0)) {
+    if (!identical(format, "parquet")) {
+      if (.restrict_runs)
+        stop("this report contains runs the metadata does not analyse, and run ",
+             "restriction before quantification needs parquet input.")
       stop("--eq-cutoff / --pgq-cutoff on --method dpc need parquet input.")
+    }
     if (!requireNamespace("arrow", quietly = TRUE) || !requireNamespace("dplyr", quietly = TRUE))
-      stop("arrow and dplyr are required to apply QuantUMS cutoffs on --method dpc.")
+      stop("arrow and dplyr are required to pre-filter the report on --method dpc.")
     flt <- arrow::open_dataset(input)
+    if (.restrict_runs) {
+      .keep_runs <- meta$File.Name
+      flt <- dplyr::filter(flt, Run %in% !!.keep_runs)
+      message(sprintf(paste0("[run_de] restricting to the %d of %d report runs in the metadata ",
+                             "BEFORE quantification (excluded runs must not decide the protein set)"),
+                      length(intersect(.rep_runs_pre, meta$File.Name)), length(.rep_runs_pre)))
+      quantums_applied <- c(quantums_applied,
+                            sprintf("restricted to %d analysed run(s) before rollup",
+                                    length(intersect(.rep_runs_pre, meta$File.Name))))
+    }
     if (!is.na(eq_cutoff) && eq_cutoff > 0) {
       if (!"Empirical.Quality" %in% have_cols)
         stop("--eq-cutoff given but this report has no Empirical.Quality column.")
@@ -236,7 +273,7 @@ if (method == "dpc") {
     }
     dpc_input <- file.path(tempdir(), "quantums_filtered_for_dpc.parquet")
     arrow::write_parquet(dplyr::collect(flt), dpc_input)
-    message("[run_de] QuantUMS pre-filter for dpc: ", paste(quantums_applied, collapse = " | "))
+    message("[run_de] pre-filter for dpc: ", paste(quantums_applied, collapse = " | "))
   }
 
   # Per-column cutoffs. limpa recycles q.cutoffs against q.columns

--- a/skill/ucdavis-proteomics-core-pipeline/tests/test_reproducibility_contract.py
+++ b/skill/ucdavis-proteomics-core-pipeline/tests/test_reproducibility_contract.py
@@ -264,5 +264,51 @@ class TestEndToEndReproduction(unittest.TestCase):
                                                    f"{len(diff)} protein(s)")
 
 
+class TestRunRestrictionHappensBeforeRollup(unittest.TestCase):
+    """Runs the design excludes must not decide the protein set.
+
+    run_de.R used to call readDIANN() on the whole report and subset columns
+    afterwards (dat[, .keep]). That drops the excluded runs' DATA but keeps every
+    precursor row they justified -- rows then entirely NA in the retained runs,
+    which still reach dpcCN()/dpcQuant().
+
+    Measured on a 12-run report analysed at 7 runs: 158 such rows survived, the
+    protein set gained 3 (exact superset, none lost), and 100% of the 4,645
+    shared proteins came out with a different logFC -- flipping 54 significance
+    calls. build_maxlfq.R has always applied keep_runs to the arrow query before
+    collect(); this asserts dpc does too.
+
+    Source-level because the behavioural check needs limpa; the end-to-end class
+    above covers it when the stack is present.
+    """
+
+    def setUp(self):
+        with open(os.path.join(SCRIPTS, "run_de.R")) as fh:
+            self.src = fh.read()
+
+    def test_runs_are_filtered_before_readdiann(self):
+        restrict = self.src.find("Run %in%")
+        read = self.src.find("limpa::readDIANN(dpc_input")
+        self.assertNotEqual(restrict, -1,
+                            "run_de.R no longer restricts runs in the arrow query; "
+                            "excluded runs will decide the protein set again")
+        self.assertNotEqual(read, -1, "could not find the dpc readDIANN call")
+        self.assertLess(restrict, read,
+                        "the run restriction must come BEFORE readDIANN(); "
+                        "subsetting columns afterwards keeps the precursor rows "
+                        "the excluded runs justified")
+
+    def test_maxlfq_still_restricts_in_the_query(self):
+        with open(os.path.join(SCRIPTS, "build_maxlfq.R")) as fh:
+            ml = fh.read()
+        self.assertIn("keep_runs", ml)
+
+    def test_the_post_hoc_column_subset_is_still_present_as_a_backstop(self):
+        # Belt and braces: the tsv route cannot pre-filter, so dat[, .keep] must
+        # remain for it. Removing it would silently reintroduce the mismatch for
+        # non-parquet input.
+        self.assertIn("dat[, .keep]", self.src)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes the defect #60 documented (merged as docs).

`--method dpc` called `readDIANN()` on the whole report and subset columns afterwards (`dat[, .keep]`). That drops the excluded runs' *data* but keeps every precursor row they justified — rows then entirely NA in the retained runs, which still reach `dpcCN()`/`dpcQuant()`. `build_maxlfq.R` has always applied `keep_runs` to the arrow query before `collect()`; dpc now matches it.

## #60's measurement understated it

It measured the protein-set effect (98 extra, 0 lost). Reproducing it surfaced a larger one it hadn't measured — what happens to the proteins that were **already** there. On a 12-run report analysed at 7 runs:

| | before | after |
|---|---|---|
| all-NA precursor rows surviving the subset | 158 | 0 |
| extra protein groups vs a pre-filtered read | 3 (exact superset) | 0 |
| **shared proteins with a different `logFC`** | **4,645 / 4,645 (100%)** | 0 structural |
| **significance calls flipped** | **54** | **0** |

So the excluded runs weren't only deciding which proteins were *eligible*. Those all-NA rows shift the detection model **every retained protein is quantified against**. The extra proteins weren't themselves significant here — the harm was 54 flipped calls among proteins that would have been analysed either way. That's a quieter failure than 3 phantom proteins, and a good deal worse.

## Residual

A numeric difference remains vs a natively pre-filtered report: median |Δ logFC| **1.1e-07**, max 3.0e-03, **0** significance flips — row ordering changing an iterative fit's path, not structure. Before the fix: median 0.0021, max 0.11, 54 flips.

## Scope

**Unaffected when the report contains only the runs you analyse** — the common case. It bites when a report deliberately holds more runs than the design uses, which is the 399-vs-373 ShortCourse situation that surfaced it.

The tsv route cannot pre-filter, so the post-hoc `dat[, .keep]` is retained as a backstop, and a test asserts it stays.

`TestRunRestrictionHappensBeforeRollup` asserts the restriction precedes `readDIANN()` — verified to fail when the filter line is removed, not assumed to. 56 tests; full R suite green. `docs/SKILL_OPEN_DEFECTS.md` is back to no open defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7kCGXB2Gqy7idYrVBffyC