### PR TITLE
diann_parallel: drop --no-ifs-removal, which no DIA-NN version accepts

### DIFF
--- a/skill/ucdavis-proteomics-core-pipeline/references/diann_parallel.md
+++ b/skill/ucdavis-proteomics-core-pipeline/references/diann_parallel.md
@@ -34,7 +34,7 @@ only).
 3. **Empirical-library assembly** — single job: `--use-quant` over the step-2 `.quant`
    to build the empirical library (`--out-lib empirical.parquet`).
 4. **Final pass** — SLURM array: search each raw vs the empirical library
-   (`--lib empirical.parquet --temp quant_step4 --no-ifs-removal --quant-ori-names`).
+   (`--lib empirical.parquet --temp quant_step4 --quant-ori-names`).
 5. **Cross-run report** — single job: `--use-quant --matrices` over the step-4
    `.quant` → `report.parquet` (the DE contract).
 

--- a/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
+++ b/skill/ucdavis-proteomics-core-pipeline/scripts/diann_parallel.py
@@ -447,7 +447,7 @@ def main():
         f'cp -f {empirical} "$LIBPRIV/lib.parquet"',
         'trap \'rm -rf "$LIBPRIV"\' EXIT',
         f'{DN} --f "$FILE" --fasta {fasta} --lib "$LIBPRIV/lib.parquet" \\',
-        f'  --temp {D}/quant_step4 --no-ifs-removal --quant-ori-names{xic_arg}{xic_out} \\',
+        f'  --temp {D}/quant_step4 --quant-ori-names{xic_arg}{xic_out} \\',
         f'  --threads {a.threads_per_file} {wflag}{flags}',
         must_exist(f'{D}/quant_step4/$QUANT', "this file's final-pass .quant")]))
 


### PR DESCRIPTION
## The bug

Step 4 (the final per-file pass) is generated with `--no-ifs-removal`. **DIA-NN does not recognise that option**, and says so at runtime:

```
WARNING: unrecognised option [--no-ifs-removal]
```

Verified against every build the skill ships against — all three reject it:

| version | result |
|---|---|
| DIA-NN 2.5.1 | `WARNING: unrecognised option [--no-ifs-removal]` |
| DIA-NN 2.6.0 | `WARNING: unrecognised option [--no-ifs-removal]` |
| DIA-NN 2.6.1 | `WARNING: unrecognised option [--no-ifs-removal]` |

So this is **not a 2.6.x regression — the flag was never valid.**

## Why it went unnoticed

Every failure mode here is silent:

- DIA-NN emits a warning but **still exits 0**, so the `afterok` chain advances normally and SLURM records `COMPLETED`.
- Interference removal is therefore **not** suppressed on the final pass — the opposite of what step 4 intends.
- `references/diann_parallel.md` documented the flag as part of step 4, so the docs asserted behaviour that never occurred.

This is the same shape as the XIC gotcha already documented in that file: a step-4 problem that leaves `COMPLETED` jobs and a plausible-looking report.

## Change

Removes the flag from the generated step-4 command and from the reference doc. Two lines.

**No replacement flag is substituted.** DIA-NN 2.6.1's `--help` is minimal (23 lines) and exposes no `ifs`/`interference` option, so the correct spelling — if one exists — should come from upstream rather than a guess. If the intent was real and there is a current equivalent, that is a follow-up; this PR just stops asserting something untrue.

## How it surfaced

A 117-file, 7-chain cross-matrix run (blood / plasma / dog / high-complexity, DIA-NN 2.6.1). All 255 tasks across all five steps completed successfully, and **every chain carried this warning in every step-4 task log**.

## Not included

I initially also patched `read_cfg_flags()` for unquoted glob splicing (`--cut K*,R*`, `--var-mod ...,*n`) — then found `main` **already fixes it** via `_GLOBBY` + `shlex.quote`, with a more careful treatment than mine (quoting only globby tokens so `$VAR`/`$(...)` in hand-written cfgs still work). Dropped from this PR. I had been reading a stale 2.3.0 plugin cache.

## Verification

- `ast.parse` clean on `diann_parallel.py`
- no remaining `no-ifs-removal` references anywhere under `skill/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)