### PR TITLE
fix(skill): the tsv route still let excluded runs decide the protein set (v2.1.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "UC Davis Proteomics Core skills for Claude \u2014 agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "UC Davis Proteomics Core pipeline \u2014 end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [Skill 2.1.2] — 2026-08-20
+
+### Fixed
+- **The tsv route still let excluded runs decide the protein set.** 2.1.1 gated
+  the pre-filter on `identical(format, "parquet")`, leaving `--format tsv` on the
+  old post-hoc `dat[, .keep]` path with exactly the defect that release removed —
+  and silently, since nothing errors. arrow reads both formats
+  (`read_tsv_arrow`), so both are now pre-filtered. Verified on a 12-run TSV
+  report analysed at 7 runs: **4,645 proteins / 577 significant**, identical
+  protein set and identical `logFC` to a natively pre-filtered TSV, and matching
+  the parquet result. Before the fix that path produced 4,648 / 553.
+- **The filtered frame is now written back in the format `readDIANN()` is told to
+  read.** Writing parquet while still passing `format = "tsv"` would fail inside
+  limpa.
+- **TSV is written with `utils::write.table`, not `arrow::write_csv_arrow`** —
+  the latter has no `delim` argument in arrow 24 (*"not yet supported in
+  Arrow"*), so it cannot write a TSV at all. The first draft of this fix used it
+  and would have failed at runtime for anyone passing `--format tsv`.
+
+### Added
+- Three guards: the restriction is not parquet-only, the TSV write-back exists,
+  and `write_csv_arrow` is not used in code (comments excluded — a bare substring
+  check trips on the comment explaining why it is unusable). 58 tests.
+
 ## [Skill 2.1.1] — 2026-08-20
 
 ### Fixed

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "UC Davis Proteomics Core pipeline \u2014 end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE \u2014 with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/run_de.R
@@ -228,25 +228,29 @@ if (method == "dpc") {
   # lost) -- and 100% of the 4,645 SHARED proteins came out with a different
   # logFC, flipping 54 significance calls. build_maxlfq.R has always applied
   # keep_runs to the arrow query before collect(); dpc now matches it.
+  # arrow reads BOTH formats, so the restriction is not parquet-only. A tsv left
+  # on the post-hoc dat[, .keep] path would keep exactly the defect this block
+  # exists to remove -- and silently, since nothing errors.
+  .open_report <- function(path, fmt) {
+    if (identical(fmt, "parquet")) arrow::open_dataset(path)
+    else arrow::read_tsv_arrow(path, as_data_frame = FALSE)
+  }
   .rep_runs_pre <- tryCatch({
-    if (identical(format, "parquet") && requireNamespace("arrow", quietly = TRUE) &&
+    if (requireNamespace("arrow", quietly = TRUE) &&
         requireNamespace("dplyr", quietly = TRUE))
-      sort(unique(dplyr::collect(dplyr::select(arrow::open_dataset(input), Run))$Run))
+      sort(unique(dplyr::collect(dplyr::select(.open_report(input, format), Run))$Run))
     else NULL
   }, error = function(e) NULL)
   .restrict_runs <- !is.null(.rep_runs_pre) && length(setdiff(.rep_runs_pre, meta$File.Name)) > 0
 
   if (.restrict_runs || (!is.na(eq_cutoff) && eq_cutoff > 0) ||
       (!is.na(pgq_cutoff) && pgq_cutoff > 0)) {
-    if (!identical(format, "parquet")) {
-      if (.restrict_runs)
-        stop("this report contains runs the metadata does not analyse, and run ",
-             "restriction before quantification needs parquet input.")
+    if (!identical(format, "parquet") &&
+        ((!is.na(eq_cutoff) && eq_cutoff > 0) || (!is.na(pgq_cutoff) && pgq_cutoff > 0)))
       stop("--eq-cutoff / --pgq-cutoff on --method dpc need parquet input.")
-    }
     if (!requireNamespace("arrow", quietly = TRUE) || !requireNamespace("dplyr", quietly = TRUE))
       stop("arrow and dplyr are required to pre-filter the report on --method dpc.")
-    flt <- arrow::open_dataset(input)
+    flt <- .open_report(input, format)
     if (.restrict_runs) {
       .keep_runs <- meta$File.Name
       flt <- dplyr::filter(flt, Run %in% !!.keep_runs)
@@ -271,8 +275,19 @@ if (method == "dpc") {
       flt <- dplyr::filter(flt, PG.MaxLFQ.Quality >= !!pgq_cutoff)
       quantums_applied <- c(quantums_applied, sprintf("PG.MaxLFQ.Quality >= %.2f", pgq_cutoff))
     }
-    dpc_input <- file.path(tempdir(), "quantums_filtered_for_dpc.parquet")
-    arrow::write_parquet(dplyr::collect(flt), dpc_input)
+    # Write back in the SAME format limpa is about to be told to read. Writing a
+    # parquet and still passing format = "tsv" would fail inside readDIANN().
+    if (identical(format, "parquet")) {
+      dpc_input <- file.path(tempdir(), "quantums_filtered_for_dpc.parquet")
+      arrow::write_parquet(dplyr::collect(flt), dpc_input)
+    } else {
+      dpc_input <- file.path(tempdir(), "runs_filtered_for_dpc.tsv")
+      # base write.table, not arrow::write_csv_arrow -- the latter does not accept
+      # a `delim` argument in arrow 24 ("not yet supported in Arrow"), so it
+      # cannot write a TSV at all. collect() has already materialised the frame.
+      utils::write.table(dplyr::collect(flt), dpc_input, sep = "\t",
+                         quote = FALSE, row.names = FALSE, na = "")
+    }
     message("[run_de] pre-filter for dpc: ", paste(quantums_applied, collapse = " | "))
   }
 

--- a/skill/ucdavis-proteomics-core-pipeline/tests/test_reproducibility_contract.py
+++ b/skill/ucdavis-proteomics-core-pipeline/tests/test_reproducibility_contract.py
@@ -304,10 +304,32 @@ class TestRunRestrictionHappensBeforeRollup(unittest.TestCase):
         self.assertIn("keep_runs", ml)
 
     def test_the_post_hoc_column_subset_is_still_present_as_a_backstop(self):
-        # Belt and braces: the tsv route cannot pre-filter, so dat[, .keep] must
-        # remain for it. Removing it would silently reintroduce the mismatch for
-        # non-parquet input.
+        # Retained for the case where arrow/dplyr are unavailable and the
+        # pre-filter cannot run at all. Removing it would silently reintroduce
+        # the mismatch there.
         self.assertIn("dat[, .keep]", self.src)
+
+    def test_the_restriction_is_not_parquet_only(self):
+        # The first version of this fix gated the pre-filter on
+        # `identical(format, "parquet")`, leaving tsv on the post-hoc path with
+        # exactly the defect the fix exists to remove -- and silently, since
+        # nothing errors. arrow reads both formats, so both are pre-filtered.
+        self.assertIn("read_tsv_arrow", self.src,
+                      "the tsv route no longer pre-filters runs")
+        # ...and the filtered frame must be written back in the SAME format
+        # readDIANN is told to read.
+        self.assertIn("runs_filtered_for_dpc.tsv", self.src)
+
+    def test_tsv_is_written_with_base_write_table_not_arrow(self):
+        # arrow::write_csv_arrow has no `delim` argument in arrow 24
+        # ("not yet supported in Arrow"), so it cannot write a TSV. Using it here
+        # fails at runtime only when someone actually passes --format tsv.
+        self.assertIn("utils::write.table", self.src)
+        # Ignore comments: the code comment explaining why write_csv_arrow is
+        # unusable mentions it by name, and a bare substring check trips on that.
+        code = [l for l in self.src.splitlines() if not l.lstrip().startswith("#")]
+        self.assertFalse([l for l in code if "write_csv_arrow" in l],
+                         "write_csv_arrow cannot write a TSV in arrow 24")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
2.1.1 gated the pre-filter on `identical(format, "parquet")`, so `--format tsv` stayed on the old post-hoc `dat[, .keep]` path carrying **exactly the defect that release removed** — and silently, since nothing errors. I flagged it as unverified when shipping 2.1.1 rather than fixing it; it turned out to be a two-line change.

arrow reads both formats (`read_tsv_arrow`), so both are pre-filtered now.

**Verified** on a 12-run TSV analysed at 7 runs: **4,645 proteins / 577 significant**, identical protein set *and* identical `logFC` to a natively pre-filtered TSV, matching the parquet result. Before the fix that path gave 4,648 / 553.

## Two things testing caught that review would not have

- **The filtered frame must be written back in the same format `readDIANN()` is told to read.** Writing parquet while still passing `format = "tsv"` fails inside limpa.
- **`arrow::write_csv_arrow` has no `delim` argument in arrow 24** (*"not yet supported in Arrow"*), so it cannot write a TSV at all. My first draft used it and would have failed at runtime for anyone passing `--format tsv` — the exact class of defect this session has been chasing: correct-looking code that only breaks on a path nobody exercises.

Three guards added, each verified to fail when the behaviour is removed. 58 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7kCGXB2Gqy7idYrVBffyC