### PR TITLE
feat(skill): hand FRAN the search DATABASE, not just the organism (v2.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "UC Davis Proteomics Core skills for Claude \u2014 agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "description": "UC Davis Proteomics Core pipeline \u2014 end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "UC Davis Proteomics Core pipeline \u2014 end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE \u2014 with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/references/fran.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/fran.md
@@ -79,6 +79,14 @@ it already knows rather than making the corpus guess. Absent, never invented, wh
 missing: `delimp_searches.fasta_*` were populated for 157 / 0 / 0 of 2,014 searches before this,
 and a NULL is honest where a guessed database is a claim about comparability.
 
+The entry count is read from the sidecar's `n_entries`, falling back to **`n_sequences`** — the
+count `fetch_fasta.py` has always written (proteome + appended contaminants). They are the same
+number, verified against a real sidecar: `n_sequences` 34,306 against 34,306 headers counted in
+the file. That matters for `check`, which is meant to stat rather than parse: reading the count
+that is already there means no sidecar written before these fields existed has to be re-scanned.
+Only a sidecar carrying neither count causes the FASTA to be read (measured on a HIVE login node:
+0.6 s for 40 MB, 1.3 s for 118 MB), and then only if the file is still where the sidecar says.
+
 **XICs ride along, but they are not in one place.** Every DIA-NN search this skill runs
 extracts chromatograms (`--xic` is forced into the cfg — SKILL.md step 6b), and where they land
 depends on the route:

--- a/skill/ucdavis-proteomics-core-pipeline/references/fran.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/fran.md
@@ -65,6 +65,20 @@ skip it in silence. Re-run `stage --force`.
 | any DIA-NN | `report_xic/` — the chromatograms, **flattened** (see below) |
 | plus | `fran_manifest.json`, the only real file in the entry |
 
+**`fran_manifest.json` carries what the cron cannot derive** — the real `output_dir`, the engine
+that genuinely ran, the confirmed **organism**, and the search **database**:
+
+| field | why it cannot be inferred |
+|---|---|
+| `fasta_path` | FRAN parses `--fasta` out of an engine log as a fallback, but that is best-effort and, for Spectronaut, depends on an `ExperimentSetupOverview` the export may not have kept |
+| `fasta_md5` | fingerprints *which build* of a proteome, which the filename does not |
+| `fasta_n_proteins` | ÷ distinct genes = **entries-per-gene**, and that is what separates a real depth difference from database redundancy — near 1.00 for one-protein-per-gene, above 2 for a full proteome with unreviewed isoforms |
+
+All three come from the `<fasta>.meta.json` `fetch_fasta.py` writes, so the skill hands over what
+it already knows rather than making the corpus guess. Absent, never invented, when that file is
+missing: `delimp_searches.fasta_*` were populated for 157 / 0 / 0 of 2,014 searches before this,
+and a NULL is honest where a guessed database is a claim about comparability.
+
 **XICs ride along, but they are not in one place.** Every DIA-NN search this skill runs
 extracts chromatograms (`--xic` is forced into the cfg — SKILL.md step 6b), and where they land
 depends on the route:

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/fetch_fasta.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/fetch_fasta.py
@@ -189,6 +189,31 @@ def _sha256(path):
     return h.hexdigest()
 
 
+def _md5(path):
+    """md5 of the built FASTA. Streamed -- these run to hundreds of MB."""
+    h = hashlib.md5()  # noqa: S324 - provenance fingerprint, not a security control
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _count_entries(path):
+    """Number of '>' records. Counted over chunk boundaries -- a naive per-chunk
+    count(b"\n>") silently drops every header that lands on one."""
+    n = 0
+    tail = b""
+    first = True
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            if first and chunk.startswith(b">"):
+                n += 1
+            first = False
+            n += (tail + chunk).count(b"\n>")
+            tail = chunk[-1:]
+    return n
+
+
 def _warn(msg):
     sys.stderr.write(f"[fetch_fasta] WARNING: {msg}\n")
 
@@ -821,6 +846,13 @@ def cmd_fetch(a):
     result = {
         "fasta": os.path.abspath(a.out),
         "sha256": _sha256(a.out),
+        # md5 and the entry count exist for FRAN, whose delimp_searches columns are fasta_md5 /
+        # fasta_n_proteins. Written HERE, where the file was just built, rather than recomputed
+        # downstream: entries-per-gene is what decides whether a protein-count difference between
+        # two searches is real depth or database redundancy, and a corpus that cannot answer
+        # "which database?" cannot warn anyone their comparison is not like-for-like.
+        "md5": _md5(a.out),
+        "n_entries": _count_entries(a.out),
         "source": source,
         "url": base_url,
         "proteome": a.proteome,

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/fran_deposit.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/fran_deposit.py
@@ -241,6 +241,70 @@ def organism_from_meta(out, explicit_meta=None):
     return None, None, None
 
 
+def fasta_from_meta(out, explicit_meta=None):
+    """Which DATABASE this search used, from the <fasta>.meta.json fetch_fasta.py wrote.
+
+    The cron cannot derive this. FRAN's own detector (ingest/engine_fasta.py) falls back to
+    parsing --fasta out of report.log.txt, which works for DIA-NN and is best-effort for
+    Spectronaut -- but a search that came through this skill KNOWS its database exactly, so
+    hand it over rather than making the corpus guess.
+
+    Why the corpus wants it: fasta_n_proteins divided by the distinct gene count gives
+    entries-per-gene, and that is what separates a real depth difference from database
+    redundancy. A one-protein-per-gene proteome sits near 1.00; a full proteome with
+    unreviewed isoforms can exceed 2, which alone can move a cross-engine protein-group gap
+    from a few percent to tens of percent.
+
+    Returns (path, md5, n_entries) with any unknown field None. Older meta files predate the
+    md5/n_entries fields, so those are recomputed here when the FASTA is still readable --
+    and left None rather than invented when it is not.
+    """
+    cands = [explicit_meta] if explicit_meta else []
+    cands += sorted(glob.glob(os.path.join(out, "*.meta.json"))) \
+        + sorted(glob.glob(os.path.join(os.path.dirname(os.path.abspath(out)), "*.fasta.meta.json"))) \
+        + sorted(glob.glob(os.path.join(out, "..", "input", "*.fasta.meta.json")))
+    for c in cands:
+        if not c or not os.path.isfile(c):
+            continue
+        try:
+            with open(c) as fh:
+                m = json.load(fh)
+        except (OSError, ValueError):
+            continue
+        sel = m.get("selected") if isinstance(m.get("selected"), dict) else m
+        path = sel.get("fasta") or m.get("fasta")
+        if not path:
+            continue
+        md5, n = sel.get("md5") or m.get("md5"), sel.get("n_entries") or m.get("n_entries")
+        if (not md5 or not n) and os.path.isfile(path):
+            md5 = md5 or _md5(path)
+            n = n or _count_entries(path)
+        return path, md5, n
+    return None, None, None
+
+
+def _md5(path):
+    h = hashlib.md5()  # noqa: S324 - provenance fingerprint, not a security control
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _count_entries(path):
+    """'>' records, counted across chunk boundaries -- a per-chunk count(b"\n>") drops every
+    header landing on one."""
+    n, tail, first = 0, b"", True
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            if first and chunk.startswith(b">"):
+                n += 1
+            first = False
+            n += (tail + chunk).count(b"\n>")
+            tail = chunk[-1:]
+    return n
+
+
 def entry_name(out):
     """Deterministic drop-entry name for a search dir: `<dir name>__<8 hex of its real path>`.
 
@@ -419,6 +483,8 @@ def check(a):
 
     org, tax, org_src = organism_from_meta(out, a.fasta_meta)
     r["organism"] = a.organism or org
+    fp, fmd5, fn = fasta_from_meta(out, a.fasta_meta)
+    r["fasta_path"], r["fasta_md5"], r["fasta_n_proteins"] = fp, fmd5, fn
     r["taxon"] = a.taxon or tax
     r["organism_source"] = "--organism (given)" if a.organism else org_src
     r["name"] = a.name
@@ -509,6 +575,12 @@ def stage(a):
         "organism": c.get("organism"),
         "taxon": c.get("taxon"),
         "organism_source": c.get("organism_source"),
+        # The search DATABASE, for delimp_searches.fasta_path / fasta_md5 / fasta_n_proteins.
+        # Absent, not guessed, when the meta.json is missing -- FRAN's own log-parsing detector
+        # is the fallback for searches that did not come through this skill.
+        "fasta_path": c.get("fasta_path"),
+        "fasta_md5": c.get("fasta_md5"),
+        "fasta_n_proteins": c.get("fasta_n_proteins"),
         "xic": c["xic"],
         "linked": linked,
         "staged_by": c["user"],

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/fran_deposit.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/fran_deposit.py
@@ -275,34 +275,44 @@ def fasta_from_meta(out, explicit_meta=None):
         path = sel.get("fasta") or m.get("fasta")
         if not path:
             continue
-        md5, n = sel.get("md5") or m.get("md5"), sel.get("n_entries") or m.get("n_entries")
-        if (not md5 or not n) and os.path.isfile(path):
-            md5 = md5 or _md5(path)
-            n = n or _count_entries(path)
+        md5 = sel.get("md5") or m.get("md5")
+        # `n_sequences` is what fetch_fasta.py has ALWAYS written (proteome + appended
+        # contaminants), and it is the same number: verified on a real sidecar, n_sequences 34306
+        # against 34306 headers counted in the file. Reading it means no meta written before the
+        # md5/n_entries fields has to be re-scanned at all -- which matters because this runs
+        # inside `check`, on a login node, and the file is hundreds of MB (measured 0.6-1.3 s).
+        n = (sel.get("n_entries") or m.get("n_entries")
+             or sel.get("n_sequences") or m.get("n_sequences"))
+        # Only a sidecar carrying NEITHER count falls through to counting the file, and only when
+        # the FASTA is still there. Left None rather than invented when it is not: a guessed
+        # database size is a claim about comparability.
+        if (md5 is None or n is None) and os.path.isfile(path):
+            helpers = _fasta_helpers()
+            if helpers:
+                _m, _c = helpers
+                md5 = md5 if md5 is not None else _m(path)
+                n = n if n is not None else _c(path)
         return path, md5, n
     return None, None, None
 
 
-def _md5(path):
-    h = hashlib.md5()  # noqa: S324 - provenance fingerprint, not a security control
-    with open(path, "rb") as fh:
-        for chunk in iter(lambda: fh.read(1 << 20), b""):
-            h.update(chunk)
-    return h.hexdigest()
+def _fasta_helpers():
+    """(md5, entry-count) from fetch_fasta.py, or None if it cannot be imported.
 
-
-def _count_entries(path):
-    """'>' records, counted across chunk boundaries -- a per-chunk count(b"\n>") drops every
-    header landing on one."""
-    n, tail, first = 0, b"", True
-    with open(path, "rb") as fh:
-        for chunk in iter(lambda: fh.read(1 << 20), b""):
-            if first and chunk.startswith(b">"):
-                n += 1
-            first = False
-            n += (tail + chunk).count(b"\n>")
-            tail = chunk[-1:]
-    return n
+    ONE definition, imported rather than copied -- the same rule radiant_parallel.py follows for
+    slurm_queue(). The entry counter walks chunk boundaries (a per-chunk count(b"\n>") silently
+    drops every header landing on one), and a second copy of logic like that is a bug fixed in one
+    place and left in the other. Degrades to None rather than raising: the fields are then absent
+    from the manifest, which is honest, and FRAN's own log-parsing detector is the fallback."""
+    try:
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from fetch_fasta import _count_entries, _md5
+        return _md5, _count_entries
+    except Exception as e:                                          # noqa: BLE001
+        sys.stderr.write(f"[fran_deposit] could not import the FASTA helpers from "
+                         f"fetch_fasta.py ({type(e).__name__}: {e}); recording the database "
+                         f"path without md5/entry count\n")
+        return None
 
 
 def entry_name(out):

--- a/skill/ucdavis-proteomics-core-pipeline/tests/test_fran_manifest_fasta.py
+++ b/skill/ucdavis-proteomics-core-pipeline/tests/test_fran_manifest_fasta.py
@@ -23,6 +23,7 @@ SCRIPTS = os.path.join(os.path.dirname(HERE), "scripts")
 sys.path.insert(0, SCRIPTS)
 
 import fran_deposit as fd  # noqa: E402
+from fetch_fasta import _count_entries  # noqa: E402  -- the ONE definition; fran_deposit imports it
 
 # 3 entries; the middle '>' is placed so a naive per-chunk count would still see it, while
 # test_entry_count_survives_chunk_boundary below forces the boundary case explicitly.
@@ -58,6 +59,30 @@ class FastaInManifest(unittest.TestCase):
             self.assertEqual(md5, hashlib.md5(FASTA.encode()).hexdigest())  # noqa: S324
             self.assertEqual(n, 3)
 
+    def test_the_count_already_in_older_sidecars_is_used_rather_than_rescanned(self):
+        """`fetch_fasta.py` has ALWAYS written `n_sequences` (proteome + appended contaminants),
+        and it is the same number as the header count -- verified against a real sidecar,
+        n_sequences 34,306 against 34,306 headers. Reading it keeps `check` a stat rather than a
+        parse: no sidecar predating the md5/n_entries fields has to be re-scanned, which on a
+        login node costs 0.6-1.3 s per hundred MB of FASTA."""
+        with tempfile.TemporaryDirectory() as root:
+            fa, mp = self._meta(root)
+            with open(mp) as fh:
+                m = json.load(fh)
+            m["n_sequences"] = 4321               # deliberately NOT the real header count
+            with open(mp, "w") as fh:
+                json.dump(m, fh)
+            _, _, n = fd.fasta_from_meta(root, mp)
+            self.assertEqual(n, 4321, "the count already in the sidecar was ignored and the "
+                                      "FASTA re-scanned instead")
+
+    def test_the_helpers_are_imported_not_copied(self):
+        """One definition. The chunk-boundary counter is exactly the logic you do not want two
+        copies of -- a bug fixed in one would silently survive in the other."""
+        src = open(os.path.join(SCRIPTS, "fran_deposit.py")).read()
+        self.assertNotIn("def _count_entries(", src)
+        self.assertIn("from fetch_fasta import", src)
+
     def test_absent_not_guessed_when_no_meta(self):
         with tempfile.TemporaryDirectory() as root:
             self.assertEqual(fd.fasta_from_meta(root, None), (None, None, None))
@@ -81,7 +106,7 @@ class FastaInManifest(unittest.TestCase):
                 head = ">a\n"
                 fh.write(head + "P" * (chunk - len(head) - 1) + "\n")  # next '>' starts at 1 MiB
                 fh.write(">b\nPEPTIDEK\n>c\nPEPTIDER\n")
-            self.assertEqual(fd._count_entries(fa), 3)
+            self.assertEqual(_count_entries(fa), 3)
 
 
 if __name__ == "__main__":

--- a/skill/ucdavis-proteomics-core-pipeline/tests/test_fran_manifest_fasta.py
+++ b/skill/ucdavis-proteomics-core-pipeline/tests/test_fran_manifest_fasta.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""The search DATABASE must reach FRAN's manifest.
+
+FRAN's delimp_searches has carried fasta_path / fasta_md5 / fasta_n_proteins since its schema
+was written, and as of 2026-08-25 they were populated for 157 / 0 / 0 of 2,014 searches --
+corpus_ingest.py never wrote them. FRAN can now parse them out of an engine log as a fallback,
+but a search that came through this skill knows its database exactly, so it should hand it over
+rather than making the corpus guess.
+
+The failure this guards is silent: a manifest with no database still stages, still ingests, and
+leaves the corpus unable to say whether two searches used comparable proteomes. Entries-per-gene
+is what separates a real depth difference from database redundancy.
+"""
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS = os.path.join(os.path.dirname(HERE), "scripts")
+sys.path.insert(0, SCRIPTS)
+
+import fran_deposit as fd  # noqa: E402
+
+# 3 entries; the middle '>' is placed so a naive per-chunk count would still see it, while
+# test_entry_count_survives_chunk_boundary below forces the boundary case explicitly.
+FASTA = ">sp|P1|A\nPEPTIDEK\n>sp|P2|B\nPEPTIDER\n>sp|P3|C\nPEPTIDEK\n"
+
+
+class FastaInManifest(unittest.TestCase):
+    def _meta(self, root, **extra):
+        fa = os.path.join(root, "db.fasta")
+        with open(fa, "w") as fh:
+            fh.write(FASTA)
+        meta = {"fasta": fa, "organism": "Homo sapiens", "taxid": 9606, **extra}
+        mp = os.path.join(root, "db.fasta.meta.json")
+        with open(mp, "w") as fh:
+            json.dump(meta, fh)
+        return fa, mp
+
+    def test_reads_path_md5_and_count_from_meta(self):
+        with tempfile.TemporaryDirectory() as root:
+            fa, mp = self._meta(root, md5="deadbeef", n_entries=3)
+            path, md5, n = fd.fasta_from_meta(root, mp)
+            self.assertEqual(path, fa)
+            self.assertEqual(md5, "deadbeef")   # trusted, not recomputed
+            self.assertEqual(n, 3)
+
+    def test_recomputes_when_meta_predates_the_fields(self):
+        """Older meta.json files have `fasta` but no md5/n_entries. Those must be filled from
+        the file rather than left NULL, or every search staged before this change stays blind."""
+        with tempfile.TemporaryDirectory() as root:
+            fa, mp = self._meta(root)
+            path, md5, n = fd.fasta_from_meta(root, mp)
+            self.assertEqual(path, fa)
+            self.assertEqual(md5, hashlib.md5(FASTA.encode()).hexdigest())  # noqa: S324
+            self.assertEqual(n, 3)
+
+    def test_absent_not_guessed_when_no_meta(self):
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual(fd.fasta_from_meta(root, None), (None, None, None))
+
+    def test_unreadable_fasta_leaves_md5_null_rather_than_inventing(self):
+        with tempfile.TemporaryDirectory() as root:
+            _, mp = self._meta(root)
+            os.remove(os.path.join(root, "db.fasta"))
+            path, md5, n = fd.fasta_from_meta(root, mp)
+            self.assertTrue(path)          # the path is still what the search used
+            self.assertIsNone(md5)         # but nothing is fabricated about its contents
+            self.assertIsNone(n)
+
+    def test_entry_count_survives_chunk_boundary(self):
+        """A per-chunk count(b"\\n>") drops any header landing exactly on a 1 MiB boundary --
+        invisible on small files, wrong on real proteomes."""
+        with tempfile.TemporaryDirectory() as root:
+            fa = os.path.join(root, "big.fasta")
+            chunk = 1 << 20
+            with open(fa, "w") as fh:
+                head = ">a\n"
+                fh.write(head + "P" * (chunk - len(head) - 1) + "\n")  # next '>' starts at 1 MiB
+                fh.write(">b\nPEPTIDEK\n>c\nPEPTIDER\n")
+            self.assertEqual(fd._count_entries(fa), 3)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Pairs with **[FRAN #6](https://github.com/bsphinney/FRAN/pull/6)**. That PR teaches FRAN's ingest to *parse* the FASTA out of an engine log; this one lets a search that came through the skill simply **declare** it.

## The gap

`fran_manifest.json` already carries what the ingest cron cannot derive — the real `output_dir`, the engine that genuinely ran, the confirmed organism. The **search database** belongs in exactly that list and was missing.

Measured on the live corpus, 2026-08-25 (n = 2,014 searches):

| column | populated |
|---|---|
| `fasta_path` | 157 (7.8%) |
| `fasta_md5` | **0** |
| `fasta_n_proteins` | **0** |

All 157 came from a one-off load ingested 2026-06-13 → 06-30. `corpus_ingest.py` never wrote any of them.

## Why the corpus wants it

`fasta_n_proteins` ÷ distinct genes gives **entries-per-gene**, and that is what separates a real depth difference from database redundancy — near 1.00 for a one-protein-per-gene proteome, above 2 for a full proteome with unreviewed isoforms. On two of our own datasets that single difference moved a cross-engine protein-group gap from **+5% to +42%** while the peptide-level gap barely moved.

Without the database on record, FRAN cannot warn anyone that their comparison is not like-for-like — which is precisely the question people bring to it. I hit this directly: two Spectronaut plasma searches I wanted to compare against DIA-NN 2.6.1 had no database recorded, and I had to *infer* it from the identified accessions (zero isoform-suffixed accessions, ~1.000 groups per gene, a small TrEMBL fraction) instead of reading it.

## The change

| file | |
|---|---|
| `scripts/fetch_fasta.py` | records `md5` + `n_entries` beside the `sha256` it already writes, at the point the FASTA is built |
| `scripts/fran_deposit.py` | `fasta_from_meta()` reads them from the same `<fasta>.meta.json` the organism already comes from; manifest carries all three |
| `references/fran.md` | documents the three fields and why each cannot be inferred |
| `tests/test_fran_manifest_fasta.py` | 5 tests |

**Absent, never invented** when the meta is missing — a NULL is honest where a guessed database is a claim about comparability. Meta files predating the new fields are handled: md5 and the count are recomputed from the FASTA when it is still readable, and left NULL when it is not, rather than leaving every previously-staged search blind.

Both counters walk chunk boundaries. A per-chunk `count(b"\n>")` silently drops every header landing exactly on a 1 MiB boundary — invisible on a test file, wrong on a real proteome. `test_entry_count_survives_chunk_boundary` constructs that case rather than hoping for it.

## Verification

- 5 new tests, **each verified to fail with the change stashed** (`AttributeError: module 'fran_deposit' has no attribute 'fasta_from_meta'`), not merely asserted to pass.
- Full skill suite green — 9 test files, including `test_fran_deposit_gate.py` (21 tests) and `test_diann_always_xic.py` (7).
- md5/entry-count logic separately checked against a real 21,044-entry proteome.

## Not verified

No live deposit was run — I have not staged a real search through the modified `fran_deposit.py` into `/quobyte/proteomics-grp/fran/incoming/`, so the manifest change is tested at unit level only. Worth one real stage before relying on it.

## Deliberately not included

Two other things surfaced in the same session and do **not** belong here:

- **`--temp` must pre-exist.** DIA-NN exits with "cannot find the temp folder" and will not create it. `diann_parallel.py:431` already does `mkdir -p … # DIA-NN --temp dirs MUST pre-exist` — the skill was right and I hit this only because I ran a search by hand.
- **Deriving a comparator engine's search envelope from FRAN** (its real length/charge/missed-cleavage/modification range, so DIA-NN can be matched rather than guessed). Genuinely useful, but it needs a corpus **read credential**, and the deposit step was deliberately built to need none — "No database, no credential… which is why this works for every Core member rather than only whoever holds the corpus token." That belongs in FRAN or as an analysis recipe, not in the skill.