### PR TITLE
feat(skill): de novo → homology species ID (v2.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "UC Davis Proteomics Core skills for Claude \u2014 agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "description": "UC Davis Proteomics Core pipeline \u2014 end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## [Skill 2.2.0] — 2026-08-20
+
+### Added
+- **De novo → homology species ID** (`§6e`), for samples with no proteome —
+  forensic hair, feather, fossil, wildlife. Casanovo → DIAMOND vs nr → LCA, as
+  four scripts: `denovo_decoy_gen.py` (FRAC-0.8 decoy spectra),
+  `denovo_search_cmd.py` (DIAMOND settings), `denovo_homology_fdr.py` (FDR), and
+  `denovo_lca.py` (species call).
+
+  The scoring half was rebuilt: the original lived in `/tmp/decoyval/` and was
+  lost to scratch, while the data survived on `/quobyte`. It is a
+  **reimplementation validated against preserved outputs**, not the original
+  code. `denovo_homology_fdr.py` reproduces the published E-value result
+  **exactly** (13,074 peptides at 1% FDR) and raw bitscore exactly (10,404);
+  mokapot rebuilds land within a few percent (14,925 / 19,757 / 9,554 / 11,325
+  against 14,706 / 19,556 / 9,335 / 12,352 — mokapot is semi-supervised, so exact
+  equality is not expected).
+
+### Fixed (in the method, not the code)
+- **`--max-target-seqs 1` makes the LCA step impossible.** The production ocelot
+  search used it (0.9 hits/peptide), so "LCA over all hits" — step 4 of the
+  method's own recommendation — silently degraded to best-hit, which is the ~36%
+  species-mis-assignment error mode LCA exists to prevent. The skill defaults to
+  **25** (the HeLa benchmark setting, 22.5 hits/peptide), `denovo_search_cmd.py`
+  warns when given < 2, and `denovo_lca.py` warns when its input averages < 2
+  hits/peptide.
+
+### Decisions, each from measurement
+- **Linear model, never gradient boosting.** GBT overfits the decoy and scores
+  *worse than raw bitscore* (9,554 vs 10,404).
+- **Five features, not thirteen.** On HeLa ground truth more features accept more
+  peptides at lower precision and recover fewer correct ones (12-feature: 2,532 /
+  55.5% / 1,405 vs 5-feature: 2,400 / 59.8% / 1,436).
+- **Confidence is load-bearing.** The homology-only model does not separate at
+  all on a standard search; every model that works includes `mean_conf`.
+- **Do not gate the species call on the FDR model.** Filtering lifts peptide
+  precision 42.4% → 59.8% but moves primate attribution only 29.5% → 32.9%,
+  leaves mammal flat at 68.5%, and discards 715 correct peptides. Species error
+  is conserved peptides — an LCA problem. Run LCA over unfiltered hits and report
+  the score as a confidence tier.
+- **Two FDR definitions, not interchangeable.** Raw scores use a rate-normalised,
+  tie-aware target-decoy threshold (the universes differ: 312,820 vs 424,552);
+  mokapot scores use mokapot's own q-values. Applying rate-normalisation to a
+  mokapot score returns ~everything (298,889 of 299,099).
+
 ## [Skill 2.1.2] — 2026-08-20
 
 ### Fixed

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "UC Davis Proteomics Core pipeline \u2014 end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE \u2014 with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -538,6 +538,52 @@ Before adding a path: run it, execute the script it emits, and diff the results 
 TestEndToEndReproduction`. Reading the emitted script is not enough; both bugs
 were invisible on inspection and obvious on execution.
 
+### 6e. De novo → homology species ID (unknown organism)
+
+For samples where the organism is unknown or has no proteome — forensic hair,
+feather, fossil, wildlife — the route is Casanovo de novo → DIAMOND vs nr → LCA.
+Four scripts, in order:
+
+```
+python3 scripts/denovo_decoy_gen.py <mzML> <decoy.mgf> 0.8 1337     # 1. decoy spectra
+python3 scripts/denovo_search_cmd.py --query peptides.fasta \
+        --db $NR --out hits.tsv                                     # 2. emits the DIAMOND cmd
+python3 scripts/denovo_homology_fdr.py --target-hits ... --decoy-hits ... \
+        --target-conf real.mztab --decoy-conf decoy.mztab \
+        --n-target N --n-decoy N --out accepted.tsv                 # 3. FDR
+python3 scripts/denovo_lca.py hits.tsv out_prefix                   # 4. species call
+```
+
+**Five things here are measured, and each is a way to get it silently wrong.**
+
+- **FRAC ≥ 0.8 for the decoy.** At 0.5 the decoy leaks — Casanovo reconstructs
+  abundant real peptides from half-kept peaks, and the null stops being a null
+  (356 decoy peptides hitting nr vs 36 at 0.8).
+- **`--max-target-seqs 25`, never 1.** The species call is LCA over *all* hits;
+  with one hit per peptide LCA silently becomes best-hit, which mis-assigns ~36%.
+  `denovo_lca.py` warns if the input averages < 2 hits/peptide.
+- **The EXTRA short-peptide DIAMOND settings**, and the Riffle build — stock
+  DIAMOND finds almost nothing on 7–30 aa queries. EXTRA nearly doubles confirmed
+  homology (9,801 → 19,671) and the gain is concentrated at ≤15 aa (168 → 1,661).
+  Costs ~5×.
+- **Linear model, calibrated on E-value.** Gradient boosting overfits the decoy
+  and scores *worse than raw bitscore* (9,554 vs 10,404). Raw bitscore is
+  length-confounded and starves short peptides.
+- **Five features, not thirteen.** On ground truth, more features accept more
+  peptides at *lower* precision and recover *fewer* correct ones (12-feature:
+  2,532 accepted / 55.5% / 1,405 correct, vs 5-feature: 2,400 / 59.8% / 1,436).
+
+**Do not gate the species call on the FDR model.** Filtering lifts peptide
+precision 42.4% → 59.8% but moves primate attribution only 29.5% → 32.9%, leaves
+mammal flat, and throws away 715 correct peptides. Species error comes from
+conserved peptides matching many taxa — that is LCA's job. Run LCA over the
+unfiltered hits and report the FDR score as a confidence tier.
+
+De novo sequence error is the binding error mode: 45% raw, 21% at conf ≥ 0.95,
+12% at conf ≥ 0.99. Say which threshold you used.
+
+→ method + all measurements: `docs/denovo_decoy_method.html` in the DE-LIMP repo.
+
 ### 7. Run the search
 ```
 python3 scripts/run_search.py --tools ~/.proteomics-pipeline/tools/tools.json \

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/denovo_decoy_gen.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/denovo_decoy_gen.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""NovoBoard-style decoy SPECTRA generator for de novo target-decoy FDR.
+
+Tran et al. 2024, Mol Cell Proteomics (doi:10.1016/j.mcpro.2024.100849), "random peak
+removal" strategy: for each real MS2 spectrum, remove FRAC of its peaks and add back the
+same number of peaks sampled from the GLOBAL pool of all peaks (so each noise peak is a
+real fragment ion from some peptide). Precursor m/z + charge are PRESERVED, so Casanovo
+sees a realistic-statistics spectrum that corresponds to no real peptide.
+
+VALIDATED PARAMETER (DE-LIMP, 2026-06-03 HeLa entrapment): use FRAC >= 0.8. At FRAC=0.5 the
+most abundant real peptides (GAPDH, beta-actin, tubulin) are still reconstructible and leak
+into the null with top BLAST scores; at >=0.8 the null is clean. See docs/DENOVO_FDR_VALIDATION.md.
+
+Usage: denovo_decoy_gen.py <input.mzML|.mgf> <out.mgf> [FRAC=0.8] [SEED=1337]
+"""
+import sys, re
+import numpy as np
+
+INPUT = sys.argv[1]
+OUTMGF = sys.argv[2]
+FRAC = float(sys.argv[3]) if len(sys.argv) > 3 else 0.8
+SEED = int(sys.argv[4]) if len(sys.argv) > 4 else 1337
+rng = np.random.default_rng(SEED)
+
+
+def read_spectra(path):
+    """Yield (scan, precursor_mz, charge, mz[], intensity[]) for MS2 spectra."""
+    low = path.lower()
+    if low.endswith(".mgf"):
+        from pyteomics import mgf
+        for i, s in enumerate(mgf.read(path)):
+            mz = np.asarray(s["m/z array"], float); it = np.asarray(s["intensity array"], float)
+            if len(mz) == 0:
+                continue
+            p = s.get("params", {})
+            pmz = (p.get("pepmass") or ("",))[0]
+            ch = ""
+            if p.get("charge"):
+                try: ch = int(p["charge"][0])
+                except Exception: ch = ""
+            m = re.search(r"scan=(\d+)", str(p.get("title", "")))
+            scan = int(m.group(1)) if m else (p.get("scans") or i)
+            yield scan, pmz, ch, mz, it
+    else:
+        from pyteomics import mzml
+        for i, s in enumerate(mzml.read(path)):
+            if s.get("ms level") != 2:
+                continue
+            mz = np.asarray(s["m/z array"], float); it = np.asarray(s["intensity array"], float)
+            if len(mz) == 0:
+                continue
+            m = re.search(r"scan=(\d+)", s.get("id", ""))
+            scan = int(m.group(1)) if m else i
+            pmz = ""; ch = ""
+            try:
+                pr = s["precursorList"]["precursor"][0]["selectedIonList"]["selectedIon"][0]
+                pmz = pr.get("selected ion m/z", ""); ch = pr.get("charge state", "")
+            except Exception:
+                pass
+            yield scan, pmz, ch, mz, it
+
+
+# Pass 1: collect spectra + global peak pool ((m/z, intensity) PAIRS, so swapped-in
+# noise peaks carry a real fragment-ion intensity from the pool — not a flat value).
+specs = []
+pool_mz = []; pool_int = []
+for scan, pmz, ch, mz, it in read_spectra(INPUT):
+    specs.append((scan, pmz, ch, mz, it)); pool_mz.append(mz); pool_int.append(it)
+pool_mz  = np.concatenate(pool_mz)  if pool_mz  else np.array([])
+pool_int = np.concatenate(pool_int) if pool_int else np.array([])
+print(f"MS2 spectra: {len(specs)} | global peak pool: {len(pool_mz)} | FRAC={FRAC}", flush=True)
+
+# Pass 2: write decoy MGF
+with open(OUTMGF, "w") as f:
+    written = 0
+    for scan, pmz, ch, mz, it in specs:
+        npk = len(mz); n_rm = int(round(FRAC * npk))
+        keep = rng.permutation(npk)[n_rm:]
+        kmz, kit = mz[keep], it[keep]
+        if n_rm > 0 and len(pool_mz):
+            sidx = rng.integers(0, len(pool_mz), size=n_rm)
+            dmz = np.concatenate([kmz, pool_mz[sidx]])
+            dit = np.concatenate([kit, pool_int[sidx]])   # real pooled intensities, not a flat fill
+        else:
+            dmz, dit = kmz, kit
+        order = np.argsort(dmz); dmz, dit = dmz[order], dit[order]
+        f.write("BEGIN IONS\n")
+        f.write(f"TITLE=decoy_scan={scan}\n")
+        if ch != "" and ch is not None:
+            f.write(f"CHARGE={int(ch)}+\n")
+        if pmz != "" and pmz is not None:
+            f.write(f"PEPMASS={float(pmz):.6f}\n")
+        f.write(f"SCANS={scan}\n")
+        for a, b in zip(dmz, dit):
+            f.write(f"{a:.5f} {b:.2f}\n")
+        f.write("END IONS\n")
+        written += 1
+print(f"wrote {written} decoy spectra -> {OUTMGF}", flush=True)

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/denovo_homology_fdr.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/denovo_homology_fdr.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""
+denovo_homology_fdr.py -- FDR for de novo -> homology species ID.
+
+Controls the two error modes that matter when calling a species from de novo
+peptides BLASTed against nr: chance homology, and de novo sequencing error.
+Method: NovoBoard decoy spectra (Tran NH et al., Mol Cell Proteomics 2024,
+doi:10.1016/j.mcpro.2024.100849) + a linear mokapot rescoring.
+
+WHAT THIS SHIPS, AND WHY -- every choice below was measured, not assumed. The
+measurements are on the UC Davis ocelot (Leopardus pardalis) hair cohort, 9x
+Exploris-480 DDA, Casanovo v5 -> DIAMOND, plus a HeLa entrapment where a Sage
+database search provides ground truth.
+
+1. SCORE WITH A LINEAR MODEL, NEVER GRADIENT BOOSTING.
+   Reproduced at 1% FDR on the clean FRAC-0.8 decoy, EXTRA nr-Eukaryota:
+       raw bitscore                        10,404
+       E-value                             13,074
+       linear  [bits+len]                  14,925
+       linear  [bits+E+len+%id]            19,757
+       GBT     [bits+len]                   9,554   <- worse than raw bitscore
+       GBT     [bits+E+len+%id]            11,325   <- worse than E-value alone
+   The non-linear model overfits the decoy in the semi-supervised loop. This is
+   why Percolator/mokapot default to a linear model.
+
+2. CALIBRATE ON E-VALUE, NEVER RAW BITSCORE. Bitscore is length-confounded, so a
+   global cut starves short peptides (11 peptides at <=15 aa vs 1,661 for the
+   linear model). E-value is length-normalised.
+
+3. FIVE FEATURES, NOT THIRTEEN. On HeLa ground truth (Sage-confirmed), adding
+   granular confidence/traceback features raises YIELD without raising
+   CORRECTNESS:
+       accept all hits        5,068 accepted   42.4% precision   2,151 correct
+       5-feature  (default)   2,400            59.8%             1,436
+       8-feature              2,506            55.7%             1,397
+       12-feature             2,532            55.5%             1,405
+   More features accept more peptides, less precisely, and recover FEWER correct
+   ones. The 5-feature model is the best of the models tested.
+
+4. CONFIDENCE IS LOAD-BEARING; HOMOLOGY ALONE FAILS. The homology-only feature
+   set cannot separate at all on a standard search ("No PSMs found below the
+   eval_fdr") -- too few decoy peptides get hits to train on. Every model that
+   works includes mean Casanovo confidence.
+
+5. DO NOT GATE THE SPECIES CALL ON THIS MODEL. Filtering lifts peptide precision
+   42.4% -> 59.8% but moves primate attribution only 29.5% -> 32.9%, leaves
+   mammal flat at 68.5%, and discards 715 genuinely-correct peptides. Species
+   mis-assignment comes from CONSERVED peptides matching many organisms, which is
+   an LCA problem, not a scoring problem. Use this score as a reported confidence
+   tier and run LCA over the unfiltered hits.
+
+TWO FDR DEFINITIONS, AND THEY ARE NOT INTERCHANGEABLE:
+  * single raw score (bitscore / E-value): RATE-NORMALISED target-decoy, because
+    the target and decoy peptide universes differ in size (312,820 vs 424,552 on
+    ocelot). FDR = (decoys>=t / N_decoy) / (targets>=t / N_target).
+  * mokapot score: mokapot's OWN q-values. Applying the rate-normalised formula
+    to a mokapot score returns ~everything (298,889 of 299,099) because the score
+    already embodies target-decoy competition and normalising again double-counts.
+
+TIES MUST MOVE TOGETHER. Accepting hits one at a time down the ranked list gives
+11,558 for bitscore instead of 10,404 (+11%); bitscore is coarse and heavily
+tied. Threshold on the score VALUE so tied hits are accepted as a group.
+"""
+import argparse
+import csv
+import json
+import math
+import os
+import sys
+
+# Feature set. Order is fixed so a rebuilt model is comparable to a recorded one.
+DEFAULT_FEATURES = ["bitscore", "log_evalue", "pep_len", "pident", "mean_conf"]
+
+# Extended sets, kept ONLY so a user can reproduce the comparison above. They are
+# not better -- see point 3. Never make one of these the default.
+FEATURE_SETS = {
+    "homology": ["bitscore", "log_evalue", "pep_len", "pident"],
+    "default": DEFAULT_FEATURES,
+    "8feat": DEFAULT_FEATURES + ["n_hi", "longest_run", "pred_count"],
+    "12feat": DEFAULT_FEATURES + ["n_hi", "longest_run", "pred_count",
+                                  "cterm", "nterm", "min_conf", "pep_score"],
+}
+
+
+def rate_normalised_accept(scores, is_target, n_target, n_decoy, fdr=0.01):
+    """Tie-aware, rate-normalised target-decoy threshold.
+
+    Returns (accepted_target_count, threshold). Higher score = better.
+    Validated: reproduces 10,404 (bitscore) and 13,074 (E-value) exactly on the
+    ocelot EXTRA nr-Eukaryota search against the clean FRAC-0.8 decoy.
+    """
+    order = sorted(range(len(scores)), key=lambda i: -scores[i])
+    nt = nd = 0
+    best_n = 0
+    best_thr = None
+    i = 0
+    while i < len(order):
+        s = scores[order[i]]
+        # consume the whole tie group before evaluating
+        while i < len(order) and scores[order[i]] == s:
+            if is_target[order[i]]:
+                nt += 1
+            else:
+                nd += 1
+            i += 1
+        if nt == 0:
+            continue
+        f = (nd / n_decoy) / (nt / n_target)
+        if f <= fdr and nt > best_n:
+            best_n, best_thr = nt, s
+    return best_n, best_thr
+
+
+def read_hits(path, layout="auto"):
+    """DIAMOND tabular hits -> list of dicts, best hit per peptide.
+
+    Handles both layouts seen in practice:
+      7-col  qseqid sseqid pident length evalue bitscore staxids
+      16-col qseqid sseqid pident len mm gap qs qe ss se evalue bitscore
+             staxids qseq sseq btop
+    """
+    rows = {}
+    with open(path) as fh:
+        for line in fh:
+            f = line.rstrip("\n").split("\t")
+            if len(f) < 7:
+                continue
+            if layout == "auto":
+                wide = len(f) >= 13
+            else:
+                wide = layout == "16"
+            try:
+                pident = float(f[2])
+                ev = float(f[10] if wide else f[4])
+                bit = float(f[11] if wide else f[5])
+                tax = f[12] if wide else f[6]
+            except (ValueError, IndexError):
+                continue
+            pep = "".join(c for c in f[0].upper() if c.isalpha())
+            prev = rows.get(pep)
+            if prev is None or bit > prev["bitscore"]:
+                rows[pep] = {"pep": pep, "subject": f[1], "pident": pident,
+                             "evalue": ev, "bitscore": bit, "staxids": tax}
+    for r in rows.values():
+        r["pep_len"] = len(r["pep"])
+        r["log_evalue"] = -math.log10(max(r["evalue"], 1e-300))
+    return list(rows.values())
+
+
+def read_confidence(path):
+    """Casanovo per-peptide confidence features.
+
+    Accepts either an mzTab (PSM rows with opt_ms_run[1]_aa_scores) or a TSV with
+    columns peptide / peptide_score / aa_scores.
+    """
+    feats = {}
+    counts = {}
+    is_mztab = path.lower().endswith(".mztab")
+    with open(path) as fh:
+        hdr = None
+        for line in fh:
+            if is_mztab:
+                if line.startswith("PSH"):
+                    hdr = line.rstrip("\n").split("\t")
+                    continue
+                if not line.startswith("PSM") or hdr is None:
+                    continue
+                d = dict(zip(hdr, line.rstrip("\n").split("\t")))
+                seq = d.get("sequence", "")
+                aa = d.get("opt_ms_run[1]_aa_scores", "")
+                score = d.get("search_engine_score[1]", "0")
+            else:
+                if hdr is None:
+                    hdr = line.rstrip("\n").split("\t")
+                    continue
+                d = dict(zip(hdr, line.rstrip("\n").split("\t")))
+                seq = d.get("peptide", "")
+                aa = d.get("aa_scores", "")
+                score = d.get("peptide_score", "0")
+            pep = "".join(c for c in seq.upper() if c.isalpha())
+            if not pep or not aa:
+                continue
+            try:
+                v = [float(x) for x in aa.split(",") if x]
+                sc = float(score)
+            except ValueError:
+                continue
+            if not v:
+                continue
+            hi = [x >= 0.9 for x in v]
+            run = best = 0
+            for h in hi:
+                run = run + 1 if h else 0
+                best = max(best, run)
+            cur = {"mean_conf": sum(v) / len(v), "min_conf": min(v),
+                   "longest_run": best, "n_hi": sum(hi),
+                   "cterm": v[-1], "nterm": v[0], "pep_score": sc}
+            counts[pep] = counts.get(pep, 0) + 1
+            prev = feats.get(pep)
+            if prev is None or cur["mean_conf"] > prev["mean_conf"]:
+                feats[pep] = cur
+    for pep, c in counts.items():
+        feats[pep]["pred_count"] = math.log1p(c)
+    return feats
+
+
+def attach(hits, conf):
+    zero = {k: 0.0 for k in ("mean_conf", "min_conf", "longest_run", "n_hi",
+                             "cterm", "nterm", "pep_score", "pred_count")}
+    for h in hits:
+        h.update(conf.get(h["pep"], zero))
+    return hits
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--target-hits", required=True, help="DIAMOND hits, real spectra")
+    ap.add_argument("--decoy-hits", required=True, help="DIAMOND hits, decoy spectra")
+    ap.add_argument("--target-conf", help="Casanovo mzTab/TSV for the real spectra")
+    ap.add_argument("--decoy-conf", help="Casanovo mzTab/TSV for the decoy spectra")
+    ap.add_argument("--n-target", type=int, required=True,
+                    help="TOTAL target peptides searched (not just those with a hit)")
+    ap.add_argument("--n-decoy", type=int, required=True,
+                    help="TOTAL decoy peptides searched")
+    ap.add_argument("--features", default="default", choices=sorted(FEATURE_SETS),
+                    help="'default' is the 5-feature linear model; the others exist "
+                         "only to reproduce the comparison and are NOT better")
+    ap.add_argument("--fdr", type=float, default=0.01)
+    ap.add_argument("--out", required=True, help="accepted peptides TSV")
+    ap.add_argument("--no-model", action="store_true",
+                    help="skip mokapot; threshold on E-value alone")
+    a = ap.parse_args()
+
+    t = read_hits(a.target_hits)
+    d = read_hits(a.decoy_hits)
+    if a.target_conf:
+        t = attach(t, read_confidence(a.target_conf))
+    if a.decoy_conf:
+        d = attach(d, read_confidence(a.decoy_conf))
+    for r in t:
+        r["target"] = True
+    for r in d:
+        r["target"] = False
+    allr = t + d
+    notes = []
+
+    feats = FEATURE_SETS[a.features]
+    have_conf = any(r.get("mean_conf") for r in allr)
+    use_model = not a.no_model and have_conf
+    if not a.no_model and not have_conf:
+        notes.append("no Casanovo confidence supplied -- falling back to E-value. "
+                     "The homology-only model does not separate on its own "
+                     "(measured: 'No PSMs found below the eval_fdr').")
+
+    scored = None
+    if use_model:
+        try:
+            import numpy as np
+            for _o, _n in (("float_", "float64"), ("unicode_", "str_"), ("int_", "int64")):
+                if not hasattr(np, _o) and hasattr(np, _n):
+                    setattr(np, _o, getattr(np, _n))
+            import pandas as pd
+            import mokapot
+            from sklearn.svm import LinearSVC
+            df = pd.DataFrame(allr)
+            df["psm_id"] = range(len(df))
+            ds = mokapot.LinearPsmDataset(psms=df, target_column="target",
+                                          spectrum_columns=["psm_id"],
+                                          peptide_column="pep", feature_columns=feats)
+            # LinearSVC on purpose. Gradient boosting overfits the decoy here and
+            # scores WORSE than raw bitscore -- see the header.
+            res, _ = mokapot.brew(ds, mokapot.Model(LinearSVC(dual="auto")),
+                                  test_fdr=a.fdr)
+            pep = res.peptides if hasattr(res, "peptides") else \
+                res.confidence_estimates["peptides"]
+            qcol = [c for c in pep.columns if "q-value" in c.lower()][0]
+            keep = set(pep.loc[pep[qcol] <= a.fdr, "pep"])
+            scored = [r for r in t if r["pep"] in keep]
+            notes.append(f"mokapot linear, features={feats}; mokapot q-values "
+                         f"(NOT rate-normalised -- see header)")
+        except ImportError as e:
+            notes.append(f"mokapot/sklearn unavailable ({e}); falling back to E-value")
+            use_model = False
+        except Exception as e:
+            notes.append(f"mokapot failed ({type(e).__name__}: {e}); "
+                         f"falling back to E-value")
+            use_model = False
+
+    if scored is None:
+        s = [r["log_evalue"] for r in allr]
+        tg = [r["target"] for r in allr]
+        n, thr = rate_normalised_accept(s, tg, a.n_target, a.n_decoy, a.fdr)
+        scored = [r for r in t if thr is not None and r["log_evalue"] >= thr]
+        notes.append("scored on E-value with the rate-normalised, tie-aware "
+                     "target-decoy threshold")
+
+    with open(a.out, "w", newline="") as fh:
+        w = csv.writer(fh, delimiter="\t")
+        cols = ["pep", "subject", "staxids", "pident", "evalue", "bitscore",
+                "pep_len", "mean_conf"]
+        w.writerow(cols)
+        for r in sorted(scored, key=lambda r: -r["bitscore"]):
+            w.writerow([r.get(c, "") for c in cols])
+
+    print(json.dumps({
+        "accepted": len(scored),
+        "target_peptides_with_hit": len(t),
+        "decoy_peptides_with_hit": len(d),
+        "n_target": a.n_target, "n_decoy": a.n_decoy,
+        "features": feats if use_model else None,
+        "model": "mokapot linear (LinearSVC)" if use_model else "E-value threshold",
+        "fdr": a.fdr,
+        "out": os.path.abspath(a.out),
+        "notes": notes,
+        "species_call_guidance":
+            "Do NOT gate the species call on this set. Run LCA over the UNFILTERED "
+            "hits; filtering lifts peptide precision 42.4%->59.8% but moves primate "
+            "attribution only 29.5%->32.9% and discards 715 correct peptides. "
+            "Species error is conserved peptides -- an LCA problem, not a scoring one.",
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/denovo_lca.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/denovo_lca.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""denovo_lca.py -- per-peptide LCA species attribution from a DIAMOND nr search.
+
+Ported from DE-LIMP scripts/lca_attribute.py. This is the step that actually
+decides the species; the FDR model does not.
+
+WHY LCA AND NOT BEST-HIT. A de novo peptide can be perfectly sequenced and
+perfectly homologous and still have its single best hit land on the wrong
+organism, because conserved peptides match many taxa. Measured on the HeLa
+entrapment (true answer: human), by best hit: only 29.5% primate, 68.5% mammal,
+13.1% not even metazoan. Rescoring does not fix this -- the best 5-feature FDR
+model moved primate attribution to just 32.9% and left mammal flat at 68.5%,
+while discarding 715 genuinely-correct peptides. Species mis-assignment is an
+LCA problem, so run this over the UNFILTERED hits and use the FDR score as a
+reported confidence tier.
+
+REQUIRES MULTIPLE HITS PER PEPTIDE. "LCA over all hits" is meaningless if the
+search kept one hit per peptide. The ocelot production search used
+--max-target-seqs 1 (0.9 hits/peptide), which silently degrades this step to
+best-hit -- exactly the failure it exists to prevent. Use --max-target-seqs 25
+(the HeLa benchmark setting, 22.5 hits/peptide); denovo_search_cmd.py emits it.
+This script warns when the input averages < 2 hits per peptide.
+
+Reads NCBI taxonomy from the PRISTINE nodes.dmp.preDmnd (real ranks -- the
+diamond DB itself was built with ranks neutralised to "no rank", which affects
+diamond's labels but not the tree).
+
+Usage: denovo_lca.py <blast_results.tsv> <out_prefix>
+  hits tsv: qseqid sseqid pident len mm gap qs qe ss se evalue bitscore staxids
+"""
+import sys, collections
+
+NODES = "/quobyte/proteomics-grp/bioinformatics_programs/blast_dbs/ncbi_nr/nodes.dmp.preDmnd"
+NAMES = "/quobyte/proteomics-grp/bioinformatics_programs/blast_dbs/ncbi_nr/names.dmp"
+HITS, OUTP = sys.argv[1], sys.argv[2]
+
+# anchor taxa for kingdom/domain classification
+METAZOA, BACTERIA, ARCHAEA, VIRUSES, FUNGI, VIRIDIPLANTAE = 33208, 2, 2157, 10239, 4751, 33090
+DIAG_RANKS = {"species", "subspecies", "species group", "species subgroup",
+              "genus", "subgenus", "strain", "isolate", "varietas", "forma"}
+
+def _warn_if_single_hit(path):
+    """One hit per peptide means this script cannot do what it says it does."""
+    q, n = set(), 0
+    with open(path) as fh:
+        for i, line in enumerate(fh):
+            if i >= 200000: break
+            q.add(line.split("\t", 1)[0]); n += 1
+    if q and n / len(q) < 2.0:
+        sys.stderr.write(
+            f"[lca] WARNING: {n/len(q):.1f} hits per peptide. LCA over all hits "
+            f"needs several; with one hit each this degrades to best-hit, which "
+            f"is the 36%-mis-assignment error mode LCA exists to fix. Re-run "
+            f"DIAMOND with --max-target-seqs 25.\n")
+
+_warn_if_single_hit(HITS)
+sys.stderr.write("[lca] loading taxonomy...\n")
+parent, rank = {}, {}
+for line in open(NODES):
+    p = line.split("\t|\t")
+    t = int(p[0]); parent[t] = int(p[1]); rank[t] = p[2]
+name = {}
+for line in open(NAMES):
+    p = line.split("\t|\t")
+    if len(p) >= 4 and p[3].rstrip("\t|\n") == "scientific name":
+        name[int(p[0])] = p[1]
+sys.stderr.write(f"[lca] {len(parent)} nodes, {len(name)} names\n")
+
+def lineage(t):
+    out, seen = [], set()
+    while t and t not in seen:
+        seen.add(t); out.append(t)
+        pt = parent.get(t)
+        if pt is None or pt == t:
+            break
+        t = pt
+    return out  # taxon -> ... -> root
+
+def lca(taxids):
+    taxids = [t for t in set(taxids) if t in parent]
+    if not taxids:
+        return None
+    lins = [lineage(t) for t in taxids]
+    common = set.intersection(*[set(l) for l in lins])
+    for t in lins[0]:          # deepest (lowest) shared node
+        if t in common:
+            return t
+    return 1
+
+# group hits by peptide
+hits = collections.defaultdict(list)   # pep -> [(bitscore, [taxids], pident)]
+for line in open(HITS):
+    f = line.rstrip("\n").split("\t")
+    if len(f) < 13:
+        continue
+    tids = [int(x) for x in f[12].replace(";", " ").split() if x.isdigit() and int(x) > 0]
+    hits[f[0]].append((float(f[11]), tids, float(f[2])))
+
+cat = collections.Counter(); host_sp = collections.Counter(); micro = collections.Counter()
+n_diag = 0
+with open(OUTP + "_peptide_lca.tsv", "w") as o:
+    o.write("peptide\tn_hits\ttop_pident\tlca_taxid\tlca_name\tlca_rank\tcategory\tdiagnostic\n")
+    for pep, hl in hits.items():
+        topbs = max(h[0] for h in hl)
+        keep = [h for h in hl if h[0] >= 0.9 * topbs]   # MEGAN-style top-10% window
+        l = lca([t for h in keep for t in h[1]])
+        if l is None:
+            continue
+        lin = set(lineage(l))
+        c = ("host" if METAZOA in lin else
+             "microbiome" if (BACTERIA in lin or ARCHAEA in lin or VIRUSES in lin) else
+             "plant/fungal" if (FUNGI in lin or VIRIDIPLANTAE in lin) else "other/conserved")
+        rk = rank.get(l, "no rank"); nm = name.get(l, str(l))
+        diag = rk in DIAG_RANKS
+        n_diag += diag
+        o.write(f"{pep}\t{len(hl)}\t{max(h[2] for h in keep):.1f}\t{l}\t{nm}\t{rk}\t{c}\t{int(diag)}\n")
+        cat[c] += 1
+        if c == "host" and diag:
+            host_sp[f"{nm} ({rk})"] += 1
+        if c == "microbiome":
+            micro[nm] += 1
+
+print(f"=== peptides with LCA: {sum(cat.values())}  (diagnostic species/genus: {n_diag}) ===")
+print("--- category ---")
+for c, n in cat.most_common():
+    print(f"  {n:>6}  {c}")
+print("--- top HOST species (diagnostic, species/genus LCA) ---")
+for s, n in host_sp.most_common(20):
+    print(f"  {n:>6}  {s}")
+print("--- top microbiome taxa ---")
+for s, n in micro.most_common(12):
+    print(f"  {n:>6}  {s}")

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/denovo_search_cmd.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/denovo_search_cmd.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+denovo_search_cmd.py -- emit the DIAMOND command for de novo -> homology species ID.
+
+Two settings here are not defaults and both were measured. Getting either wrong
+silently degrades the result rather than failing.
+
+1. THE SHORT-PEPTIDE ("EXTRA") CONFIGURATION.
+   De novo peptides are 7-30 aa. DIAMOND's defaults find essentially nothing in
+   that range -- its heuristics are tuned for full-length proteins. The EXTRA
+   settings below disable the filters that discard short alignments. Measured
+   effect at 1% FDR on nr-Eukaryota: standard finds 9,801 peptides with confirmed
+   homology, EXTRA finds 19,671, and the gain is concentrated exactly where it
+   should be -- 168 -> 1,661 peptides at <=15 aa.
+   Cost: ~5x standard (~217 core-hours vs ~44 for a 9-file cohort).
+
+2. --max-target-seqs 25, NOT 1.
+   The species call is made by LCA over ALL hits for a peptide. With one hit per
+   peptide there is nothing to take an ancestor of, so LCA degrades silently to
+   best-hit -- the 36%-mis-assignment error mode it exists to prevent. The ocelot
+   production search used --max-target-seqs 1 (0.9 hits/peptide) and could not
+   run the LCA step its own method section recommends. The HeLa benchmark used 25
+   (22.5 hits/peptide).
+   Cost: ~22x the hit rows. This is a real trade against (1) on a large cohort,
+   which is why it is stated rather than hidden.
+
+The binary matters too: use the Riffle build (diamond_mriffle_2.1.10.sif on
+HIVE). Standard DIAMOND releases do not accept --short-query-ungapped-bitscore.
+"""
+import argparse
+import json
+import shlex
+
+EXTRA = ["-b8.0", "--matrix", "BLOSUM62", "--ultra-sensitive", "-s2", "--id2", "1",
+         "--short-query-ungapped-bitscore", "1", "--algo", "0", "--masking", "0",
+         "--gapped-filter-evalue", "0", "--min-score", "1",
+         "--gapopen", "6", "--gapextend", "2"]
+STANDARD = ["--evalue", "1"]
+OUTFMT = ["--outfmt", "6", "qseqid", "sseqid", "pident", "length", "mismatch",
+          "gapopen", "qstart", "qend", "sstart", "send", "evalue", "bitscore",
+          "staxids"]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--query", required=True)
+    ap.add_argument("--db", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--mode", choices=["extra", "standard"], default="extra",
+                    help="extra = short-peptide sensitive (default, ~5x cost)")
+    ap.add_argument("--max-target-seqs", type=int, default=25,
+                    help="25 keeps LCA possible; 1 silently reduces it to best-hit")
+    ap.add_argument("--taxonlist", default="2759",
+                    help="2759 = Eukaryota; empty string for all of nr")
+    ap.add_argument("--threads", type=int, default=32)
+    ap.add_argument("--sif", default="/quobyte/proteomics-grp/apptainers/diamond_mriffle_2.1.10.sif",
+                    help="Riffle build; standard DIAMOND lacks --short-query-ungapped-bitscore")
+    a = ap.parse_args()
+
+    warnings = []
+    if a.max_target_seqs < 2:
+        warnings.append(
+            f"--max-target-seqs {a.max_target_seqs} makes LCA impossible: with one hit "
+            f"per peptide the species step degrades to best-hit, which mis-assigns "
+            f"~36% of peptides. Use 25 unless you are deliberately skipping LCA.")
+    if a.mode == "standard":
+        warnings.append(
+            "standard mode finds about half the homology of EXTRA on short peptides "
+            "(9,801 vs 19,671 at 1% FDR; 168 vs 1,661 peptides at <=15 aa). Use it "
+            "only when compute-bound.")
+
+    cmd = ["diamond", "blastp"]
+    cmd += EXTRA if a.mode == "extra" else STANDARD
+    if a.taxonlist:
+        cmd += ["--taxonlist", a.taxonlist]
+    cmd += ["--ignore-warnings"] + OUTFMT
+    cmd += ["--max-target-seqs", str(a.max_target_seqs),
+            "--threads", str(a.threads),
+            "--query", a.query, "--db", a.db, "--out", a.out]
+    full = ["apptainer", "exec", "--bind", "/quobyte:/quobyte", a.sif] + cmd if a.sif else cmd
+
+    print(json.dumps({
+        "mode": a.mode,
+        "max_target_seqs": a.max_target_seqs,
+        "lca_possible": a.max_target_seqs >= 2,
+        "command": " ".join(shlex.quote(c) for c in full),
+        "warnings": warnings,
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skill/ucdavis-proteomics-core-pipeline/tests/test_denovo_species_id.py
+++ b/skill/ucdavis-proteomics-core-pipeline/tests/test_denovo_species_id.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+The de novo -> homology species-ID workflow.
+
+Guards the settings that fail SILENTLY rather than loudly. Every number in the
+assertions below came from measurement on the ocelot cohort + HeLa entrapment;
+the failure modes are all "runs fine, answer is wrong".
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS = os.path.join(os.path.dirname(HERE), "scripts")
+sys.path.insert(0, SCRIPTS)
+
+from denovo_homology_fdr import (  # noqa: E402
+    rate_normalised_accept, FEATURE_SETS, DEFAULT_FEATURES, read_hits,
+)
+
+
+def run(script, *args):
+    p = subprocess.run([sys.executable, os.path.join(SCRIPTS, script), *args],
+                       capture_output=True, text=True)
+    return p
+
+
+class TestSearchSettings(unittest.TestCase):
+    def _emit(self, *extra):
+        p = run("denovo_search_cmd.py", "--query", "q.fa", "--db", "nr",
+                "--out", "o.tsv", *extra)
+        self.assertEqual(p.returncode, 0, p.stderr)
+        return json.loads(p.stdout)
+
+    def test_short_peptide_flags_are_present_by_default(self):
+        # Stock DIAMOND finds almost nothing on 7-30 aa queries.
+        cmd = self._emit()["command"]
+        for flag in ("--ultra-sensitive", "--short-query-ungapped-bitscore",
+                     "--masking 0", "--gapped-filter-evalue 0", "--min-score 1"):
+            self.assertIn(flag, cmd, f"missing short-peptide flag: {flag}")
+
+    def test_max_target_seqs_defaults_to_something_lca_can_use(self):
+        d = self._emit()
+        self.assertGreaterEqual(d["max_target_seqs"], 2)
+        self.assertTrue(d["lca_possible"])
+
+    def test_max_target_seqs_1_is_flagged_not_silently_accepted(self):
+        # The production ocelot search used 1 and could not run the LCA step its
+        # own method recommends. That must not happen quietly again.
+        d = self._emit("--max-target-seqs", "1")
+        self.assertFalse(d["lca_possible"])
+        self.assertTrue(any("LCA" in w for w in d["warnings"]))
+
+    def test_standard_mode_warns_about_lost_short_peptides(self):
+        d = self._emit("--mode", "standard")
+        self.assertTrue(any("short" in w.lower() or "9,801" in w for w in d["warnings"]))
+
+    def test_taxid_and_outfmt_carry_staxids(self):
+        # LCA needs staxids in the output or it has nothing to work with.
+        self.assertIn("staxids", self._emit()["command"])
+
+
+class TestFdrMath(unittest.TestCase):
+    def test_rate_normalisation_uses_the_peptide_universes(self):
+        # Equal hit counts but unequal universes must NOT give 100% FDR.
+        scores = [10.0, 9.0, 8.0, 7.0]
+        tgt = [True, False, True, False]
+        n, thr = rate_normalised_accept(scores, tgt, n_target=1000, n_decoy=4000)
+        self.assertGreater(n, 0)
+
+    def test_ties_move_together(self):
+        # Bitscore is coarse and heavily tied; accepting a partial tie group
+        # inflated the ocelot count 10,404 -> 11,558 (+11%).
+        scores = [5.0, 5.0, 5.0, 5.0]
+        tgt = [True, True, False, False]
+        n, thr = rate_normalised_accept(scores, tgt, n_target=100, n_decoy=100, fdr=1.0)
+        self.assertIn(n, (0, 2), "a tie group must be accepted whole or not at all")
+
+    def test_default_model_is_the_five_feature_set(self):
+        self.assertEqual(FEATURE_SETS["default"], DEFAULT_FEATURES)
+        self.assertEqual(len(DEFAULT_FEATURES), 5)
+        self.assertIn("mean_conf", DEFAULT_FEATURES,
+                      "confidence is load-bearing: the homology-only model does "
+                      "not separate at all on a standard search")
+        self.assertIn("log_evalue", DEFAULT_FEATURES,
+                      "calibrate on E-value, never raw bitscore")
+
+    def test_bigger_feature_sets_exist_but_are_not_the_default(self):
+        # They accept more peptides, less precisely, and recover FEWER correct.
+        self.assertGreater(len(FEATURE_SETS["12feat"]), len(FEATURE_SETS["default"]))
+        self.assertNotEqual(FEATURE_SETS["default"], FEATURE_SETS["12feat"])
+
+
+class TestHitParsing(unittest.TestCase):
+    def _write(self, tmp, rows):
+        p = os.path.join(tmp, "h.tsv")
+        with open(p, "w") as fh:
+            for r in rows:
+                fh.write("\t".join(str(x) for x in r) + "\n")
+        return p
+
+    def test_reads_the_7_column_layout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, [["PEPTIDEK", "sp1", 90.0, 8, "1e-5", 40.0, "9606"]])
+            h = read_hits(p)
+            self.assertEqual(len(h), 1)
+            self.assertAlmostEqual(h[0]["bitscore"], 40.0)
+            self.assertEqual(h[0]["staxids"], "9606")
+
+    def test_reads_the_16_column_extended_layout(self):
+        # Both layouts occur in real output; picking the wrong one silently reads
+        # mismatch counts as E-values.
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, [["PEPTIDEK", "sp1", 90.0, 8, 1, 0, 1, 8, 10, 17,
+                                   "1e-5", 40.0, "9606", "PEP", "PEP", "8"]])
+            h = read_hits(p)
+            self.assertEqual(len(h), 1)
+            self.assertAlmostEqual(h[0]["bitscore"], 40.0)
+            self.assertEqual(h[0]["staxids"], "9606")
+
+    def test_keeps_only_the_best_hit_per_peptide(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, [
+                ["PEPTIDEK", "a", 90.0, 8, "1e-2", 30.0, "1"],
+                ["PEPTIDEK", "b", 95.0, 8, "1e-9", 55.0, "2"]])
+            h = read_hits(p)
+            self.assertEqual(len(h), 1)
+            self.assertAlmostEqual(h[0]["bitscore"], 55.0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Casanovo → DIAMOND vs nr → LCA, for samples with no proteome — forensic hair, feather, fossil, wildlife.

## The scoring half is a rebuild, not a port

The original `composite_fdr.R` / `run_mokapot.py` lived in `/tmp/decoyval/` and are gone; the data survived on `/quobyte`. So this is a **reimplementation validated against preserved outputs**, labelled as such rather than presented as the code behind the figures.

| scoring | published | rebuilt |
|---|---|---|
| raw bitscore | 10,404 | **10,404** ✅ exact |
| E-value | 13,074 | **13,074** ✅ exact |
| linear [bits+len] | 14,706 | 14,925 |
| linear [bits+E+len+%id] | 19,556 | 19,757 |
| GBT [bits+len] | 9,335 | 9,554 |
| GBT [bits+E+len+%id] | 12,352 | 11,325 |

mokapot is semi-supervised, so exact equality isn't expected there.

## Three corrections along the way, each a wrong-but-plausible number avoided

- **`diamond_extra/` is the leaky FRAC-0.5 decoy**, not the clean f08. Found by testing query membership against each candidate peptide FASTA rather than trusting directory names.
- **FDR must be rate-normalised** — the universes differ (312,820 vs 424,552). Confirmed against independently-stated numbers before use.
- **Ties must move together.** One-at-a-time acceptance gives 11,558 for bitscore instead of 10,404 (+11%). E-value, nearly continuous, was off by only 43 — so the bug was nearly invisible on one metric and glaring on the other.

## Found while validating: one hit per peptide makes LCA impossible

The production ocelot search used `--max-target-seqs 1` (0.9 hits/peptide), so *"LCA over all hits"* — step 4 of the method's own recommendation — **silently degraded to best-hit**, the ~36% mis-assignment mode LCA exists to prevent. Nothing flagged it.

The skill now defaults to **25** (the HeLa benchmark setting, 22.5 hits/peptide). `denovo_search_cmd.py` warns when given fewer than 2, and `denovo_lca.py` warns when its input averages fewer than 2 hits per peptide.

Cost note: 25 multiplies hit rows ~22×, on top of EXTRA's ~5×. That trade is stated in the script header rather than hidden in a default.

## Model choices, measured on ground truth rather than inherited

- **Linear, never GBT** — GBT overfits the decoy and scores *worse than raw bitscore* (9,554 vs 10,404).
- **Five features, not thirteen** — 12-feature: 2,532 accepted / 55.5% precision / **1,405 correct**; 5-feature: 2,400 / 59.8% / **1,436 correct**. More features accept more, less precisely, and recover fewer correct ones.
- **Confidence is load-bearing** — the homology-only model doesn't separate at all on a standard search ("No PSMs found below the eval_fdr").
- **Don't gate the species call on the model** — filtering lifts peptide precision 42.4% → 59.8% but moves primate attribution only 29.5% → 32.9%, leaves mammal flat at 68.5%, and discards 715 correct peptides. Species error is conserved peptides matching many taxa — an LCA problem, not a scoring one.

## Two FDR definitions, not interchangeable

Raw scores use a rate-normalised, tie-aware target-decoy threshold. mokapot scores use mokapot's own q-values. Applying rate-normalisation to a mokapot score returns ~everything (298,889 of 299,099), because the score already embodies target-decoy competition.

70 tests. The harness reproduces the published ground-truth baseline exactly (5,068 accepted, 42.4% precision, 2,151 correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7kCGXB2Gqy7idYrVBffyC
