### PR TITLE
skill: trigger on any DIA-NN/Sage search, not just end-to-end analyses

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "UC Davis Proteomics Core skills for Claude \u2014 agentic mass-spec search + differential expression.",
   "owner": {
     "name": "Brett Phinney",
@@ -11,7 +11,7 @@
     {
       "name": "ucdavis-proteomics-core-pipeline",
       "source": "./skill/ucdavis-proteomics-core-pipeline",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "description": "UC Davis Proteomics Core pipeline \u2014 end-to-end proteomics search + differential expression from raw .raw/.d/.mzML files (DIA-NN / Sage, limpa/limma). Auto-installs its toolchain, derives search parameters from the data type, writes a biological analysis report and a full reproducibility bundle, and packages results into tidy session folders.",
       "author": {
         "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
+++ b/skill/ucdavis-proteomics-core-pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ucdavis-proteomics-core-pipeline",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "UC Davis Proteomics Core pipeline \u2014 end-to-end proteomics search + differential expression from raw mass-spec data. Detects DIA/DDA + instrument, auto-installs the toolchain, runs DIA-NN (DIA) or Sage (DDA) with data-derived parameters, then limpa/limma DE \u2014 with a written analysis report, full reproducibility bundle, and tidy session packaging.",
   "author": {
     "name": "Brett Phinney",

--- a/skill/ucdavis-proteomics-core-pipeline/SKILL.md
+++ b/skill/ucdavis-proteomics-core-pipeline/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: ucdavis-proteomics-core-pipeline
 description: >
-  Run an end-to-end proteomics search + differential expression analysis from raw
-  mass-spec data. Use this whenever the user wants to "analyze my proteomics data",
-  "search these raw files", "run my DIA/DDA data", "find differentially expressed
-  proteins", "process this timsTOF/Astral/Orbitrap run", or points at a folder of
-  .raw / .d / .mzML files and asks what's in it. Detects acquisition + instrument,
-  derives the search parameters from that data type, downloads the pinned search
-  engine, runs DIA-NN (DIA) or Sage (DDA), then limpa/limma DE — with full
-  provenance for every parameter. Also use it to "write the LC-MS methods
-  section" / "generate a publication-ready methods section with the instrument grant
-  acknowledgment" from facility raw data (UC Davis Proteomics Core).
+  Run a proteomics search and/or differential expression analysis from mass-spec data.
+  Use this whenever the user wants to "analyze my proteomics data", "search these raw
+  files", "run my DIA/DDA data", "find differentially expressed proteins", "process this
+  timsTOF/Astral/Orbitrap run", or points at a folder of .raw / .d / .mzML files and asks
+  what's in it. ALSO use it for any single search step, even when no DE is wanted and the
+  file paths are already known: "run DIA-NN on these files", "re-run this search",
+  "re-search with different parameters", "match the search settings to the Spectronaut /
+  FragPipe run", "compare DIA-NN vs Spectronaut", "submit a search to the cluster /
+  SLURM / HPC", "extract XICs". Use it INSTEAD OF hand-writing an sbatch script or a
+  diann-linux / sage command line — the skill picks the validated workflow, including the
+  5-step parallel SLURM chain that searches files concurrently (DIA-NN's own --threads
+  parallelises only WITHIN one run, so a hand-rolled single-shot job searches raw files
+  one at a time and is dramatically slower). Detects acquisition + instrument, derives the
+  search parameters from that data type, downloads the pinned search engine, runs DIA-NN
+  (DIA) or Sage (DDA), then limpa/limma DE — with full provenance for every parameter.
+  Also use it to "write the LC-MS methods section" / "generate a publication-ready methods
+  section with the instrument grant acknowledgment" from facility raw data (UC Davis
+  Proteomics Core).
 ---
 
 # Proteomics Pipeline


### PR DESCRIPTION
## Problem

The skill's `description` is the only thing Claude sees when deciding whether to invoke it, and it advertised **only discovery-style triggers**:

> "analyze my proteomics data", "search these raw files", "run my DIA/DDA data", "find differentially expressed proteins", "points at a folder of .raw / .d / .mzML files and asks what's in it"

A task framed as a **single search step** — *"re-run DIA-NN 2.6.1 with a search envelope matched to the existing Spectronaut result; here are the file paths"* — matches none of those. The skill did not fire, and the search was hand-rolled as a single-shot `sbatch` + `diann-linux` command line. Given the stated triggers, that non-invocation was arguably correct behaviour; the description was the bug.

## Why it was expensive

`--threads N` parallelises **within** one run, not across runs. A hand-written single-shot job therefore searches raw files **sequentially** — confirmed in the log, one `Loading run …` every ~30 min:

```
[13:36]  Loading run ..._60spd_10_...d
[48:07]  Loading run ..._60spd_11_...d      +34 min
[81:29]  Loading run ..._60spd_12_...d      +33 min
[112:23] Loading run ..._60spd_13_...d      +31 min
```

Projected wall-clock for the affected comparison:

| arm | files | single-shot (sequential) |
|---|---|---|
| blood x2 | 6 each | ~3 h |
| dog x2 | 9 each | ~4.5 h |
| plasma x2 | 24 each | **~12 h** |
| high-complexity | 39 | **~19.5 h** |

`run_search.py` would have routed **every one of these** to the 5-step parallel SLURM chain automatically — all four documented routing conditions were met (DIA-NN, >5 files, SLURM present, mass accuracy fixed at 15/15). ~3 h of cluster time across 7 nodes was discarded and everything resubmitted through `diann_parallel.py`.

## Change

Frontmatter `description` only, plus a patch version bump so `/plugin` picks it up. **No script behaviour changes.**

Added to the description:

- **Explicit single-search triggers** — "run DIA-NN on these files", "re-run this search", "re-search with different parameters", "match the search settings to the Spectronaut / FragPipe run", "compare DIA-NN vs Spectronaut", "submit a search to the cluster / SLURM / HPC", "extract XICs"
- **That it applies when no DE is wanted** and the file paths are already known — the previous wording implied the skill was only for end-to-end raw→DE runs
- **A negative trigger**: use this *instead of* hand-writing an sbatch or a `diann-linux` / `sage` command line, with the reason inline (within-run-only `--threads`). Descriptions that say when *not* to reach for the alternative tend to fire more reliably than ones listing positive phrasings alone.

## Related, not included here

Two things surfaced alongside this that are **not** in this PR:

1. `read_cfg_flags()` splices the `.cfg` into the sbatch **unquoted**, so glob-bearing values must be quoted *in the cfg* (`--cut "K*,R*"`, `--var-mod "UniMod:1,42.010565,*n"`). Bare, bash expands them and silently changes the digest rule and the N-term modification. Worth either quoting in `read_cfg_flags()` via `shlex.quote`, or documenting in `diann_parallel.md` — happy to open a separate PR whichever you prefer.
2. A matching hard rule was added to the local `DataAnalysis/CLAUDE.md` ("never hand-write a DIA-NN invocation; go through `run_search.py`"), which covers that one project. This PR is what covers everyone else.

## Verification

- YAML frontmatter parses (`yaml.safe_load`), keys `name` + `description` intact
- `plugin.json` valid; diff is version-only (2.4.0 → 2.4.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)